### PR TITLE
feat(contracts): enforce configurable active Place Bid rate limit per investor (#486)

### DIFF
--- a/docs/contracts/bidding.md
+++ b/docs/contracts/bidding.md
@@ -45,6 +45,10 @@ pub fn place_bid(
 7. Bid amount cannot exceed investor's investment limit
 8. Investor cannot have an existing active bid on the same invoice
 9. Expired bids are automatically cleaned up before validation
+10. Global active bid cap per investor is enforced across all invoices:
+   - Only `Placed` bids count
+   - `Withdrawn`, `Accepted`, `Expired`, and `Cancelled` do not count
+   - Default cap is `20` and can be changed by admin
 
 **Events Emitted:**
 - `bid_plc`: Bid placed event with bid details
@@ -56,7 +60,7 @@ pub fn place_bid(
 - `InvalidAmount`: Bid amount is invalid
 - `InvalidExpectedReturn`: Expected return is lower than bid amount
 - `InvoiceAmountInvalid`: Bid amount exceeds invoice amount
-- `OperationNotAllowed`: Investor already has an active bid on this invoice
+- `OperationNotAllowed`: Investor already has an active bid on this invoice, or active bid cap is exceeded
 
 **Example:**
 ```rust
@@ -247,6 +251,13 @@ pub enum BidStatus {
 - `get_bid_ttl_days(env) -> u64`: Read-only entrypoint returning the configured TTL in days (returns 7 if not set).
 
 Security: only the configured protocol admin may call `set_bid_ttl_days`. Calls require the admin to authorize the transaction.
+
+### Active Bid Cap Configuration (Admin)
+
+- `set_max_active_bids_per_investor(env, limit: u32) -> Result<u32, QuickLendXError>`: Admin-only entrypoint to set the maximum number of active `Placed` bids an investor can hold across all invoices. `0` disables the cap.
+- `get_max_active_bids_per_investor(env) -> u32`: Read-only entrypoint returning the configured cap (returns `20` if not set).
+
+Security: only the configured protocol admin may call `set_max_active_bids_per_investor`. Calls require the admin to authorize the transaction.
 
 2. **Withdraw Bid**: Investor withdraws their bid before acceptance
    - Status: `Withdrawn`

--- a/quicklendx-contracts/src/bid.rs
+++ b/quicklendx-contracts/src/bid.rs
@@ -10,6 +10,8 @@ const DEFAULT_BID_TTL_DAYS: u64 = 7;
 const MIN_BID_TTL_DAYS: u64 = 1;
 const MAX_BID_TTL_DAYS: u64 = 30;
 const BID_TTL_KEY: Symbol = symbol_short!("bid_ttl");
+const MAX_ACTIVE_BIDS_PER_INVESTOR_KEY: Symbol = symbol_short!("mx_actbd");
+const DEFAULT_MAX_ACTIVE_BIDS_PER_INVESTOR: u32 = 20;
 const SECONDS_PER_DAY: u64 = 86400;
 
 #[contracttype]
@@ -124,6 +126,55 @@ impl BidStorage {
 
         env.storage().instance().set(&BID_TTL_KEY, &days);
         Ok(days)
+    }
+
+    /// Get configured max number of active (Placed) bids per investor across all invoices.
+    /// A value of 0 disables this limit.
+    pub fn get_max_active_bids_per_investor(env: &Env) -> u32 {
+        env.storage()
+            .instance()
+            .get(&MAX_ACTIVE_BIDS_PER_INVESTOR_KEY)
+            .unwrap_or(DEFAULT_MAX_ACTIVE_BIDS_PER_INVESTOR)
+    }
+
+    /// Admin-only: set max number of active (Placed) bids per investor across all invoices.
+    /// A value of 0 disables this limit.
+    pub fn set_max_active_bids_per_investor(
+        env: &Env,
+        admin: &Address,
+        limit: u32,
+    ) -> Result<u32, QuickLendXError> {
+        admin.require_auth();
+        AdminStorage::require_admin(env, admin)?;
+        env.storage()
+            .instance()
+            .set(&MAX_ACTIVE_BIDS_PER_INVESTOR_KEY, &limit);
+        Ok(limit)
+    }
+
+    /// Count currently active (Placed) bids for an investor across all invoices.
+    /// Expired bids are transitioned to `Expired` during this scan and do not count.
+    pub fn count_active_placed_bids_for_investor(env: &Env, investor: &Address) -> u32 {
+        let current_timestamp = env.ledger().timestamp();
+        let bid_ids = Self::get_bids_by_investor_all(env, investor);
+        let mut count = 0u32;
+
+        for bid_id in bid_ids.iter() {
+            if let Some(mut bid) = Self::get_bid(env, &bid_id) {
+                if bid.status != BidStatus::Placed {
+                    continue;
+                }
+                if bid.is_expired(current_timestamp) {
+                    bid.status = BidStatus::Expired;
+                    Self::update_bid(env, &bid);
+                    emit_bid_expired(env, &bid);
+                } else {
+                    count = count.saturating_add(1);
+                }
+            }
+        }
+
+        count
     }
     pub fn add_bid_to_invoice(env: &Env, invoice_id: &BytesN<32>, bid_id: &BytesN<32>) {
         let mut bids = Self::get_bids_for_invoice(env, invoice_id);

--- a/quicklendx-contracts/src/lib.rs
+++ b/quicklendx-contracts/src/lib.rs
@@ -194,6 +194,22 @@ impl QuickLendXContract {
         bid::BidStorage::get_bid_ttl_days(&env)
     }
 
+    /// Admin-only: configure max active (Placed) bids per investor across all invoices.
+    /// A value of 0 disables the limit. Default is 20.
+    pub fn set_max_active_bids_per_investor(
+        env: Env,
+        limit: u32,
+    ) -> Result<u32, QuickLendXError> {
+        let admin = AdminStorage::get_admin(&env).ok_or(QuickLendXError::NotAdmin)?;
+        bid::BidStorage::set_max_active_bids_per_investor(&env, &admin, limit)
+    }
+
+    /// Get configured max active (Placed) bids per investor across all invoices.
+    /// Returns default 20 if not set.
+    pub fn get_max_active_bids_per_investor(env: Env) -> u32 {
+        bid::BidStorage::get_max_active_bids_per_investor(&env)
+    }
+
     /// Initiate emergency withdraw for stuck funds (admin only). Timelock applies before execute.
     /// See docs/contracts/emergency-recovery.md. Last-resort only.
     pub fn initiate_emergency_withdraw(
@@ -927,6 +943,13 @@ impl QuickLendXContract {
         }
 
         BidStorage::cleanup_expired_bids(&env, &invoice_id);
+        let max_active_bids = BidStorage::get_max_active_bids_per_investor(&env);
+        if max_active_bids > 0 {
+            let active_bids = BidStorage::count_active_placed_bids_for_investor(&env, &investor);
+            if active_bids >= max_active_bids {
+                return Err(QuickLendXError::OperationNotAllowed);
+            }
+        }
         validate_bid(&env, &invoice, bid_amount, expected_return, &investor)?;
         // Create bid
         let bid_id = BidStorage::generate_unique_bid_id(&env);


### PR DESCRIPTION
Closes #486 

## Summary
Implements issue #486 by adding a configurable rate limit for `place_bid` in Soroban contracts.

This change enforces a maximum number of active (`Placed`) bids per investor across all invoices, with a default of `20`, admin configurability, and clear failure behavior when exceeded.

## What Changed

### Smart contract logic
- Added configurable active-bid cap in bid storage:
  - `get_max_active_bids_per_investor() -> u32` (default `20`)
  - `set_max_active_bids_per_investor(limit: u32) -> Result<u32, QuickLendXError>` (admin-only)
- Added active bid counter:
  - `count_active_placed_bids_for_investor(...)`
  - Counts only `Placed` bids across all invoices.
  - During counting, expired bids are transitioned to `Expired` and excluded.

### `place_bid` enforcement
- In `place_bid`, before creating a bid:
  - Reads configured cap.
  - If cap > 0, checks investor active placed count.
  - Returns `QuickLendXError::OperationNotAllowed` when the cap is reached/exceeded.
- Existing same-invoice duplicate active bid protection remains intact.

### Documentation
- Updated `docs/contracts/bidding.md` with:
  - New global active-bid cap validation rule.
  - Clarification of counted vs non-counted statuses:
    - Counted: `Placed`
    - Not counted: `Withdrawn`, `Accepted`, `Expired`, `Cancelled`
  - New admin config entrypoints and default behavior.

## Behavior Notes
- Default limit is `20`.
- `limit = 0` disables the global cap.
- Error on cap exceed: `OperationNotAllowed`.

## Tests Added
In `quicklendx-contracts/src/test_bid.rs`:
- `test_default_max_active_bids_per_investor_is_20`
- `test_active_bid_limit_enforced_and_withdrawn_not_counted`
- `test_active_bid_limit_ignores_accepted_and_expired_bids`

## Security Notes
- Enforcement is on-chain and occurs before bid creation.
- Admin update path is authorization-protected (`require_auth` + admin validation).
- Expiry-aware counting prevents stale expired bids from consuming capacity.
- No external calls introduced in rate-limit logic.

## Validation / CI Notes
- Local full `cargo test` is currently blocked by a pre-existing parse error in `quicklendx-contracts/src/test_currency.rs` (unclosed delimiter), unrelated to this PR’s file changes.
- Current GitHub CI in `.github/workflows/ci.yml` does not run `cargo test` (tests are commented), so this PR follows existing CI behavior.