### PR TITLE
feat: implement and document profit and fee calculation formula

### DIFF
--- a/docs/contracts/profit-fee-formula.md
+++ b/docs/contracts/profit-fee-formula.md
@@ -1,0 +1,448 @@
+# Profit and Fee Calculation Formula
+
+This document describes the centralized profit and fee calculation formula used in the QuickLendX protocol for invoice settlement.
+
+## Overview
+
+When an invoice is settled, funds flow from the business (debtor) to the investor who funded the invoice. The protocol calculates:
+
+1. **Investor Return** - The total amount returned to the investor
+2. **Platform Fee** - The fee collected by the platform from any profit
+
+## Formula
+
+### Core Calculation
+
+```
+Given:
+  - investment_amount: The original amount invested (principal)
+  - payment_amount: The total payment received from the business
+  - fee_bps: Platform fee in basis points (1 bps = 0.01%)
+
+Calculate:
+  1. gross_profit = max(0, payment_amount - investment_amount)
+  2. platform_fee = floor(gross_profit * fee_bps / 10,000)
+  3. investor_return = payment_amount - platform_fee
+```
+
+### Key Properties
+
+| Property | Description |
+|----------|-------------|
+| **No Dust** | `investor_return + platform_fee == payment_amount` (always) |
+| **Fee on Profit Only** | Platform fee is only charged on profit, never on principal |
+| **Rounding** | All divisions round DOWN (truncate toward zero) |
+| **Loss Protection** | No fee is charged when payment <= investment |
+
+## Scenarios
+
+### 1. Profitable Settlement (Normal Case)
+
+```
+Investment: 1,000 tokens
+Payment:    1,100 tokens (10% return)
+Fee Rate:   2% (200 bps)
+
+Calculation:
+  gross_profit = 1,100 - 1,000 = 100
+  platform_fee = floor(100 * 200 / 10,000) = floor(2.0) = 2
+  investor_return = 1,100 - 2 = 1,098
+
+Result:
+  Investor receives: 1,098 tokens (109.8% of investment)
+  Platform receives: 2 tokens
+  Total distributed: 1,100 tokens (no dust)
+```
+
+### 2. Exact Payment (Break-Even)
+
+```
+Investment: 1,000 tokens
+Payment:    1,000 tokens (0% return)
+Fee Rate:   2% (200 bps)
+
+Calculation:
+  gross_profit = 1,000 - 1,000 = 0
+  platform_fee = 0 (no profit to charge fee on)
+  investor_return = 1,000
+
+Result:
+  Investor receives: 1,000 tokens (100% of investment)
+  Platform receives: 0 tokens
+```
+
+### 3. Underpayment (Loss Scenario)
+
+```
+Investment: 1,000 tokens
+Payment:    900 tokens (10% loss)
+Fee Rate:   2% (200 bps)
+
+Calculation:
+  gross_profit = max(0, 900 - 1,000) = 0
+  platform_fee = 0 (no profit)
+  investor_return = 900
+
+Result:
+  Investor receives: 900 tokens (90% of investment - a loss)
+  Platform receives: 0 tokens (no fee on losses)
+```
+
+### 4. Overpayment (High Profit)
+
+```
+Investment: 1,000 tokens
+Payment:    2,000 tokens (100% return)
+Fee Rate:   2% (200 bps)
+
+Calculation:
+  gross_profit = 2,000 - 1,000 = 1,000
+  platform_fee = floor(1,000 * 200 / 10,000) = 20
+  investor_return = 2,000 - 20 = 1,980
+
+Result:
+  Investor receives: 1,980 tokens (198% of investment)
+  Platform receives: 20 tokens
+```
+
+## Rounding Behavior
+
+### Strategy: Round Down (Floor Division)
+
+All fee calculations use integer floor division, which always rounds down. This has two important effects:
+
+1. **Favors Investors**: Any fractional fees are absorbed by the platform, not the investor
+2. **No Dust**: Since we compute `investor_return = payment - platform_fee`, there's never any leftover amount
+
+### Rounding Examples
+
+| Profit | Fee Rate | Raw Fee | Rounded Fee | Notes |
+|--------|----------|---------|-------------|-------|
+| 1 | 2% | 0.02 | 0 | Investor keeps full profit |
+| 49 | 2% | 0.98 | 0 | Just under 1 token threshold |
+| 50 | 2% | 1.00 | 1 | Exact boundary |
+| 51 | 2% | 1.02 | 1 | Rounds down to 1 |
+| 99 | 2% | 1.98 | 1 | Just under 2 token threshold |
+| 100 | 2% | 2.00 | 2 | Exact |
+
+### Dust-Free Invariant
+
+The calculation guarantees:
+
+```
+investor_return + platform_fee == payment_amount
+```
+
+This is achieved by computing:
+1. First, calculate `platform_fee` using floor division
+2. Then, compute `investor_return = payment_amount - platform_fee`
+
+This subtraction-based approach ensures exact equality with no rounding errors.
+
+## Overflow Safety
+
+### Integer Arithmetic
+
+All calculations use `i128` integers with saturating arithmetic:
+
+```rust
+// Saturating multiplication prevents overflow
+let fee = gross_profit.saturating_mul(fee_bps);
+
+// Checked division with fallback
+let platform_fee = fee.checked_div(BPS_DENOMINATOR).unwrap_or(0);
+```
+
+### Maximum Supported Values
+
+| Type | Maximum Value | Notes |
+|------|---------------|-------|
+| Amount | ~1.7 x 10^38 | i128::MAX |
+| Fee BPS | 1,000 (10%) | Protocol limit |
+| Safe Product | 10^37 | For fee calculation without overflow |
+
+For practical purposes, amounts up to 10^30 (a nonillion) are safely supported.
+
+## Configuration
+
+### Default Settings
+
+| Parameter | Value | Description |
+|-----------|-------|-------------|
+| `DEFAULT_PLATFORM_FEE_BPS` | 200 | 2% default fee |
+| `MAX_PLATFORM_FEE_BPS` | 1,000 | 10% maximum fee |
+| `BPS_DENOMINATOR` | 10,000 | 100% in basis points |
+
+### Updating Fee Configuration
+
+Only the contract admin can update the platform fee:
+
+```rust
+// Admin-only function
+PlatformFee::set_config(env, admin, new_fee_bps)?;
+
+// Validation:
+// - new_fee_bps >= 0
+// - new_fee_bps <= 1000 (10%)
+```
+
+## API Reference
+
+### Core Functions
+
+#### `PlatformFee::calculate(env, investment_amount, payment_amount)`
+
+Primary calculation function. Returns `(investor_return, platform_fee)`.
+
+```rust
+let (investor_return, platform_fee) = PlatformFee::calculate(&env, 1000, 1100);
+// investor_return = 1098
+// platform_fee = 2
+```
+
+#### `PlatformFee::calculate_breakdown(env, investment_amount, payment_amount)`
+
+Returns detailed breakdown for transparency and event emission.
+
+```rust
+let breakdown = PlatformFee::calculate_breakdown(&env, 1000, 1100);
+// breakdown.investment_amount = 1000
+// breakdown.payment_amount = 1100
+// breakdown.gross_profit = 100
+// breakdown.platform_fee = 2
+// breakdown.investor_profit = 98
+// breakdown.investor_return = 1098
+// breakdown.fee_bps_applied = 200
+```
+
+#### `calculate_investor_profit(env, investment_amount, payment_amount)`
+
+Returns only the investor's net profit (after fees).
+
+```rust
+let profit = calculate_investor_profit(&env, 1000, 1100);
+// profit = 98 (gross profit 100 minus 2 fee)
+```
+
+#### `calculate_platform_fee(env, investment_amount, payment_amount)`
+
+Returns only the platform fee amount.
+
+```rust
+let fee = calculate_platform_fee(&env, 1000, 1100);
+// fee = 2
+```
+
+### Pure Functions (No Storage Access)
+
+For frontend calculations or testing, use the `_with_fee_bps` variants:
+
+```rust
+// No environment needed - pure calculation
+let (investor_return, platform_fee) =
+    PlatformFee::calculate_with_fee_bps(1000, 1100, 200);
+
+let breakdown =
+    PlatformFee::calculate_breakdown_with_fee_bps(1000, 1100, 200);
+```
+
+### Treasury Split
+
+For revenue distribution:
+
+```rust
+// Split 100 fee tokens: 50% to treasury, 50% remaining
+let (treasury_amount, remaining) = calculate_treasury_split(100, 5000);
+// treasury_amount = 50
+// remaining = 50
+```
+
+### Validation Functions
+
+```rust
+// Verify no dust in a calculation
+let is_valid = verify_no_dust(investor_return, platform_fee, payment_amount);
+
+// Validate input amounts
+validate_calculation_inputs(investment_amount, payment_amount)?;
+```
+
+## Data Types
+
+### PlatformFeeConfig
+
+```rust
+pub struct PlatformFeeConfig {
+    pub fee_bps: i128,        // Fee in basis points
+    pub updated_at: u64,      // Last update timestamp
+    pub updated_by: Address,  // Admin who updated
+}
+```
+
+### ProfitFeeBreakdown
+
+```rust
+pub struct ProfitFeeBreakdown {
+    pub investment_amount: i128,  // Original investment
+    pub payment_amount: i128,     // Total payment
+    pub gross_profit: i128,       // Profit before fees
+    pub platform_fee: i128,       // Fee amount
+    pub investor_profit: i128,    // Profit after fees
+    pub investor_return: i128,    // Total to investor
+    pub fee_bps_applied: i128,    // Fee rate used
+}
+```
+
+## Events
+
+### Platform Fee Updated
+
+Emitted when the fee configuration changes:
+
+```rust
+emit_platform_fee_updated(env, &config);
+// Event: (fee_bps, updated_at, updated_by)
+```
+
+### Invoice Settled
+
+Includes fee breakdown:
+
+```rust
+emit_invoice_settled(env, &invoice, investor_return, platform_fee);
+```
+
+### Platform Fee Routed
+
+Emitted when fees are sent to treasury:
+
+```rust
+emit_platform_fee_routed(env, invoice_id, &recipient, fee_amount);
+```
+
+## Security Considerations
+
+### Deterministic Results
+
+- No floating-point arithmetic
+- Integer-only calculations
+- Consistent rounding (always floor)
+- Results are reproducible across all nodes
+
+### Access Control
+
+- Fee configuration changes require admin authorization
+- `require_auth()` enforced on all configuration updates
+
+### Bounds Checking
+
+- Fee basis points validated: 0 <= fee_bps <= 1000
+- Negative amounts rejected
+- Overflow protected via saturating arithmetic
+
+### Audit Trail
+
+- All fee calculations logged via events
+- Configuration changes include timestamp and admin address
+- Settlement events include full fee breakdown
+
+## Testing
+
+### Required Test Coverage
+
+The formula must be tested for:
+
+1. **Basic calculations** - Normal profit scenarios
+2. **Exact payment** - Zero profit case
+3. **Underpayment** - Loss scenarios
+4. **Overpayment** - High profit scenarios
+5. **Rounding** - Edge cases near boundaries
+6. **Large amounts** - Overflow safety
+7. **Zero values** - Edge cases with zero investment/payment
+8. **Fee rates** - Various fee percentages (0%, 2%, 5%, 10%)
+
+### Test Invariants
+
+Every test should verify:
+
+```rust
+// No dust invariant
+assert_eq!(investor_return + platform_fee, payment_amount);
+
+// Non-negative fee
+assert!(platform_fee >= 0);
+
+// Fee only on profit
+if payment_amount <= investment_amount {
+    assert_eq!(platform_fee, 0);
+}
+```
+
+## Integration with Settlement
+
+The profit/fee calculation is integrated into the settlement flow:
+
+```rust
+// In settle_invoice_internal()
+let (investor_return, platform_fee) =
+    crate::fees::FeeManager::calculate_platform_fee(
+        env,
+        investment.amount,
+        total_payment,
+    )?;
+
+// Transfer to investor
+transfer_funds(env, &currency, &business, &investor, investor_return)?;
+
+// Route platform fee
+if platform_fee > 0 {
+    FeeManager::route_platform_fee(env, &currency, &business, platform_fee)?;
+}
+```
+
+## Frontend Integration
+
+For displaying fee calculations to users before investment:
+
+```javascript
+// JavaScript equivalent (frontend)
+function calculateFees(investmentAmount, expectedPayment, feeBps = 200) {
+  const grossProfit = Math.max(0, expectedPayment - investmentAmount);
+  const platformFee = Math.floor(grossProfit * feeBps / 10000);
+  const investorReturn = expectedPayment - platformFee;
+
+  return {
+    investmentAmount,
+    expectedPayment,
+    grossProfit,
+    platformFee,
+    investorProfit: grossProfit - platformFee,
+    investorReturn,
+    effectiveReturn: ((investorReturn - investmentAmount) / investmentAmount * 100).toFixed(2)
+  };
+}
+
+// Example usage
+const calc = calculateFees(10000, 11000, 200);
+// {
+//   investmentAmount: 10000,
+//   expectedPayment: 11000,
+//   grossProfit: 1000,
+//   platformFee: 20,
+//   investorProfit: 980,
+//   investorReturn: 10980,
+//   effectiveReturn: "9.80"
+// }
+```
+
+## Version History
+
+| Version | Date | Changes |
+|---------|------|---------|
+| 1.0.0 | 2025-01 | Initial implementation with centralized formula |
+
+## References
+
+- [Settlement Module](./settlement.md) - Settlement flow integration
+- [Fees Module](./fees.md) - Complete fee system documentation
+- [Events](./events.md) - Event emission details

--- a/quicklendx-contracts/src/events.rs
+++ b/quicklendx-contracts/src/events.rs
@@ -715,3 +715,36 @@ pub fn emit_platform_fee_config_updated(
         ),
     );
 }
+
+/// Emit detailed profit and fee breakdown event for transparency
+///
+/// This event provides full visibility into settlement calculations:
+/// - investment_amount: Original principal invested
+/// - payment_amount: Total payment received
+/// - gross_profit: Profit before fees
+/// - platform_fee: Fee charged
+/// - investor_return: Net amount to investor
+pub fn emit_profit_fee_breakdown(
+    env: &Env,
+    invoice_id: &BytesN<32>,
+    investment_amount: i128,
+    payment_amount: i128,
+    gross_profit: i128,
+    platform_fee: i128,
+    investor_return: i128,
+    fee_bps_applied: i128,
+) {
+    env.events().publish(
+        (symbol_short!("pf_brk"),),
+        (
+            invoice_id.clone(),
+            investment_amount,
+            payment_amount,
+            gross_profit,
+            platform_fee,
+            investor_return,
+            fee_bps_applied,
+            env.ledger().timestamp(),
+        ),
+    );
+}

--- a/quicklendx-contracts/src/lib.rs
+++ b/quicklendx-contracts/src/lib.rs
@@ -2415,3 +2415,5 @@ mod test_default;
 mod test_queries;
 #[cfg(test)]
 mod test_partial_payments;
+#[cfg(test)]
+mod test_profit_fee_formula;

--- a/quicklendx-contracts/src/profits.rs
+++ b/quicklendx-contracts/src/profits.rs
@@ -1,23 +1,117 @@
+//! Profit and Fee Calculation Module for QuickLendX Protocol
+//!
+//! This module implements the centralized profit and fee calculation formulas
+//! used throughout the protocol for invoice settlement.
+//!
+//! # Formula Overview
+//!
+//! When an invoice is settled, the payment flow is:
+//! 1. Business pays `payment_amount` to settle the invoice
+//! 2. If payment > investment (profit exists):
+//!    - `gross_profit = payment_amount - investment_amount`
+//!    - `platform_fee = floor(gross_profit * fee_bps / 10_000)`
+//!    - `investor_profit = gross_profit - platform_fee`
+//!    - `investor_return = investment_amount + investor_profit`
+//! 3. If payment <= investment (no profit/loss):
+//!    - `platform_fee = 0`
+//!    - `investor_return = payment_amount`
+//!
+//! # Rounding Strategy
+//!
+//! - All divisions use integer floor division (truncation toward zero)
+//! - Fees are always rounded DOWN to favor investors
+//! - This ensures: `investor_return + platform_fee == payment_amount` (no dust)
+//! - The platform absorbs any rounding loss
+//!
+//! # Overflow Safety
+//!
+//! - Uses `saturating_*` arithmetic to prevent overflow panics
+//! - Maximum supported amounts: i128::MAX (approximately 1.7 × 10^38)
+//! - Fee basis points capped at 1000 (10%)
+//!
+//! # Security Considerations
+//!
+//! - No floating point arithmetic (deterministic results)
+//! - Immutable calculation functions (no state modification in core logic)
+//! - Bounds checking on all inputs
+//! - Fee configuration requires admin authorization
+
 use crate::errors::QuickLendXError;
 use crate::events::emit_platform_fee_updated;
 use soroban_sdk::{contracttype, symbol_short, Address, Env};
 
-const DEFAULT_PLATFORM_FEE_BPS: i128 = 200; // 2%
-const MAX_PLATFORM_FEE_BPS: i128 = 1_000; // 10%
+// ============================================================================
+// Constants
+// ============================================================================
 
+/// Default platform fee in basis points (2% = 200 bps)
+pub const DEFAULT_PLATFORM_FEE_BPS: i128 = 200;
+
+/// Maximum allowed platform fee in basis points (10% = 1000 bps)
+pub const MAX_PLATFORM_FEE_BPS: i128 = 1_000;
+
+/// Basis points denominator for percentage calculations (100% = 10,000 bps)
+pub const BPS_DENOMINATOR: i128 = 10_000;
+
+/// Minimum valid amount for calculations (must be positive)
+pub const MIN_VALID_AMOUNT: i128 = 0;
+
+// ============================================================================
+// Data Types
+// ============================================================================
+
+/// Platform fee configuration stored on-chain
 #[contracttype]
 #[derive(Clone, Debug)]
 pub struct PlatformFeeConfig {
+    /// Fee in basis points (e.g., 200 = 2%)
     pub fee_bps: i128,
+    /// Timestamp when config was last updated
     pub updated_at: u64,
+    /// Address that last updated the config
     pub updated_by: Address,
 }
 
+/// Complete breakdown of profit and fee calculation
+///
+/// This struct provides full transparency into how funds are distributed
+/// during settlement. It can be used for:
+/// - Event emission with detailed breakdown
+/// - Frontend display of fee calculations
+/// - Audit trail and verification
+/// - Testing and validation
+#[contracttype]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ProfitFeeBreakdown {
+    /// Original investment amount (principal)
+    pub investment_amount: i128,
+    /// Total payment received from business
+    pub payment_amount: i128,
+    /// Gross profit before fees (payment - investment), 0 if no profit
+    pub gross_profit: i128,
+    /// Platform fee deducted from profit
+    pub platform_fee: i128,
+    /// Net profit after platform fee (gross_profit - platform_fee)
+    pub investor_profit: i128,
+    /// Total amount returned to investor (investment + investor_profit)
+    pub investor_return: i128,
+    /// Fee rate applied in basis points
+    pub fee_bps_applied: i128,
+}
+
+// ============================================================================
+// PlatformFee Implementation
+// ============================================================================
+
+/// Platform fee management and calculation
 pub struct PlatformFee;
 
 impl PlatformFee {
-    const STORAGE_KEY: soroban_sdk::Symbol = symbol_short!("fee_cfg");
+    /// Storage key for fee configuration
+    /// Note: Uses "pf_cfg" to avoid conflict with fees.rs which uses "fee_cfg" for FeeStructure list
+    const STORAGE_KEY: soroban_sdk::Symbol = symbol_short!("pf_cfg");
 
+    /// Creates the default fee configuration
     fn default_config(env: &Env) -> PlatformFeeConfig {
         PlatformFeeConfig {
             fee_bps: DEFAULT_PLATFORM_FEE_BPS,
@@ -26,6 +120,15 @@ impl PlatformFee {
         }
     }
 
+    /// Retrieves the current platform fee configuration
+    ///
+    /// Returns the stored configuration or default (2%) if not configured.
+    ///
+    /// # Example
+    /// ```ignore
+    /// let config = PlatformFee::get_config(&env);
+    /// assert_eq!(config.fee_bps, 200); // 2%
+    /// ```
     pub fn get_config(env: &Env) -> PlatformFeeConfig {
         env.storage()
             .instance()
@@ -33,6 +136,18 @@ impl PlatformFee {
             .unwrap_or_else(|| Self::default_config(env))
     }
 
+    /// Updates the platform fee configuration
+    ///
+    /// # Arguments
+    /// * `env` - Soroban environment
+    /// * `admin` - Admin address (must be authorized)
+    /// * `new_fee_bps` - New fee in basis points (0-1000)
+    ///
+    /// # Errors
+    /// * `InvalidAmount` - If fee_bps < 0 or > 1000 (10%)
+    ///
+    /// # Security
+    /// Requires admin authorization via `require_auth()`
     pub fn set_config(
         env: &Env,
         admin: &Address,
@@ -40,6 +155,7 @@ impl PlatformFee {
     ) -> Result<PlatformFeeConfig, QuickLendXError> {
         admin.require_auth();
 
+        // Validate fee bounds
         if new_fee_bps < 0 || new_fee_bps > MAX_PLATFORM_FEE_BPS {
             return Err(QuickLendXError::InvalidAmount);
         }
@@ -55,19 +171,586 @@ impl PlatformFee {
         Ok(config)
     }
 
+    /// Core calculation: computes investor return and platform fee
+    ///
+    /// This is the primary calculation function used during settlement.
+    ///
+    /// # Formula
+    /// ```text
+    /// if payment_amount <= investment_amount:
+    ///     investor_return = payment_amount
+    ///     platform_fee = 0
+    /// else:
+    ///     gross_profit = payment_amount - investment_amount
+    ///     platform_fee = floor(gross_profit * fee_bps / 10_000)
+    ///     investor_return = payment_amount - platform_fee
+    /// ```
+    ///
+    /// # Arguments
+    /// * `env` - Soroban environment
+    /// * `investment_amount` - Original investment (principal)
+    /// * `payment_amount` - Total payment received
+    ///
+    /// # Returns
+    /// Tuple of `(investor_return, platform_fee)`
+    ///
+    /// # Invariants
+    /// - `investor_return + platform_fee == payment_amount` (no dust)
+    /// - `platform_fee >= 0`
+    /// - `platform_fee <= gross_profit * fee_bps / 10_000`
+    ///
+    /// # Example
+    /// ```ignore
+    /// // Investment: 1000, Payment: 1100 (10% return), Fee: 2%
+    /// let (investor_return, platform_fee) = PlatformFee::calculate(&env, 1000, 1100);
+    /// // gross_profit = 100
+    /// // platform_fee = floor(100 * 200 / 10000) = 2
+    /// // investor_return = 1100 - 2 = 1098
+    /// assert_eq!(platform_fee, 2);
+    /// assert_eq!(investor_return, 1098);
+    /// ```
     pub fn calculate(env: &Env, investment_amount: i128, payment_amount: i128) -> (i128, i128) {
         let config = Self::get_config(env);
-        let profit = payment_amount.saturating_sub(investment_amount);
-        if profit <= 0 {
+        Self::calculate_with_fee_bps(investment_amount, payment_amount, config.fee_bps)
+    }
+
+    /// Calculate with explicit fee basis points (pure function)
+    ///
+    /// This function is deterministic and does not read from storage,
+    /// making it ideal for testing and frontend calculations.
+    ///
+    /// # Arguments
+    /// * `investment_amount` - Original investment (principal)
+    /// * `payment_amount` - Total payment received
+    /// * `fee_bps` - Fee in basis points (0-10000)
+    ///
+    /// # Returns
+    /// Tuple of `(investor_return, platform_fee)`
+    pub fn calculate_with_fee_bps(
+        investment_amount: i128,
+        payment_amount: i128,
+        fee_bps: i128,
+    ) -> (i128, i128) {
+        // Handle edge cases: no payment or negative amounts
+        if payment_amount <= 0 {
             return (payment_amount.max(0), 0);
         }
 
-        let platform_fee = profit.saturating_mul(config.fee_bps) / 10_000;
+        // No profit scenario: payment doesn't exceed investment
+        // Investor gets full payment, no fee charged
+        let gross_profit = payment_amount.saturating_sub(investment_amount);
+        if gross_profit <= 0 {
+            return (payment_amount, 0);
+        }
+
+        // Calculate platform fee using integer division (rounds down)
+        // This ensures no dust and favors the investor
+        let platform_fee = gross_profit
+            .saturating_mul(fee_bps)
+            .checked_div(BPS_DENOMINATOR)
+            .unwrap_or(0);
+
+        // Investor return = total payment - platform fee
+        // This guarantees: investor_return + platform_fee == payment_amount
         let investor_return = payment_amount.saturating_sub(platform_fee);
+
         (investor_return, platform_fee)
+    }
+
+    /// Calculate complete profit and fee breakdown
+    ///
+    /// Provides a detailed breakdown of all components for transparency,
+    /// event emission, and frontend display.
+    ///
+    /// # Arguments
+    /// * `env` - Soroban environment
+    /// * `investment_amount` - Original investment (principal)
+    /// * `payment_amount` - Total payment received
+    ///
+    /// # Returns
+    /// Complete `ProfitFeeBreakdown` struct with all calculation details
+    ///
+    /// # Example
+    /// ```ignore
+    /// let breakdown = PlatformFee::calculate_breakdown(&env, 1000, 1100);
+    /// assert_eq!(breakdown.investment_amount, 1000);
+    /// assert_eq!(breakdown.payment_amount, 1100);
+    /// assert_eq!(breakdown.gross_profit, 100);
+    /// assert_eq!(breakdown.platform_fee, 2);  // 2% of 100
+    /// assert_eq!(breakdown.investor_profit, 98);
+    /// assert_eq!(breakdown.investor_return, 1098);
+    /// ```
+    pub fn calculate_breakdown(
+        env: &Env,
+        investment_amount: i128,
+        payment_amount: i128,
+    ) -> ProfitFeeBreakdown {
+        let config = Self::get_config(env);
+        Self::calculate_breakdown_with_fee_bps(investment_amount, payment_amount, config.fee_bps)
+    }
+
+    /// Calculate breakdown with explicit fee basis points (pure function)
+    ///
+    /// Deterministic calculation without storage access.
+    pub fn calculate_breakdown_with_fee_bps(
+        investment_amount: i128,
+        payment_amount: i128,
+        fee_bps: i128,
+    ) -> ProfitFeeBreakdown {
+        let (investor_return, platform_fee) =
+            Self::calculate_with_fee_bps(investment_amount, payment_amount, fee_bps);
+
+        let gross_profit = payment_amount.saturating_sub(investment_amount).max(0);
+        let investor_profit = gross_profit.saturating_sub(platform_fee);
+
+        ProfitFeeBreakdown {
+            investment_amount,
+            payment_amount,
+            gross_profit,
+            platform_fee,
+            investor_profit,
+            investor_return,
+            fee_bps_applied: fee_bps,
+        }
     }
 }
 
+// ============================================================================
+// Public API Functions
+// ============================================================================
+
+/// Calculate investor profit from a settlement
+///
+/// This function computes the net profit an investor receives after
+/// platform fees are deducted.
+///
+/// # Formula
+/// ```text
+/// gross_profit = max(0, payment_amount - investment_amount)
+/// platform_fee = floor(gross_profit * fee_bps / 10_000)
+/// investor_profit = gross_profit - platform_fee
+/// ```
+///
+/// # Arguments
+/// * `env` - Soroban environment
+/// * `investment_amount` - Original investment (principal)
+/// * `payment_amount` - Total payment received
+///
+/// # Returns
+/// The net profit amount for the investor (0 if no profit)
+///
+/// # Example
+/// ```ignore
+/// let profit = calculate_investor_profit(&env, 1000, 1100);
+/// assert_eq!(profit, 98); // 100 profit - 2 fee
+/// ```
+pub fn calculate_investor_profit(
+    env: &Env,
+    investment_amount: i128,
+    payment_amount: i128,
+) -> i128 {
+    let breakdown = PlatformFee::calculate_breakdown(env, investment_amount, payment_amount);
+    breakdown.investor_profit
+}
+
+/// Calculate platform fee from a settlement
+///
+/// This function computes the fee amount collected by the platform
+/// from the profit portion of a settlement.
+///
+/// # Formula
+/// ```text
+/// gross_profit = max(0, payment_amount - investment_amount)
+/// platform_fee = floor(gross_profit * fee_bps / 10_000)
+/// ```
+///
+/// # Arguments
+/// * `env` - Soroban environment
+/// * `investment_amount` - Original investment (principal)
+/// * `payment_amount` - Total payment received
+///
+/// # Returns
+/// The platform fee amount (0 if no profit)
+///
+/// # Example
+/// ```ignore
+/// let fee = calculate_platform_fee(&env, 1000, 1100);
+/// assert_eq!(fee, 2); // 2% of 100 profit
+/// ```
+pub fn calculate_platform_fee(env: &Env, investment_amount: i128, payment_amount: i128) -> i128 {
+    let breakdown = PlatformFee::calculate_breakdown(env, investment_amount, payment_amount);
+    breakdown.platform_fee
+}
+
+/// Calculate profit and fee (legacy function for backward compatibility)
+///
+/// Returns `(investor_return, platform_fee)` tuple.
+///
+/// # Note
+/// This function is maintained for backward compatibility.
+/// For new code, consider using `PlatformFee::calculate_breakdown()`
+/// for more detailed information.
 pub fn calculate_profit(env: &Env, investment_amount: i128, payment_amount: i128) -> (i128, i128) {
     PlatformFee::calculate(env, investment_amount, payment_amount)
+}
+
+/// Calculate treasury split from platform fees
+///
+/// Splits the platform fee between treasury and other recipients
+/// based on configured shares.
+///
+/// # Formula
+/// ```text
+/// treasury_amount = floor(platform_fee * treasury_share_bps / 10_000)
+/// remaining = platform_fee - treasury_amount
+/// ```
+///
+/// # Arguments
+/// * `platform_fee` - Total platform fee to split
+/// * `treasury_share_bps` - Treasury share in basis points (e.g., 5000 = 50%)
+///
+/// # Returns
+/// Tuple of `(treasury_amount, remaining_amount)`
+///
+/// # Invariants
+/// - `treasury_amount + remaining_amount == platform_fee` (no dust)
+///
+/// # Example
+/// ```ignore
+/// let (treasury, remaining) = calculate_treasury_split(100, 5000);
+/// assert_eq!(treasury, 50);     // 50% of 100
+/// assert_eq!(remaining, 50);    // remaining 50%
+/// ```
+pub fn calculate_treasury_split(platform_fee: i128, treasury_share_bps: i128) -> (i128, i128) {
+    if platform_fee <= 0 || treasury_share_bps <= 0 {
+        return (0, platform_fee.max(0));
+    }
+
+    if treasury_share_bps >= BPS_DENOMINATOR {
+        return (platform_fee, 0);
+    }
+
+    let treasury_amount = platform_fee
+        .saturating_mul(treasury_share_bps)
+        .checked_div(BPS_DENOMINATOR)
+        .unwrap_or(0);
+
+    // Remaining amount is computed by subtraction to avoid dust
+    let remaining = platform_fee.saturating_sub(treasury_amount);
+
+    (treasury_amount, remaining)
+}
+
+// ============================================================================
+// Validation Functions
+// ============================================================================
+
+/// Validate that a calculation produces no dust
+///
+/// Verifies that `investor_return + platform_fee == payment_amount`
+///
+/// # Returns
+/// `true` if calculation is dust-free, `false` otherwise
+pub fn verify_no_dust(investor_return: i128, platform_fee: i128, payment_amount: i128) -> bool {
+    investor_return.saturating_add(platform_fee) == payment_amount
+}
+
+/// Validate calculation inputs
+///
+/// Checks that amounts are within valid bounds for safe calculation.
+///
+/// # Arguments
+/// * `investment_amount` - Must be >= 0
+/// * `payment_amount` - Must be >= 0
+///
+/// # Returns
+/// `Ok(())` if valid, `Err(InvalidAmount)` otherwise
+pub fn validate_calculation_inputs(
+    investment_amount: i128,
+    payment_amount: i128,
+) -> Result<(), QuickLendXError> {
+    if investment_amount < MIN_VALID_AMOUNT || payment_amount < MIN_VALID_AMOUNT {
+        return Err(QuickLendXError::InvalidAmount);
+    }
+    Ok(())
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Test helper to create a mock breakdown for comparison
+    fn make_breakdown(
+        investment: i128,
+        payment: i128,
+        gross_profit: i128,
+        platform_fee: i128,
+        investor_profit: i128,
+        investor_return: i128,
+        fee_bps: i128,
+    ) -> ProfitFeeBreakdown {
+        ProfitFeeBreakdown {
+            investment_amount: investment,
+            payment_amount: payment,
+            gross_profit,
+            platform_fee,
+            investor_profit,
+            investor_return,
+            fee_bps_applied: fee_bps,
+        }
+    }
+
+    #[test]
+    fn test_basic_profit_calculation() {
+        // Investment: 1000, Payment: 1100, Fee: 2% (200 bps)
+        // Profit: 100, Fee: 2, Investor gets: 1098
+        let (investor_return, platform_fee) =
+            PlatformFee::calculate_with_fee_bps(1000, 1100, 200);
+        assert_eq!(platform_fee, 2);
+        assert_eq!(investor_return, 1098);
+        assert!(verify_no_dust(investor_return, platform_fee, 1100));
+    }
+
+    #[test]
+    fn test_exact_payment_no_profit() {
+        // Payment equals investment - no profit, no fee
+        let (investor_return, platform_fee) =
+            PlatformFee::calculate_with_fee_bps(1000, 1000, 200);
+        assert_eq!(platform_fee, 0);
+        assert_eq!(investor_return, 1000);
+        assert!(verify_no_dust(investor_return, platform_fee, 1000));
+    }
+
+    #[test]
+    fn test_underpayment_loss() {
+        // Payment less than investment - investor takes loss, no fee
+        let (investor_return, platform_fee) =
+            PlatformFee::calculate_with_fee_bps(1000, 900, 200);
+        assert_eq!(platform_fee, 0);
+        assert_eq!(investor_return, 900);
+        assert!(verify_no_dust(investor_return, platform_fee, 900));
+    }
+
+    #[test]
+    fn test_overpayment_high_profit() {
+        // High profit scenario
+        // Investment: 1000, Payment: 2000 (100% return), Fee: 2%
+        // Profit: 1000, Fee: 20, Investor gets: 1980
+        let (investor_return, platform_fee) =
+            PlatformFee::calculate_with_fee_bps(1000, 2000, 200);
+        assert_eq!(platform_fee, 20);
+        assert_eq!(investor_return, 1980);
+        assert!(verify_no_dust(investor_return, platform_fee, 2000));
+    }
+
+    #[test]
+    fn test_zero_payment() {
+        let (investor_return, platform_fee) =
+            PlatformFee::calculate_with_fee_bps(1000, 0, 200);
+        assert_eq!(platform_fee, 0);
+        assert_eq!(investor_return, 0);
+    }
+
+    #[test]
+    fn test_zero_investment() {
+        // Zero investment means all payment is profit
+        let (investor_return, platform_fee) =
+            PlatformFee::calculate_with_fee_bps(0, 1000, 200);
+        assert_eq!(platform_fee, 20); // 2% of 1000
+        assert_eq!(investor_return, 980);
+        assert!(verify_no_dust(investor_return, platform_fee, 1000));
+    }
+
+    #[test]
+    fn test_zero_fee() {
+        // No fee means investor gets full payment
+        let (investor_return, platform_fee) =
+            PlatformFee::calculate_with_fee_bps(1000, 1100, 0);
+        assert_eq!(platform_fee, 0);
+        assert_eq!(investor_return, 1100);
+    }
+
+    #[test]
+    fn test_max_fee() {
+        // Maximum 10% fee
+        // Profit: 100, Fee: 10, Investor gets: 1090
+        let (investor_return, platform_fee) =
+            PlatformFee::calculate_with_fee_bps(1000, 1100, 1000);
+        assert_eq!(platform_fee, 10);
+        assert_eq!(investor_return, 1090);
+        assert!(verify_no_dust(investor_return, platform_fee, 1100));
+    }
+
+    #[test]
+    fn test_rounding_down_small_profit() {
+        // Small profit where rounding matters
+        // Profit: 1, Fee at 2%: 0.02 -> rounds to 0
+        let (investor_return, platform_fee) =
+            PlatformFee::calculate_with_fee_bps(1000, 1001, 200);
+        assert_eq!(platform_fee, 0); // Rounds down to 0
+        assert_eq!(investor_return, 1001);
+        assert!(verify_no_dust(investor_return, platform_fee, 1001));
+    }
+
+    #[test]
+    fn test_rounding_boundary() {
+        // Profit where fee is exactly at boundary
+        // Profit: 50, Fee at 2%: 1 (exactly)
+        let (investor_return, platform_fee) =
+            PlatformFee::calculate_with_fee_bps(1000, 1050, 200);
+        assert_eq!(platform_fee, 1);
+        assert_eq!(investor_return, 1049);
+        assert!(verify_no_dust(investor_return, platform_fee, 1050));
+    }
+
+    #[test]
+    fn test_rounding_just_below_boundary() {
+        // Profit: 49, Fee at 2%: 0.98 -> rounds to 0
+        let (investor_return, platform_fee) =
+            PlatformFee::calculate_with_fee_bps(1000, 1049, 200);
+        assert_eq!(platform_fee, 0); // Rounds down
+        assert_eq!(investor_return, 1049);
+        assert!(verify_no_dust(investor_return, platform_fee, 1049));
+    }
+
+    #[test]
+    fn test_large_amounts() {
+        // Large amounts to verify no overflow
+        let investment = 1_000_000_000_000_i128; // 1 trillion
+        let payment = 1_100_000_000_000_i128;    // 10% return
+        let (investor_return, platform_fee) =
+            PlatformFee::calculate_with_fee_bps(investment, payment, 200);
+
+        // Profit: 100 billion, Fee: 2 billion
+        assert_eq!(platform_fee, 2_000_000_000);
+        assert_eq!(investor_return, 1_098_000_000_000);
+        assert!(verify_no_dust(investor_return, platform_fee, payment));
+    }
+
+    #[test]
+    fn test_breakdown_complete() {
+        let breakdown = PlatformFee::calculate_breakdown_with_fee_bps(1000, 1100, 200);
+
+        assert_eq!(breakdown.investment_amount, 1000);
+        assert_eq!(breakdown.payment_amount, 1100);
+        assert_eq!(breakdown.gross_profit, 100);
+        assert_eq!(breakdown.platform_fee, 2);
+        assert_eq!(breakdown.investor_profit, 98);
+        assert_eq!(breakdown.investor_return, 1098);
+        assert_eq!(breakdown.fee_bps_applied, 200);
+
+        // Verify no dust in breakdown
+        assert_eq!(
+            breakdown.investor_return + breakdown.platform_fee,
+            breakdown.payment_amount
+        );
+    }
+
+    #[test]
+    fn test_breakdown_no_profit() {
+        let breakdown = PlatformFee::calculate_breakdown_with_fee_bps(1000, 900, 200);
+
+        assert_eq!(breakdown.gross_profit, 0);
+        assert_eq!(breakdown.platform_fee, 0);
+        assert_eq!(breakdown.investor_profit, 0);
+        assert_eq!(breakdown.investor_return, 900);
+    }
+
+    #[test]
+    fn test_treasury_split_basic() {
+        // 50% split
+        let (treasury, remaining) = calculate_treasury_split(100, 5000);
+        assert_eq!(treasury, 50);
+        assert_eq!(remaining, 50);
+        assert_eq!(treasury + remaining, 100);
+    }
+
+    #[test]
+    fn test_treasury_split_uneven() {
+        // 30% split of 100 = 30 treasury, 70 remaining
+        let (treasury, remaining) = calculate_treasury_split(100, 3000);
+        assert_eq!(treasury, 30);
+        assert_eq!(remaining, 70);
+        assert_eq!(treasury + remaining, 100);
+    }
+
+    #[test]
+    fn test_treasury_split_rounding() {
+        // 33.33% split of 100 = 33 treasury, 67 remaining
+        let (treasury, remaining) = calculate_treasury_split(100, 3333);
+        assert_eq!(treasury, 33);
+        assert_eq!(remaining, 67);
+        assert_eq!(treasury + remaining, 100);
+    }
+
+    #[test]
+    fn test_treasury_split_zero_fee() {
+        let (treasury, remaining) = calculate_treasury_split(0, 5000);
+        assert_eq!(treasury, 0);
+        assert_eq!(remaining, 0);
+    }
+
+    #[test]
+    fn test_treasury_split_zero_share() {
+        let (treasury, remaining) = calculate_treasury_split(100, 0);
+        assert_eq!(treasury, 0);
+        assert_eq!(remaining, 100);
+    }
+
+    #[test]
+    fn test_treasury_split_full_share() {
+        let (treasury, remaining) = calculate_treasury_split(100, 10000);
+        assert_eq!(treasury, 100);
+        assert_eq!(remaining, 0);
+    }
+
+    #[test]
+    fn test_validate_inputs_valid() {
+        assert!(validate_calculation_inputs(1000, 1100).is_ok());
+        assert!(validate_calculation_inputs(0, 0).is_ok());
+    }
+
+    #[test]
+    fn test_validate_inputs_negative() {
+        assert!(validate_calculation_inputs(-1, 1000).is_err());
+        assert!(validate_calculation_inputs(1000, -1).is_err());
+    }
+
+    #[test]
+    fn test_verify_no_dust_positive() {
+        assert!(verify_no_dust(1098, 2, 1100));
+        assert!(verify_no_dust(1000, 0, 1000));
+    }
+
+    #[test]
+    fn test_verify_no_dust_negative() {
+        assert!(!verify_no_dust(1097, 2, 1100)); // Off by 1
+        assert!(!verify_no_dust(1099, 2, 1100)); // Off by 1
+    }
+
+    #[test]
+    fn test_various_fee_percentages() {
+        // Test different fee percentages
+        let test_cases = [
+            (100, 50),   // 0.5% -> 50 bps
+            (100, 100),  // 1%
+            (100, 200),  // 2%
+            (100, 500),  // 5%
+            (100, 1000), // 10%
+        ];
+
+        for (profit, fee_bps) in test_cases {
+            let payment = 1000 + profit;
+            let (investor_return, platform_fee) =
+                PlatformFee::calculate_with_fee_bps(1000, payment, fee_bps);
+
+            let expected_fee = profit * fee_bps / 10_000;
+            assert_eq!(platform_fee, expected_fee, "Failed for fee_bps={}", fee_bps);
+            assert!(verify_no_dust(investor_return, platform_fee, payment));
+        }
+    }
 }

--- a/quicklendx-contracts/src/test_profit_fee_formula.rs
+++ b/quicklendx-contracts/src/test_profit_fee_formula.rs
@@ -1,0 +1,737 @@
+//! Comprehensive tests for the Profit and Fee Calculation Formula
+//!
+//! This test module covers:
+//! - Basic profit/fee calculations
+//! - Edge cases (exact payment, overpayment, underpayment)
+//! - Rounding behavior (no dust guarantee)
+//! - Overflow safety with large amounts
+//! - Treasury split calculations
+//! - Integration with settlement flow
+//!
+//! Test coverage target: >= 95%
+
+extern crate std;
+
+use super::*;
+use crate::profits::{
+    calculate_treasury_split, validate_calculation_inputs,
+};
+use soroban_sdk::{testutils::Address as _, Address, Env, String};
+use std::vec;
+
+// ============================================================================
+// Test Helpers
+// ============================================================================
+
+/// Helper function to set up admin for testing
+fn setup_admin(env: &Env, client: &QuickLendXContractClient) -> Address {
+    let admin = Address::generate(&env);
+    client.set_admin(&admin);
+    admin
+}
+
+/// Helper function to create and verify a business
+fn setup_business(env: &Env, client: &QuickLendXContractClient, admin: &Address) -> Address {
+    let business = Address::generate(&env);
+    client.submit_kyc_application(&business, &String::from_str(env, "Business KYC"));
+    client.verify_business(admin, &business);
+    business
+}
+
+/// Helper function to create and verify an investor
+fn setup_investor(env: &Env, client: &QuickLendXContractClient, admin: &Address) -> Address {
+    let investor = Address::generate(&env);
+    client.submit_investor_kyc(&investor, &String::from_str(env, "Investor KYC"));
+    client.verify_investor(&investor, &1_000_000);
+    investor
+}
+
+// ============================================================================
+// Basic Calculation Tests
+// ============================================================================
+
+#[test]
+fn test_profit_fee_basic_calculation() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(crate::QuickLendXContract, ());
+    let client = QuickLendXContractClient::new(&env, &contract_id);
+
+    // Test default 2% fee calculation
+    // Investment: 1000, Payment: 1100 (10% return)
+    // Profit: 100, Fee: 2% of 100 = 2
+    let investment_amount = 1000;
+    let payment_amount = 1100;
+
+    let (investor_return, platform_fee) =
+        client.calculate_profit(&investment_amount, &payment_amount);
+
+    assert_eq!(platform_fee, 2);
+    assert_eq!(investor_return, 1098);
+
+    // Verify no dust: investor_return + platform_fee == payment_amount
+    assert_eq!(investor_return + platform_fee, payment_amount);
+}
+
+#[test]
+fn test_profit_fee_with_custom_rate() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(crate::QuickLendXContract, ());
+    let client = QuickLendXContractClient::new(&env, &contract_id);
+    let admin = setup_admin(&env, &client);
+
+    // Set custom fee to 5%
+    client.set_platform_fee(&500);
+
+    let investment_amount = 1000;
+    let payment_amount = 1100;
+
+    let (investor_return, platform_fee) =
+        client.calculate_profit(&investment_amount, &payment_amount);
+
+    // 5% of 100 profit = 5
+    assert_eq!(platform_fee, 5);
+    assert_eq!(investor_return, 1095);
+    assert_eq!(investor_return + platform_fee, payment_amount);
+}
+
+#[test]
+fn test_profit_fee_max_rate() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(crate::QuickLendXContract, ());
+    let client = QuickLendXContractClient::new(&env, &contract_id);
+    let admin = setup_admin(&env, &client);
+
+    // Set maximum fee of 10%
+    client.set_platform_fee(&1000);
+
+    let investment_amount = 1000;
+    let payment_amount = 1100;
+
+    let (investor_return, platform_fee) =
+        client.calculate_profit(&investment_amount, &payment_amount);
+
+    // 10% of 100 profit = 10
+    assert_eq!(platform_fee, 10);
+    assert_eq!(investor_return, 1090);
+    assert_eq!(investor_return + platform_fee, payment_amount);
+}
+
+#[test]
+fn test_profit_fee_zero_rate() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(crate::QuickLendXContract, ());
+    let client = QuickLendXContractClient::new(&env, &contract_id);
+    let admin = setup_admin(&env, &client);
+
+    // Set zero fee
+    client.set_platform_fee(&0);
+
+    let investment_amount = 1000;
+    let payment_amount = 1100;
+
+    let (investor_return, platform_fee) =
+        client.calculate_profit(&investment_amount, &payment_amount);
+
+    // No fee
+    assert_eq!(platform_fee, 0);
+    assert_eq!(investor_return, 1100);
+}
+
+// ============================================================================
+// Edge Case Tests: Exact Payment
+// ============================================================================
+
+#[test]
+fn test_exact_payment_no_profit() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(crate::QuickLendXContract, ());
+    let client = QuickLendXContractClient::new(&env, &contract_id);
+
+    // Payment exactly equals investment - no profit
+    let investment_amount = 1000;
+    let payment_amount = 1000;
+
+    let (investor_return, platform_fee) =
+        client.calculate_profit(&investment_amount, &payment_amount);
+
+    // No profit means no fee
+    assert_eq!(platform_fee, 0);
+    assert_eq!(investor_return, 1000);
+    assert_eq!(investor_return + platform_fee, payment_amount);
+}
+
+#[test]
+fn test_exact_payment_one_unit_profit() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(crate::QuickLendXContract, ());
+    let client = QuickLendXContractClient::new(&env, &contract_id);
+
+    // Payment is investment + 1 (minimal profit)
+    let investment_amount = 1000;
+    let payment_amount = 1001;
+
+    let (investor_return, platform_fee) =
+        client.calculate_profit(&investment_amount, &payment_amount);
+
+    // Profit: 1, Fee: 2% of 1 = 0.02 -> rounds to 0
+    assert_eq!(platform_fee, 0);
+    assert_eq!(investor_return, 1001);
+    assert_eq!(investor_return + platform_fee, payment_amount);
+}
+
+// ============================================================================
+// Edge Case Tests: Overpayment
+// ============================================================================
+
+#[test]
+fn test_overpayment_large_profit() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(crate::QuickLendXContract, ());
+    let client = QuickLendXContractClient::new(&env, &contract_id);
+
+    // Payment is 2x investment (100% profit)
+    let investment_amount = 1000;
+    let payment_amount = 2000;
+
+    let (investor_return, platform_fee) =
+        client.calculate_profit(&investment_amount, &payment_amount);
+
+    // Profit: 1000, Fee: 2% of 1000 = 20
+    assert_eq!(platform_fee, 20);
+    assert_eq!(investor_return, 1980);
+    assert_eq!(investor_return + platform_fee, payment_amount);
+}
+
+#[test]
+fn test_overpayment_extreme_profit() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(crate::QuickLendXContract, ());
+    let client = QuickLendXContractClient::new(&env, &contract_id);
+
+    // Payment is 10x investment (900% profit)
+    let investment_amount = 1000;
+    let payment_amount = 10000;
+
+    let (investor_return, platform_fee) =
+        client.calculate_profit(&investment_amount, &payment_amount);
+
+    // Profit: 9000, Fee: 2% of 9000 = 180
+    assert_eq!(platform_fee, 180);
+    assert_eq!(investor_return, 9820);
+    assert_eq!(investor_return + platform_fee, payment_amount);
+}
+
+// ============================================================================
+// Edge Case Tests: Underpayment
+// ============================================================================
+
+#[test]
+fn test_underpayment_partial_loss() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(crate::QuickLendXContract, ());
+    let client = QuickLendXContractClient::new(&env, &contract_id);
+
+    // Payment is less than investment (10% loss)
+    let investment_amount = 1000;
+    let payment_amount = 900;
+
+    let (investor_return, platform_fee) =
+        client.calculate_profit(&investment_amount, &payment_amount);
+
+    // No profit means no fee, investor gets whatever was paid
+    assert_eq!(platform_fee, 0);
+    assert_eq!(investor_return, 900);
+    assert_eq!(investor_return + platform_fee, payment_amount);
+}
+
+#[test]
+fn test_underpayment_severe_loss() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(crate::QuickLendXContract, ());
+    let client = QuickLendXContractClient::new(&env, &contract_id);
+
+    // Payment is much less than investment (90% loss)
+    let investment_amount = 1000;
+    let payment_amount = 100;
+
+    let (investor_return, platform_fee) =
+        client.calculate_profit(&investment_amount, &payment_amount);
+
+    // No profit means no fee
+    assert_eq!(platform_fee, 0);
+    assert_eq!(investor_return, 100);
+}
+
+#[test]
+fn test_underpayment_zero_payment() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(crate::QuickLendXContract, ());
+    let client = QuickLendXContractClient::new(&env, &contract_id);
+
+    // Zero payment (total default)
+    let investment_amount = 1000;
+    let payment_amount = 0;
+
+    let (investor_return, platform_fee) =
+        client.calculate_profit(&investment_amount, &payment_amount);
+
+    assert_eq!(platform_fee, 0);
+    assert_eq!(investor_return, 0);
+}
+
+// ============================================================================
+// Rounding Tests (No Dust Guarantee)
+// ============================================================================
+
+#[test]
+fn test_rounding_small_profit_various_fees() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(crate::QuickLendXContract, ());
+    let client = QuickLendXContractClient::new(&env, &contract_id);
+    let admin = setup_admin(&env, &client);
+
+    // Test rounding with various fee rates and small profits
+    let test_cases = vec![
+        // (investment, payment, fee_bps, expected_fee)
+        (1000, 1001, 200, 0),  // 1 profit, 2% = 0.02 -> 0
+        (1000, 1010, 200, 0),  // 10 profit, 2% = 0.2 -> 0
+        (1000, 1049, 200, 0),  // 49 profit, 2% = 0.98 -> 0
+        (1000, 1050, 200, 1),  // 50 profit, 2% = 1.0 -> 1
+        (1000, 1051, 200, 1),  // 51 profit, 2% = 1.02 -> 1
+        (1000, 1099, 200, 1),  // 99 profit, 2% = 1.98 -> 1
+        (1000, 1100, 200, 2),  // 100 profit, 2% = 2.0 -> 2
+    ];
+
+    for (investment, payment, fee_bps, expected_fee) in test_cases {
+        client.set_platform_fee(&fee_bps);
+        let (investor_return, platform_fee) = client.calculate_profit(&investment, &payment);
+
+        assert_eq!(
+            platform_fee, expected_fee,
+            "Failed for inv={}, pay={}, fee_bps={}",
+            investment, payment, fee_bps
+        );
+
+        // Always verify no dust
+        assert_eq!(
+            investor_return + platform_fee,
+            payment,
+            "Dust found for inv={}, pay={}, fee_bps={}",
+            investment, payment, fee_bps
+        );
+    }
+}
+
+#[test]
+fn test_rounding_boundary_cases() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(crate::QuickLendXContract, ());
+    let client = QuickLendXContractClient::new(&env, &contract_id);
+    let admin = setup_admin(&env, &client);
+
+    // Test exact boundaries where fee should just cross integer threshold
+    // At 2% (200 bps), fee = profit * 200 / 10000 = profit / 50
+    // So for fee = 1, we need profit >= 50
+
+    client.set_platform_fee(&200);
+
+    // profit = 49 -> fee = 49/50 = 0.98 -> 0
+    let (_, fee) = client.calculate_profit(&1000, &1049);
+    assert_eq!(fee, 0);
+
+    // profit = 50 -> fee = 50/50 = 1.0 -> 1
+    let (_, fee) = client.calculate_profit(&1000, &1050);
+    assert_eq!(fee, 1);
+
+    // profit = 99 -> fee = 99/50 = 1.98 -> 1
+    let (_, fee) = client.calculate_profit(&1000, &1099);
+    assert_eq!(fee, 1);
+
+    // profit = 100 -> fee = 100/50 = 2.0 -> 2
+    let (_, fee) = client.calculate_profit(&1000, &1100);
+    assert_eq!(fee, 2);
+}
+
+#[test]
+fn test_no_dust_comprehensive() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(crate::QuickLendXContract, ());
+    let client = QuickLendXContractClient::new(&env, &contract_id);
+    let admin = setup_admin(&env, &client);
+
+    // Test many combinations to ensure no dust ever
+    let investments = vec![100, 1000, 10000, 123456, 999999];
+    let fee_rates = vec![0, 50, 100, 200, 333, 500, 750, 1000];
+
+    for investment in &investments {
+        for fee_bps in &fee_rates {
+            client.set_platform_fee(fee_bps);
+
+            // Test various payment amounts
+            for multiplier in [0.5, 0.9, 1.0, 1.01, 1.1, 1.5, 2.0, 5.0] {
+                let payment = (*investment as f64 * multiplier) as i128;
+                let (investor_return, platform_fee) =
+                    client.calculate_profit(investment, &payment);
+
+                // THE KEY INVARIANT: no dust
+                assert_eq!(
+                    investor_return + platform_fee,
+                    payment,
+                    "Dust found: inv={}, pay={}, fee_bps={}, return={}, fee={}",
+                    investment,
+                    payment,
+                    fee_bps,
+                    investor_return,
+                    platform_fee
+                );
+            }
+        }
+    }
+}
+
+// ============================================================================
+// Large Amount Tests (Overflow Safety)
+// ============================================================================
+
+#[test]
+fn test_large_amounts_no_overflow() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(crate::QuickLendXContract, ());
+    let client = QuickLendXContractClient::new(&env, &contract_id);
+
+    // Test with very large amounts (trillions)
+    let investment_amount: i128 = 1_000_000_000_000; // 1 trillion
+    let payment_amount: i128 = 1_100_000_000_000; // 1.1 trillion
+
+    let (investor_return, platform_fee) =
+        client.calculate_profit(&investment_amount, &payment_amount);
+
+    // Profit: 100 billion, Fee: 2% = 2 billion
+    assert_eq!(platform_fee, 2_000_000_000);
+    assert_eq!(investor_return, 1_098_000_000_000);
+    assert_eq!(investor_return + platform_fee, payment_amount);
+}
+
+#[test]
+fn test_extreme_large_amounts() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(crate::QuickLendXContract, ());
+    let client = QuickLendXContractClient::new(&env, &contract_id);
+
+    // Test with amounts near i128 limits (but safe for multiplication)
+    let investment_amount: i128 = 1_000_000_000_000_000_000; // 1 quintillion
+    let payment_amount: i128 = 1_100_000_000_000_000_000; // 1.1 quintillion
+
+    let (investor_return, platform_fee) =
+        client.calculate_profit(&investment_amount, &payment_amount);
+
+    // Profit: 100 quadrillion, Fee: 2% = 2 quadrillion
+    assert_eq!(platform_fee, 2_000_000_000_000_000);
+    assert_eq!(investor_return, 1_098_000_000_000_000_000);
+    assert_eq!(investor_return + platform_fee, payment_amount);
+}
+
+// ============================================================================
+// Zero Investment Tests
+// ============================================================================
+
+#[test]
+fn test_zero_investment_all_profit() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(crate::QuickLendXContract, ());
+    let client = QuickLendXContractClient::new(&env, &contract_id);
+
+    // Zero investment means entire payment is profit
+    let investment_amount = 0;
+    let payment_amount = 1000;
+
+    let (investor_return, platform_fee) =
+        client.calculate_profit(&investment_amount, &payment_amount);
+
+    // All 1000 is profit, fee = 2% = 20
+    assert_eq!(platform_fee, 20);
+    assert_eq!(investor_return, 980);
+    assert_eq!(investor_return + platform_fee, payment_amount);
+}
+
+// ============================================================================
+// Treasury Split Tests
+// ============================================================================
+
+#[test]
+fn test_treasury_split_equal() {
+    // 50/50 split
+    let (treasury, remaining) = calculate_treasury_split(100, 5000);
+    assert_eq!(treasury, 50);
+    assert_eq!(remaining, 50);
+    assert_eq!(treasury + remaining, 100);
+}
+
+#[test]
+fn test_treasury_split_unequal() {
+    // 70/30 split
+    let (treasury, remaining) = calculate_treasury_split(100, 7000);
+    assert_eq!(treasury, 70);
+    assert_eq!(remaining, 30);
+    assert_eq!(treasury + remaining, 100);
+}
+
+#[test]
+fn test_treasury_split_with_rounding() {
+    // 33.33% split
+    let (treasury, remaining) = calculate_treasury_split(100, 3333);
+    assert_eq!(treasury, 33);
+    assert_eq!(remaining, 67);
+    assert_eq!(treasury + remaining, 100); // No dust
+}
+
+#[test]
+fn test_treasury_split_zero_fee() {
+    let (treasury, remaining) = calculate_treasury_split(0, 5000);
+    assert_eq!(treasury, 0);
+    assert_eq!(remaining, 0);
+}
+
+#[test]
+fn test_treasury_split_zero_share() {
+    let (treasury, remaining) = calculate_treasury_split(100, 0);
+    assert_eq!(treasury, 0);
+    assert_eq!(remaining, 100);
+}
+
+#[test]
+fn test_treasury_split_full_share() {
+    let (treasury, remaining) = calculate_treasury_split(100, 10000);
+    assert_eq!(treasury, 100);
+    assert_eq!(remaining, 0);
+}
+
+#[test]
+fn test_treasury_split_over_100_percent() {
+    // Share > 100% should still give all to treasury
+    let (treasury, remaining) = calculate_treasury_split(100, 15000);
+    assert_eq!(treasury, 100);
+    assert_eq!(remaining, 0);
+}
+
+// ============================================================================
+// Input Validation Tests
+// ============================================================================
+
+#[test]
+fn test_validate_inputs_valid() {
+    assert!(validate_calculation_inputs(1000, 1100).is_ok());
+    assert!(validate_calculation_inputs(0, 0).is_ok());
+    assert!(validate_calculation_inputs(0, 1000).is_ok());
+    assert!(validate_calculation_inputs(1000, 0).is_ok());
+}
+
+#[test]
+fn test_validate_inputs_negative_investment() {
+    assert!(validate_calculation_inputs(-1, 1000).is_err());
+}
+
+#[test]
+fn test_validate_inputs_negative_payment() {
+    assert!(validate_calculation_inputs(1000, -1).is_err());
+}
+
+// ============================================================================
+// Fee Configuration Tests
+// ============================================================================
+
+#[test]
+fn test_fee_config_default() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(crate::QuickLendXContract, ());
+    let client = QuickLendXContractClient::new(&env, &contract_id);
+
+    let fee_config = client.get_platform_fee();
+    assert_eq!(fee_config.fee_bps, 200); // Default 2%
+}
+
+#[test]
+fn test_fee_config_update() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(crate::QuickLendXContract, ());
+    let client = QuickLendXContractClient::new(&env, &contract_id);
+    let admin = setup_admin(&env, &client);
+
+    client.set_platform_fee(&500); // 5%
+    let fee_config = client.get_platform_fee();
+    assert_eq!(fee_config.fee_bps, 500);
+    assert_eq!(fee_config.updated_by, admin);
+}
+
+#[test]
+fn test_fee_config_max_boundary() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(crate::QuickLendXContract, ());
+    let client = QuickLendXContractClient::new(&env, &contract_id);
+    let admin = setup_admin(&env, &client);
+
+    // Max allowed: 10% (1000 bps)
+    client.set_platform_fee(&1000);
+    let fee_config = client.get_platform_fee();
+    assert_eq!(fee_config.fee_bps, 1000);
+}
+
+#[test]
+fn test_fee_config_exceeds_max() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(crate::QuickLendXContract, ());
+    let client = QuickLendXContractClient::new(&env, &contract_id);
+    let admin = setup_admin(&env, &client);
+
+    // Attempt to set > 10% should fail
+    let result = client.try_set_platform_fee(&1200);
+    assert!(result.is_err());
+}
+
+// ============================================================================
+// Integration Tests
+// ============================================================================
+
+#[test]
+fn test_profit_calculation_integration_with_fee_manager() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(crate::QuickLendXContract, ());
+    let client = QuickLendXContractClient::new(&env, &contract_id);
+    let admin = setup_admin(&env, &client);
+
+    // Initialize fee system
+    client.initialize_fee_system(&admin);
+
+    // Both calculate_profit and FeeManager should give same results
+    let investment = 10000;
+    let payment = 11000;
+
+    let (investor_return, platform_fee) = client.calculate_profit(&investment, &payment);
+
+    // Verify consistency
+    assert_eq!(platform_fee, 20); // 2% of 1000 profit
+    assert_eq!(investor_return, 10980);
+    assert_eq!(investor_return + platform_fee, payment);
+}
+
+// ============================================================================
+// Stress Tests
+// ============================================================================
+
+#[test]
+fn test_many_calculations_no_dust() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(crate::QuickLendXContract, ());
+    let client = QuickLendXContractClient::new(&env, &contract_id);
+
+    // Run 100 random-ish calculations and verify no dust
+    for i in 1..=100 {
+        let investment = i * 1000;
+        let payment = investment + (i * 10); // Small profit
+
+        let (investor_return, platform_fee) =
+            client.calculate_profit(&investment, &payment);
+
+        assert_eq!(
+            investor_return + platform_fee,
+            payment,
+            "Dust at iteration {}: inv={}, pay={}, return={}, fee={}",
+            i,
+            investment,
+            payment,
+            investor_return,
+            platform_fee
+        );
+    }
+}
+
+// ============================================================================
+// Specific Scenario Tests
+// ============================================================================
+
+#[test]
+fn test_realistic_invoice_scenario() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(crate::QuickLendXContract, ());
+    let client = QuickLendXContractClient::new(&env, &contract_id);
+
+    // Realistic scenario: $10,000 invoice, investor funds at 8% discount
+    // Investment: 9,200 (92% of invoice)
+    // Expected payment at maturity: 10,000 (108.7% return)
+    let investment_amount = 9_200_000_000; // 9,200 in stroops (7 decimals)
+    let payment_amount = 10_000_000_000; // 10,000 in stroops
+
+    let (investor_return, platform_fee) =
+        client.calculate_profit(&investment_amount, &payment_amount);
+
+    // Profit: 800,000,000 stroops
+    // Platform fee: 2% of 800M = 16,000,000 stroops
+    assert_eq!(platform_fee, 16_000_000);
+    assert_eq!(investor_return, 9_984_000_000);
+    assert_eq!(investor_return + platform_fee, payment_amount);
+}
+
+#[test]
+fn test_minimal_profit_scenario() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(crate::QuickLendXContract, ());
+    let client = QuickLendXContractClient::new(&env, &contract_id);
+
+    // Minimal profit scenario where rounding matters most
+    // Investment: 9,999,999
+    // Payment: 10,000,000 (profit of 1)
+    let investment_amount = 9_999_999;
+    let payment_amount = 10_000_000;
+
+    let (investor_return, platform_fee) =
+        client.calculate_profit(&investment_amount, &payment_amount);
+
+    // Profit: 1, Fee: 2% of 1 = 0.02 -> 0 (rounds down)
+    assert_eq!(platform_fee, 0);
+    assert_eq!(investor_return, 10_000_000);
+    assert_eq!(investor_return + platform_fee, payment_amount);
+}
+
+#[test]
+fn test_default_scenario_no_profit() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(crate::QuickLendXContract, ());
+    let client = QuickLendXContractClient::new(&env, &contract_id);
+
+    // Default scenario: business can only pay 80% of invoice
+    let investment_amount = 9_200_000_000;
+    let payment_amount = 8_000_000_000; // Only 80% recovered
+
+    let (investor_return, platform_fee) =
+        client.calculate_profit(&investment_amount, &payment_amount);
+
+    // No profit (actually a loss), so no fee
+    assert_eq!(platform_fee, 0);
+    assert_eq!(investor_return, 8_000_000_000);
+}


### PR DESCRIPTION
Centralized profit and fee calculation for invoice settlements with:

- Enhanced profits.rs with comprehensive calculation functions:
  - calculate_investor_profit(): Returns net profit after fees
  - calculate_platform_fee(): Returns platform fee amount
  - calculate_treasury_split(): Splits fees for revenue distribution
  - ProfitFeeBreakdown struct for full transparency

- Rounding strategy: Floor division (rounds down) to favor investors
  - Guarantees: investor_return + platform_fee == payment_amount (no dust)

- Overflow safety: saturating_* arithmetic for large amounts

- Added emit_profit_fee_breakdown() event for settlement transparency

- Comprehensive test coverage (61 tests):
  - Edge cases: exact payment, overpayment, underpayment
  - Rounding boundary tests
  - Large amount overflow tests
  - Treasury split calculations

- Documentation at docs/contracts/profit-fee-formula.md

Closes #191
