### PR TITLE
test: add invariant test scaffold for state consistency

### DIFF
--- a/quicklendx-contracts/src/test_invariants.rs
+++ b/quicklendx-contracts/src/test_invariants.rs
@@ -1,0 +1,11 @@
+#![cfg(test)]
+
+use soroban_sdk::Env;
+
+/// Invariant test scaffold for protocol state consistency.
+/// Intentionally minimal and non-invasive.
+#[test]
+fn invariant_env_creation_is_safe() {
+    let env = Env::default();
+    let _ = env.ledger().timestamp();
+}


### PR DESCRIPTION
### Summary
Adds a minimal invariant test scaffold for protocol state consistency as described in #201.

### Notes
- Invariant test is intentionally non-invasive
- Does not trigger protocol flows
- Provides a foundation for future invariant expansion without impacting existing behavior
