### PR TITLE
bidExpiration

### DIFF
--- a/docs/contracts/bidding.md
+++ b/docs/contracts/bidding.md
@@ -206,7 +206,7 @@ pub fn get_all_bids_by_investor(env: Env, investor: Address) -> Vec<Bid>
 ### `Bid`
 
 ```rust
-pub struct Bid {
+    pub struct Bid {
     pub bid_id: BytesN<32>,           // Unique bid identifier
     pub invoice_id: BytesN<32>,       // Associated invoice
     pub investor: Address,            // Investor who placed the bid
@@ -214,7 +214,7 @@ pub struct Bid {
     pub expected_return: i128,        // Expected return amount
     pub timestamp: u64,               // When bid was placed
     pub status: BidStatus,            // Current bid status
-    pub expiration_timestamp: u64,    // When bid expires (default: 7 days)
+    pub expiration_timestamp: u64,    // When bid expires (default: 7 days). Admin-configurable (1–30 days)
 }
 ```
 
@@ -234,7 +234,7 @@ pub enum BidStatus {
 
 1. **Place Bid**: Investor places a bid on a verified invoice
    - Status: `Placed`
-   - Expiration: 7 days from placement (configurable via `DEFAULT_BID_TTL`)
+    - Expiration: 7 days from placement by default. Admin can update TTL via `set_bid_ttl_days` (bounds 1–30 days).
 
 2. **Withdraw Bid**: Investor withdraws their bid before acceptance
    - Status: `Withdrawn`

--- a/quicklendx-contracts/src/bid.rs
+++ b/quicklendx-contracts/src/bid.rs
@@ -1,6 +1,8 @@
 use core::cmp::Ordering;
 use soroban_sdk::{contracttype, symbol_short, Address, BytesN, Env, Vec};
 
+use crate::storage::ConfigStorage;
+
 use crate::events::emit_bid_expired;
 
 const DEFAULT_BID_TTL: u64 = 7 * 24 * 60 * 60;
@@ -33,8 +35,9 @@ impl Bid {
         current_timestamp > self.expiration_timestamp
     }
 
-    pub fn default_expiration(now: u64) -> u64 {
-        now.saturating_add(DEFAULT_BID_TTL)
+    pub fn default_expiration(env: &Env, now: u64) -> u64 {
+        let ttl = ConfigStorage::get_bid_ttl_seconds(env).unwrap_or(DEFAULT_BID_TTL);
+        now.saturating_add(ttl)
     }
 }
 

--- a/quicklendx-contracts/src/storage.rs
+++ b/quicklendx-contracts/src/storage.rs
@@ -46,6 +46,11 @@ impl StorageKeys {
     pub fn platform_fees() -> Symbol {
         symbol_short!("fees")
     }
+    
+    /// Key for bid TTL configuration (seconds)
+    pub fn bid_ttl() -> Symbol {
+        symbol_short!("bid_ttl")
+    }
 
     /// Key for invoice count
     pub fn invoice_count() -> Symbol {
@@ -482,5 +487,15 @@ impl ConfigStorage {
     /// Get platform fee configuration
     pub fn get_platform_fees(env: &Env) -> Option<PlatformFeeConfig> {
         env.storage().instance().get(&StorageKeys::platform_fees())
+    }
+
+    /// Set bid TTL in seconds (stored as u64)
+    pub fn set_bid_ttl_seconds(env: &Env, seconds: &u64) {
+        env.storage().instance().set(&StorageKeys::bid_ttl(), seconds);
+    }
+
+    /// Get bid TTL in seconds if set
+    pub fn get_bid_ttl_seconds(env: &Env) -> Option<u64> {
+        env.storage().instance().get(&StorageKeys::bid_ttl())
     }
 }

--- a/quicklendx-contracts/src/test_admin.rs
+++ b/quicklendx-contracts/src/test_admin.rs
@@ -26,6 +26,35 @@ mod test_admin {
         (env, client)
     }
 
+    #[test]
+    fn test_admin_can_set_bid_ttl() {
+        let (env, client, _admin) = setup_with_admin();
+
+        let result = client.try_set_bid_ttl_days(&5);
+        assert!(result.is_ok(), "Admin should be able to set bid TTL");
+        assert_eq!(client.get_bid_ttl_days(), 5);
+    }
+
+    #[test]
+    fn test_set_bid_ttl_without_admin_fails() {
+        let (env, client) = setup();
+        env.mock_all_auths();
+
+        let result = client.try_set_bid_ttl_days(&5);
+        assert!(result.is_err(), "Setting bid TTL without admin must fail");
+    }
+
+    #[test]
+    fn test_set_bid_ttl_out_of_bounds_fails() {
+        let (_env, client, _admin) = setup_with_admin();
+
+        let zero = client.try_set_bid_ttl_days(&0);
+        assert!(zero.is_err(), "Zero days must be rejected");
+
+        let high = client.try_set_bid_ttl_days(&31);
+        assert!(high.is_err(), ">30 days must be rejected");
+    }
+
     fn setup_with_admin() -> (Env, QuickLendXContractClient<'static>, Address) {
         let (env, client) = setup();
         env.mock_all_auths();

--- a/quicklendx-contracts/src/test_overflow.rs
+++ b/quicklendx-contracts/src/test_overflow.rs
@@ -288,7 +288,7 @@ fn test_compare_bids_equal_profit_ordering() {
 #[test]
 fn test_timestamp_bid_default_expiration_saturates() {
     let env = Env::default();
-    let result = Bid::default_expiration(u64::MAX);
+    let result = Bid::default_expiration(&env, u64::MAX);
     assert_eq!(result, u64::MAX);
 }
 


### PR DESCRIPTION
closes #323 

## 📝 Description
Added an admin-configurable bid expiration (TTL) while keeping the default at 7 days.

## 🎯 Type of Change
- [ ] New feature


## 🔧 Changes Made
storage
bid logic
admin api
tests
docs

### Files Modified
- storage.rs
- bid.rs
- lib.rs
- test_overflow.rs
- bidding.md
