### PR TITLE
Allow configurable platform fee with admin controls

### DIFF
--- a/quicklendx-contracts/src/events.rs
+++ b/quicklendx-contracts/src/events.rs
@@ -1,6 +1,7 @@
 use crate::audit::{AuditLogEntry, AuditOperation};
 use crate::invoice::Invoice;
 use crate::payments::{Escrow, EscrowStatus};
+use crate::profits::PlatformFeeConfig;
 use soroban_sdk::{symbol_short, Address, BytesN, Env, String};
 
 pub fn emit_invoice_uploaded(env: &Env, invoice: &Invoice) {
@@ -44,6 +45,13 @@ pub fn emit_invoice_defaulted(env: &Env, invoice: &crate::invoice::Invoice) {
     env.events().publish(
         (symbol_short!("inv_def"),),
         (invoice.id.clone(), invoice.business.clone()),
+    );
+}
+
+pub fn emit_platform_fee_updated(env: &Env, config: &PlatformFeeConfig) {
+    env.events().publish(
+        (symbol_short!("fee_upd"),),
+        (config.fee_bps, config.updated_at, config.updated_by.clone()),
     );
 }
 

--- a/quicklendx-contracts/src/lib.rs
+++ b/quicklendx-contracts/src/lib.rs
@@ -31,7 +31,7 @@ use events::{
 use investment::{Investment, InvestmentStatus, InvestmentStorage};
 use invoice::{DisputeStatus, Invoice, InvoiceStatus, InvoiceStorage};
 use payments::{create_escrow, refund_escrow, release_escrow, EscrowStorage};
-use profits::calculate_profit as do_calculate_profit;
+use profits::{calculate_profit as do_calculate_profit, PlatformFee, PlatformFeeConfig};
 use settlement::settle_invoice as do_settle_invoice;
 use verification::{
     get_business_verification_status, reject_business, submit_kyc_application, validate_bid,
@@ -419,11 +419,24 @@ impl QuickLendXContract {
 
     /// Calculate profit and platform fee
     pub fn calculate_profit(
-        _env: Env,
+        env: Env,
         investment_amount: i128,
         payment_amount: i128,
     ) -> (i128, i128) {
-        do_calculate_profit(investment_amount, payment_amount)
+        do_calculate_profit(&env, investment_amount, payment_amount)
+    }
+
+    /// Retrieve the current platform fee configuration
+    pub fn get_platform_fee(env: Env) -> PlatformFeeConfig {
+        PlatformFee::get_config(&env)
+    }
+
+    /// Update the platform fee basis points (admin only)
+    pub fn set_platform_fee(env: Env, new_fee_bps: i128) -> Result<(), QuickLendXError> {
+        let admin =
+            BusinessVerificationStorage::get_admin(&env).ok_or(QuickLendXError::NotAdmin)?;
+        PlatformFee::set_config(&env, &admin, new_fee_bps)?;
+        Ok(())
     }
 
     // Rating Functions (from feat-invoice_rating_system)

--- a/quicklendx-contracts/src/profits.rs
+++ b/quicklendx-contracts/src/profits.rs
@@ -1,14 +1,73 @@
-const DEFAULT_PLATFORM_FEE_BPS: i128 = 200; // 2%
+use crate::errors::QuickLendXError;
+use crate::events::emit_platform_fee_updated;
+use soroban_sdk::{contracttype, symbol_short, Address, Env};
 
-/// Calculate investor payout and platform fee from a payment amount.
-/// Returns a tuple of (investor_return, platform_fee).
-pub fn calculate_profit(investment_amount: i128, payment_amount: i128) -> (i128, i128) {
-    let profit = payment_amount.saturating_sub(investment_amount);
-    if profit <= 0 {
-        return (payment_amount.max(0), 0);
+const DEFAULT_PLATFORM_FEE_BPS: i128 = 200; // 2%
+const MAX_PLATFORM_FEE_BPS: i128 = 1_000; // 10%
+
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct PlatformFeeConfig {
+    pub fee_bps: i128,
+    pub updated_at: u64,
+    pub updated_by: Address,
+}
+
+pub struct PlatformFee;
+
+impl PlatformFee {
+    const STORAGE_KEY: soroban_sdk::Symbol = symbol_short!("fee_cfg");
+
+    fn default_config(env: &Env) -> PlatformFeeConfig {
+        PlatformFeeConfig {
+            fee_bps: DEFAULT_PLATFORM_FEE_BPS,
+            updated_at: 0,
+            updated_by: env.current_contract_address(),
+        }
     }
 
-    let platform_fee = profit.saturating_mul(DEFAULT_PLATFORM_FEE_BPS) / 10_000;
-    let investor_return = payment_amount.saturating_sub(platform_fee);
-    (investor_return, platform_fee)
+    pub fn get_config(env: &Env) -> PlatformFeeConfig {
+        env.storage()
+            .instance()
+            .get(&Self::STORAGE_KEY)
+            .unwrap_or_else(|| Self::default_config(env))
+    }
+
+    pub fn set_config(
+        env: &Env,
+        admin: &Address,
+        new_fee_bps: i128,
+    ) -> Result<PlatformFeeConfig, QuickLendXError> {
+        admin.require_auth();
+
+        if new_fee_bps < 0 || new_fee_bps > MAX_PLATFORM_FEE_BPS {
+            return Err(QuickLendXError::InvalidAmount);
+        }
+
+        let config = PlatformFeeConfig {
+            fee_bps: new_fee_bps,
+            updated_at: env.ledger().timestamp(),
+            updated_by: admin.clone(),
+        };
+
+        env.storage().instance().set(&Self::STORAGE_KEY, &config);
+        emit_platform_fee_updated(env, &config);
+        Ok(config)
+    }
+
+    pub fn calculate(env: &Env, investment_amount: i128, payment_amount: i128) -> (i128, i128) {
+        let config = Self::get_config(env);
+        let profit = payment_amount.saturating_sub(investment_amount);
+        if profit <= 0 {
+            return (payment_amount.max(0), 0);
+        }
+
+        let platform_fee = profit.saturating_mul(config.fee_bps) / 10_000;
+        let investor_return = payment_amount.saturating_sub(platform_fee);
+        (investor_return, platform_fee)
+    }
+}
+
+pub fn calculate_profit(env: &Env, investment_amount: i128, payment_amount: i128) -> (i128, i128) {
+    PlatformFee::calculate(env, investment_amount, payment_amount)
 }

--- a/quicklendx-contracts/src/settlement.rs
+++ b/quicklendx-contracts/src/settlement.rs
@@ -39,7 +39,7 @@ pub fn settle_invoice(
     }
 
     // Calculate profit and platform fee
-    let (investor_return, platform_fee) = calculate_profit(investment.amount, payment_amount);
+    let (investor_return, platform_fee) = calculate_profit(env, investment.amount, payment_amount);
 
     // Transfer funds to investor and platform
     let business_address = invoice.business.clone();

--- a/quicklendx-contracts/test_snapshots/test/test_platform_fee_configuration.1.json
+++ b/quicklendx-contracts/test_snapshots/test/test_platform_fee_configuration.1.json
@@ -1,0 +1,231 @@
+{
+  "generators": {
+    "address": 2,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "set_admin",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "set_platform_fee",
+              "args": [
+                {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 300
+                  }
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [],
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 22,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": [
+                      {
+                        "key": {
+                          "string": "admin_address"
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                        }
+                      },
+                      {
+                        "key": {
+                          "symbol": "fee_cfg"
+                        },
+                        "val": {
+                          "map": [
+                            {
+                              "key": {
+                                "symbol": "fee_bps"
+                              },
+                              "val": {
+                                "i128": {
+                                  "hi": 0,
+                                  "lo": 300
+                                }
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "updated_at"
+                              },
+                              "val": {
+                                "u64": 0
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "updated_by"
+                              },
+                              "val": {
+                                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 801925984706572462
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 801925984706572462
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 5541220902715666415
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 5541220902715666415
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}


### PR DESCRIPTION
# Description
- persisted platform fee configuration (basis points, timestamp, updater) with sensible defaults
- introduced admin-only update API that validates fee bounds, emits a `fee_upd` event, and stores metadata
- wired settlement profit sharing to read from the persisted configuration, replacing the hard-coded percentage
- added tests covering default fee retrieval, updates, and invalid input; updated snapshots and ran `cargo fmt`, `cargo build`, `cargo test`

Closes #19 