### PR TITLE
test: escrow creation and release

### DIFF
--- a/quicklendx-contracts/src/test_escrow.rs
+++ b/quicklendx-contracts/src/test_escrow.rs
@@ -29,6 +29,7 @@ fn setup() -> (Env, QuickLendXContractClient<'static>, Address) {
     let contract_id = env.register(QuickLendXContract, ());
     let client = QuickLendXContractClient::new(&env, &contract_id);
     let admin = Address::generate(&env);
+    let _ = client.try_initialize_admin(&admin);
     client.set_admin(&admin);
     (env, client, admin)
 }
@@ -575,4 +576,73 @@ fn test_escrow_invariants() {
         escrow.created_at <= env.ledger().timestamp(),
         "Escrow created_at cannot be in future"
     );
+}
+
+// ============================================================================
+// release_escrow_funds tests (Issue #273 – authorized, idempotency blocked)
+// ============================================================================
+
+#[test]
+fn test_release_escrow_funds_success() {
+    let (env, client, _admin) = setup();
+    let contract_id = client.address.clone();
+
+    let business = setup_verified_business(&env, &client, &_admin);
+    let investor = setup_verified_investor(&env, &client, 50_000);
+
+    let currency = setup_token(&env, &business, &investor, &contract_id);
+    let token_client = token::Client::new(&env, &currency);
+
+    let amount = 10_000i128;
+    let invoice_id = create_verified_invoice(&env, &client, &business, amount, &currency);
+    let bid_id = place_test_bid(&client, &investor, &invoice_id, amount, amount + 1000);
+
+    client.accept_bid(&invoice_id, &bid_id);
+
+    let business_balance_before = token_client.balance(&business);
+    let escrow_before = client.get_escrow_details(&invoice_id);
+    assert_eq!(escrow_before.status, EscrowStatus::Held);
+
+    let result = client.try_release_escrow_funds(&invoice_id);
+    assert!(result.is_ok(), "release_escrow_funds should succeed");
+
+    let business_balance_after = token_client.balance(&business);
+    assert_eq!(
+        business_balance_after - business_balance_before,
+        amount,
+        "Business should receive escrow amount"
+    );
+
+    let escrow_after = client.get_escrow_details(&invoice_id);
+    assert_eq!(
+        escrow_after.status,
+        EscrowStatus::Released,
+        "Escrow status should be Released after release"
+    );
+}
+
+#[test]
+fn test_release_escrow_funds_idempotency_blocked() {
+    let (env, client, _admin) = setup();
+    let contract_id = client.address.clone();
+
+    let business = setup_verified_business(&env, &client, &_admin);
+    let investor = setup_verified_investor(&env, &client, 50_000);
+
+    let currency = setup_token(&env, &business, &investor, &contract_id);
+
+    let amount = 10_000i128;
+    let invoice_id = create_verified_invoice(&env, &client, &business, amount, &currency);
+    let bid_id = place_test_bid(&client, &investor, &invoice_id, amount, amount + 1000);
+
+    client.accept_bid(&invoice_id, &bid_id);
+    client.release_escrow_funds(&invoice_id);
+
+    let result = client.try_release_escrow_funds(&invoice_id);
+    assert!(
+        result.is_err(),
+        "Second release_escrow_funds should fail (idempotency blocked)"
+    );
+    let err = result.unwrap_err().unwrap();
+    assert_eq!(err, QuickLendXError::InvalidStatus);
 }


### PR DESCRIPTION
Fixes #273

- Add **release_escrow_funds** tests: success path (funds to business, escrow status Released) and idempotency (second release fails with InvalidStatus).
- Ensure setup uses `try_initialize_admin` so `verify_invoice` works in all tests.
- Covers accept_bid_and_fund (funds locked, state transitions), release_escrow_funds (authorized, idempotency blocked), reject double accept and withdrawn bid as per issue.
- `cargo test test_escrow` passes (22 tests).