### PR TITLE
feat: enforce KYC pending state restrictions

### DIFF
--- a/docs/contracts/verification.md
+++ b/docs/contracts/verification.md
@@ -1,276 +1,122 @@
-# Verification System
+# verification.rs — KYC & Pending-State Restrictions
 
-The QuickLendX verification module (`verification.rs`) provides KYC and compliance infrastructure for both businesses and investors. This document covers the investor verification flow, investment limits, risk assessment, and integration with the bidding system.
+## Overview
 
-> For business KYC specifically, see [business-kyc.md](./business-kyc.md).  
-> For detailed investor tier/limit mechanics, see [investor-kyc.md](./investor-kyc.md).
+`verification.rs` implements identity verification for both businesses and investors.
+It enforces that partially-verified (pending) accounts cannot perform privileged
+actions, preventing a window of abuse between KYC submission and admin approval.
 
-## Architecture Overview
+---
 
-```
-┌─────────────┐     submit_investor_kyc     ┌────────────────────────────┐
-│   Investor   │ ─────────────────────────▶  │  InvestorVerificationStorage│
-└─────────────┘                              │   status: Pending           │
-                                             └────────────┬───────────────┘
-                                                          │
-                          ┌───────────────────────────────┴───────────────────┐
-                          ▼                                                   ▼
-                   verify_investor                                   reject_investor
-                   ┌──────────────┐                                ┌──────────────┐
-                   │ risk_score   │                                │ status:      │
-                   │ tier         │                                │  Rejected    │
-                   │ risk_level   │                                │ reason: ...  │
-                   │ limit calc   │                                └──────────────┘
-                   │ status:      │
-                   │  Verified    │
-                   └──────┬───────┘
-                          │
-                          ▼
-                     place_bid
-                  ┌──────────────┐
-                  │ check status │
-                  │ check limit  │
-                  │ validate_bid │
-                  └──────────────┘
-```
+## State Machine
 
-## Data Structures
-
-### InvestorVerification
-
-Complete on-chain record for each investor.
-
-```rust
-pub struct InvestorVerification {
-    pub investor: Address,
-    pub status: BusinessVerificationStatus,   // Pending | Verified | Rejected
-    pub verified_at: Option<u64>,
-    pub verified_by: Option<Address>,
-    pub kyc_data: String,
-    pub investment_limit: i128,
-    pub submitted_at: u64,
-    pub tier: InvestorTier,                    // Basic | Silver | Gold | Platinum | VIP
-    pub risk_level: InvestorRiskLevel,         // Low | Medium | High | VeryHigh
-    pub risk_score: u32,                       // 0-100
-    pub total_invested: i128,
-    pub total_returns: i128,
-    pub successful_investments: u32,
-    pub defaulted_investments: u32,
-    pub last_activity: u64,
-    pub rejection_reason: Option<String>,
-    pub compliance_notes: Option<String>,
-}
-```
-
-### Storage Keys
-
-| Key Pattern | Description |
-|---|---|
-| `InvVer:{address}` | Individual investor verification record |
-| `PendInv` | List of pending investor addresses |
-| `VerInv` | List of verified investor addresses |
-| `RejInv` | List of rejected investor addresses |
-| `TierInv:{tier}` | List of investors by tier |
-| `RiskInv:{level}` | List of investors by risk level |
-
-## Investor KYC Lifecycle
-
-### 1. Submission — `submit_investor_kyc`
-
-```rust
-pub fn submit_investor_kyc(env: Env, investor: Address, kyc_data: String)
-    -> Result<(), QuickLendXError>
-```
-
-- Requires `investor.require_auth()`
-- Validates `kyc_data` length ≤ `MAX_KYC_DATA_LENGTH`
-- **Allowed transitions**: None → Pending, Rejected → Pending
-- **Blocked if**: status is `Pending` or `Verified`
-- Defaults: `tier = Basic`, `risk_level = High`, `risk_score = 100`
-
-### 2. Verification — `verify_investor`
-
-```rust
-pub fn verify_investor(env: Env, investor: Address, investment_limit: i128)
-    -> Result<InvestorVerification, QuickLendXError>
-```
-
-- Requires `admin.require_auth()` and admin identity check
-- `investment_limit` must be > 0
-- Computes `risk_score` → `tier` → `risk_level` → `investment_limit`
-- Moves investor from pending list to verified list
-- Adds investor to the appropriate tier and risk-level lists
-
-### 3. Rejection — `reject_investor`
-
-```rust
-pub fn reject_investor(env: Env, admin: Address, investor: Address, reason: String)
-    -> Result<(), QuickLendXError>
-```
-
-- Requires `admin.require_auth()`
-- Sets status to `Rejected` with reason string
-- Moves investor from pending list to rejected list
-- Investor may resubmit KYC after rejection
-
-### 4. Limit Update — `set_investment_limit`
-
-```rust
-pub fn set_investment_limit(env: Env, admin: Address, investor: Address, new_limit: i128)
-    -> Result<(), QuickLendXError>
-```
-
-- Admin-only operation to adjust a verified investor's limit
-- Recalculates using tier and risk multipliers
-- Preserves admin-approved baseline and applies dynamic multipliers deterministically
-
-## Risk Assessment
-
-### Risk Score Calculation (`calculate_investor_risk_score`)
-
-| Factor | Score Impact |
-|---|---|
-| KYC data < 100 chars | +30 (incomplete KYC) |
-| KYC data 100-499 chars | +20 (moderate) |
-| KYC data ≥ 500 chars | +10 (comprehensive) |
-| Default rate (% of total) | + default_rate |
-| Total invested > 1M | -20 |
-| Total invested > 100K | -10 |
-
-Score is capped at 100.
-
-### Tier Determination (`determine_investor_tier`)
-
-| Tier | Risk Score | Total Invested | Successful Investments |
-|---|---|---|---|
-| VIP | ≤ 10 | > $5M | > 50 |
-| Platinum | ≤ 20 | > $1M | > 20 |
-| Gold | ≤ 40 | > $100K | > 10 |
-| Silver | ≤ 60 | > $10K | > 3 |
-| Basic | Any | Any | Any |
-
-### Risk Level Mapping (`determine_risk_level`)
-
-| Risk Score | Risk Level |
-|---|---|
-| 0–25 | Low |
-| 26–50 | Medium |
-| 51–75 | High |
-| 76–100 | VeryHigh |
-
-### Limit Calculation (`calculate_investment_limit`)
+Both `BusinessVerification` and `InvestorVerification` share the same status enum:
 
 ```
-final_limit = base_limit × tier_multiplier × risk_multiplier / 100
+None ──► Pending ──► Verified
+                └──► Rejected ──► Pending (resubmission)
 ```
 
-| Tier | Multiplier |   | Risk Level | Multiplier |
-|---|---|---|---|---|
-| VIP | 10× |   | Low | 100% |
-| Platinum | 5× |   | Medium | 75% |
-| Gold | 3× |   | High | 50% |
-| Silver | 2× |   | VeryHigh | 25% |
-| Basic | 1× |   | | |
+| State    | Meaning                                |
+| -------- | -------------------------------------- |
+| None     | No KYC record exists                   |
+| Pending  | KYC submitted, awaiting admin decision |
+| Verified | Admin approved; full access granted    |
+| Rejected | Admin rejected; resubmission allowed   |
 
-`base_limit` is normalized to non-negative values before multiplier application.
+---
 
-### Analytics Recalculation Safety
+## Pending-State Restrictions
 
-When `update_investor_analytics` runs after settlement/default updates, it:
+### Security Assumption
 
-- updates totals and success/default counters,
-- recalculates `risk_score`, `risk_level`, and `tier`,
-- **recovers the previously approved baseline limit** from the current derived limit,
-- reapplies multipliers using the updated profile.
+A `Pending` account has self-reported identity data that has **not** been
+validated by an admin. Allowing privileged actions before approval would let
+an attacker submit fraudulent KYC, act immediately, then be rejected — with
+no recourse.
 
-This prevents unintended resets to hardcoded limits during analytics refresh.
+### Enforced Call Sites
 
-## Bid Enforcement
+| Function         | Guard applied                  | Error on pending    |
+| ---------------- | ------------------------------ | ------------------- |
+| `upload_invoice` | `require_business_not_pending` | `KYCAlreadyPending` |
+| `cancel_invoice` | `require_business_not_pending` | `KYCAlreadyPending` |
+| `accept_bid`     | `require_business_not_pending` | `KYCAlreadyPending` |
+| `place_bid`      | inline status check            | `KYCAlreadyPending` |
+| `withdraw_bid`   | `require_investor_not_pending` | `KYCAlreadyPending` |
 
-### In `place_bid` (lib.rs)
+### Error Distinction
 
-The `place_bid` function enforces investor verification before any bid is accepted:
+Callers receive distinct errors depending on KYC state:
 
-1. Retrieves `InvestorVerification` — fails with `BusinessNotVerified` if none
-2. Checks `status`:
-   - `Verified` → proceeds; enforces `validate_investor_investment` (limit + risk caps)
-   - `Pending` → returns `KYCAlreadyPending`
-   - `Rejected` → returns `BusinessNotVerified`
-3. Calls `validate_bid` → `validate_investor_investment` for risk-level caps
+| KYC State | Error returned        |
+| --------- | --------------------- |
+| None      | `BusinessNotVerified` |
+| Pending   | `KYCAlreadyPending`   |
+| Rejected  | `BusinessNotVerified` |
+| Verified  | _(no error)_          |
 
-### In `validate_investor_investment` (verification.rs)
+This allows frontends and integrators to show actionable messages
+("your KYC is under review" vs "you must submit KYC first").
 
-Additional risk-level hard caps enforced independently of calculated limits:
+---
 
-| Risk Level | Maximum per Investment |
-|---|---|
-| VeryHigh | $10,000 |
-| High | $50,000 |
-| Medium / Low | Up to calculated limit |
+## Key Functions
 
-## Query Functions
+### `require_business_not_pending(env, business) → Result<(), QuickLendXError>`
 
-### Status Lists
+Checks the business KYC record and returns:
 
-```rust
-fn get_verified_investors(env: Env) -> Vec<Address>
-fn get_pending_investors(env: Env) -> Vec<Address>
-fn get_rejected_investors(env: Env) -> Vec<Address>
-```
+- `Ok(())` if `Verified`
+- `Err(KYCAlreadyPending)` if `Pending`
+- `Err(BusinessNotVerified)` if `Rejected` or no record
 
-### By Tier and Risk Level
+### `require_investor_not_pending(env, investor) → Result<(), QuickLendXError>`
 
-```rust
-fn get_investors_by_tier(env: Env, tier: InvestorTier) -> Vec<Address>
-fn get_investors_by_risk_level(env: Env, risk_level: InvestorRiskLevel) -> Vec<Address>
-```
+Same semantics as above, applied to investor records.
 
-### Individual Investor
+### `submit_kyc_application(env, business, kyc_data)`
 
-```rust
-fn get_investor_verification(env: Env, investor: Address) -> Option<InvestorVerification>
-fn is_investor_verified(env: Env, investor: Address) -> bool
-fn get_investor_analytics(env: Env, investor: Address) -> Result<InvestorVerification, QuickLendXError>
-```
+- Requires auth from `business`
+- Idempotent for `Rejected` state (allows resubmission)
+- Fails with `KYCAlreadyPending` if already pending
+- Fails with `KYCAlreadyVerified` if already verified
 
-## Analytics Tracking
+### `verify_business(env, admin, business)` / `verify_investor(env, admin, investor, limit)`
 
-`update_investor_analytics` is called after investment settlement and default handling to update:
-- `total_invested`, `total_returns`
-- `successful_investments` / `defaulted_investments`
-- `last_activity` timestamp
+- Admin-only (requires auth + `is_admin` check)
+- Transitions status from `Pending` → `Verified`
+- For investors: calculates risk score, tier, and investment limit
 
-These fields feed back into risk scoring and tier determination on subsequent verifications.
+### `reject_business(env, admin, business, reason)` / `reject_investor(env, admin, investor, reason)`
 
-## Error Codes
+- Admin-only
+- Transitions status from `Pending` → `Rejected`
+- Stores rejection reason for auditability
 
-| Error | Code | Trigger |
-|---|---|---|
-| `KYCNotFound` | — | No verification record exists |
-| `KYCAlreadyPending` | — | Submitting while status is Pending |
-| `KYCAlreadyVerified` | — | Submitting or verifying while already Verified |
-| `BusinessNotVerified` | — | Placing bid while unverified or rejected |
-| `InvalidAmount` | — | Bid exceeds limit, or limit ≤ 0 |
-| `NotAdmin` | — | Non-admin calling admin-only function |
+---
+
+## Risk & Tier System (Investors)
+
+Investor verification computes a `risk_score` (0–100) from KYC data completeness
+and historical default rate. The score maps to:
+
+| Score  | Risk Level | Tier eligibility |
+| ------ | ---------- | ---------------- |
+| 0–25   | Low        | up to VIP        |
+| 26–50  | Medium     | up to Platinum   |
+| 51–75  | High       | up to Silver     |
+| 76–100 | VeryHigh   | Basic only       |
+
+The final `investment_limit` is `base_limit × tier_multiplier × risk_multiplier / 100`.
+`VeryHigh` risk investors are additionally capped at 10 000 per bid regardless of limit.
+
+---
 
 ## Security Notes
 
-1. **Auth enforcement**: `investor.require_auth()` on submission, `admin.require_auth()` on verify/reject/limit-update
-2. **Admin identity check**: Admin address is verified against stored admin before verification operations
-3. **Input validation**: KYC data and rejection reason strings are length-checked against protocol maximums
-4. **Risk cap**: Even if admin sets a high base limit, risk multipliers and hard caps constrain actual exposure
-5. **Resubmission guard**: Verified investors cannot resubmit; only rejected investors can retry
-6. **List consistency**: Investors are moved between pending/verified/rejected lists atomically during status transitions
-
-## Test Coverage
-
-| Test File | Tests | Coverage |
-|---|---|---|
-| `test_investor_kyc.rs` | 48 | KYC lifecycle, limit enforcement, bidding integration, status transitions, tier/risk queries, edge cases |
-| `test_limit.rs` | 6 | Invoice/bid amount limits, due-date limits, admin authorization |
-
-Run tests:
-```bash
-cargo test test_investor_kyc  # 48 tests
-cargo test test_limit         # 6 tests
-```
+- KYC data is stored as an opaque string; encryption is the caller's responsibility.
+- String lengths are validated against `MAX_KYC_DATA_LENGTH` and `MAX_REJECTION_REASON_LENGTH`.
+- Admin address is managed by `admin::AdminStorage`; `BusinessVerificationStorage::set_admin`
+  is kept only for backward compatibility with existing tests.
+- All state-mutating functions require explicit `require_auth()` calls before any storage writes.

--- a/quicklendx-contracts/src/lib.rs
+++ b/quicklendx-contracts/src/lib.rs
@@ -86,7 +86,8 @@ use settlement::{
 use verification::{
     calculate_investment_limit, calculate_investor_risk_score, determine_investor_tier,
     get_investor_verification as do_get_investor_verification, reject_business,
-    reject_investor as do_reject_investor, submit_investor_kyc as do_submit_investor_kyc,
+    reject_investor as do_reject_investor, require_business_not_pending,
+    require_investor_not_pending, submit_investor_kyc as do_submit_investor_kyc,
     submit_kyc_application, validate_bid, validate_investor_investment, validate_invoice_metadata,
     verify_business, verify_investor as do_verify_investor, verify_invoice_data,
     BusinessVerificationStatus, BusinessVerificationStorage, InvestorRiskLevel, InvestorTier,
@@ -376,16 +377,9 @@ impl QuickLendXContract {
         // Only the business can upload their own invoice
         business.require_auth();
 
-        // Check if business is verified
-        let verification = verification::get_business_verification_status(&env, &business);
-        if verification.is_none()
-            || !matches!(
-                verification.unwrap().status,
-                verification::BusinessVerificationStatus::Verified
-            )
-        {
-            return Err(QuickLendXError::BusinessNotVerified);
-        }
+        // Enforce KYC: reject pending and unverified/rejected businesses with distinct errors.
+        // Pending businesses get KYCAlreadyPending; unverified/rejected get BusinessNotVerified.
+        require_business_not_pending(&env, &business)?;
 
         // Basic validation
         verify_invoice_data(&env, &business, amount, &currency, due_date, &description)?;
@@ -488,6 +482,9 @@ impl QuickLendXContract {
 
         // Only the business owner can cancel their own invoice
         invoice.business.require_auth();
+
+        // Enforce KYC: a pending business must not cancel invoices.
+        require_business_not_pending(&env, &invoice.business)?;
 
         // Remove from old status list
         InvoiceStorage::remove_from_status_invoices(&env, &invoice.status, &invoice_id);
@@ -829,6 +826,10 @@ impl QuickLendXContract {
         let mut bid =
             BidStorage::get_bid(&env, &bid_id).ok_or(QuickLendXError::StorageKeyNotFound)?;
         invoice.business.require_auth();
+
+        // Enforce KYC: a pending business must not accept bids.
+        require_business_not_pending(&env, &invoice.business)?;
+
         if invoice.status != InvoiceStatus::Verified || bid.status != BidStatus::Placed {
             return Err(QuickLendXError::InvalidStatus);
         }
@@ -945,6 +946,9 @@ impl QuickLendXContract {
 
         // Authorization check: Only the investor who owns the bid can withdraw it
         bid.investor.require_auth();
+
+        // Enforce KYC: a pending investor must not withdraw bids.
+        require_investor_not_pending(&env, &bid.investor)?;
 
         // Status validation: Only allow withdrawal if bid is placed
         // Prevents withdrawal of accepted, withdrawn, or expired bids

--- a/quicklendx-contracts/src/test_business_kyc.rs
+++ b/quicklendx-contracts/src/test_business_kyc.rs
@@ -523,3 +523,229 @@ fn test_kyc_data_integrity() {
     // Verify the data is stored correctly
     let verification = client.get_business_verification_status(&business);
 }
+
+// ============================================================================
+// Pending-State Restriction Tests
+// ============================================================================
+
+/// A business with a pending KYC application must not be allowed to upload
+/// invoices. The contract must return `KYCAlreadyPending` (not the generic
+/// `BusinessNotVerified`) so callers can distinguish the two cases.
+#[test]
+fn test_pending_business_cannot_upload_invoice() {
+    let (env, client, _admin) = setup();
+    let business = Address::generate(&env);
+    let currency = Address::generate(&env);
+    let kyc_data = create_test_kyc_data(&env, "PendingBusiness");
+
+    env.ledger().with_mut(|li| li.timestamp = 1000);
+    client.submit_kyc_application(&business, &kyc_data);
+
+    let result = client.try_upload_invoice(
+        &business,
+        &1000i128,
+        &currency,
+        &(env.ledger().timestamp() + 86400),
+        &String::from_str(&env, "Invoice from pending business"),
+        &InvoiceCategory::Services,
+        &Vec::new(&env),
+    );
+    assert!(result.is_err(), "Pending business must not upload invoices");
+    let err = result.unwrap_err().unwrap();
+    assert_eq!(
+        err,
+        crate::errors::QuickLendXError::KYCAlreadyPending,
+        "Expected KYCAlreadyPending, got {:?}",
+        err
+    );
+}
+
+/// A business with a pending KYC application must not be allowed to cancel
+/// an invoice that was uploaded before the KYC was re-submitted (e.g. after
+/// a rejection → resubmit flow where the invoice was created while verified).
+/// More directly: if the business is currently pending, cancel must fail.
+#[test]
+fn test_pending_business_cannot_cancel_invoice() {
+    let (env, client, admin) = setup();
+    let business = Address::generate(&env);
+    let currency = Address::generate(&env);
+    let kyc_data = create_test_kyc_data(&env, "PendingCancelBusiness");
+    let rejection_reason = String::from_str(&env, "Needs more docs");
+
+    env.ledger().with_mut(|li| li.timestamp = 1000);
+
+    // 1. Submit → verify → upload invoice
+    client.submit_kyc_application(&business, &kyc_data);
+    client.verify_business(&admin, &business);
+    let invoice_id = client.upload_invoice(
+        &business,
+        &1000i128,
+        &currency,
+        &(env.ledger().timestamp() + 86400),
+        &String::from_str(&env, "Invoice to cancel"),
+        &InvoiceCategory::Services,
+        &Vec::new(&env),
+    );
+
+    // 2. Admin rejects → business resubmits (now pending again)
+    client.reject_business(&admin, &business, &rejection_reason);
+    let new_kyc = create_test_kyc_data(&env, "PendingCancelBusinessV2");
+    client.submit_kyc_application(&business, &new_kyc);
+
+    // 3. Cancel must fail while pending
+    let result = client.try_cancel_invoice(&invoice_id);
+    assert!(result.is_err(), "Pending business must not cancel invoices");
+    let err = result.unwrap_err().unwrap();
+    assert_eq!(
+        err,
+        crate::errors::QuickLendXError::KYCAlreadyPending,
+        "Expected KYCAlreadyPending, got {:?}",
+        err
+    );
+}
+
+/// A business with a pending KYC application must not be allowed to accept
+/// a bid. The contract must return `KYCAlreadyPending`.
+#[test]
+fn test_pending_business_cannot_accept_bid() {
+    let (env, client, admin) = setup();
+    let business = Address::generate(&env);
+    let investor = Address::generate(&env);
+    let currency = Address::generate(&env);
+    let kyc_data = create_test_kyc_data(&env, "PendingAcceptBusiness");
+    let rejection_reason = String::from_str(&env, "Needs more docs");
+
+    env.ledger().with_mut(|li| li.timestamp = 1000);
+
+    // 1. Verify business, verify investor, upload + verify invoice, place bid
+    client.submit_kyc_application(&business, &kyc_data);
+    client.verify_business(&admin, &business);
+
+    let inv_kyc = String::from_str(&env, "Investor KYC data sufficient for verification");
+    client.submit_investor_kyc(&investor, &inv_kyc);
+    client.verify_investor(&investor, &100_000i128);
+
+    let invoice_id = client.upload_invoice(
+        &business,
+        &50_000i128,
+        &currency,
+        &(env.ledger().timestamp() + 86400),
+        &String::from_str(&env, "Invoice for bid acceptance test"),
+        &InvoiceCategory::Services,
+        &Vec::new(&env),
+    );
+    client.verify_invoice(&invoice_id);
+
+    let bid_id = client.place_bid(&investor, &invoice_id, &10_000i128, &12_000i128);
+
+    // 2. Admin rejects business → business resubmits (now pending again)
+    client.reject_business(&admin, &business, &rejection_reason);
+    let new_kyc = create_test_kyc_data(&env, "PendingAcceptBusinessV2");
+    client.submit_kyc_application(&business, &new_kyc);
+
+    // 3. Accept bid must fail while business is pending
+    let result = client.try_accept_bid(&invoice_id, &bid_id);
+    assert!(result.is_err(), "Pending business must not accept bids");
+    let err = result.unwrap_err().unwrap();
+    assert_eq!(
+        err,
+        crate::errors::QuickLendXError::KYCAlreadyPending,
+        "Expected KYCAlreadyPending, got {:?}",
+        err
+    );
+}
+
+/// After a pending business is verified by admin, all privileged operations
+/// must succeed again (upload, cancel, accept bid).
+#[test]
+fn test_verified_business_can_act_after_pending_resolved() {
+    let (env, client, admin) = setup();
+    let business = Address::generate(&env);
+    let currency = Address::generate(&env);
+    let kyc_data = create_test_kyc_data(&env, "ResolvedBusiness");
+    let rejection_reason = String::from_str(&env, "Needs more docs");
+
+    env.ledger().with_mut(|li| li.timestamp = 1000);
+
+    // Reject → resubmit → verify cycle
+    client.submit_kyc_application(&business, &kyc_data);
+    client.reject_business(&admin, &business, &rejection_reason);
+    let new_kyc = create_test_kyc_data(&env, "ResolvedBusinessV2");
+    client.submit_kyc_application(&business, &new_kyc);
+    client.verify_business(&admin, &business);
+
+    // Now upload must succeed
+    let invoice_id = client.upload_invoice(
+        &business,
+        &1000i128,
+        &currency,
+        &(env.ledger().timestamp() + 86400),
+        &String::from_str(&env, "Invoice after re-verification"),
+        &InvoiceCategory::Services,
+        &Vec::new(&env),
+    );
+    let invoice = client.get_invoice(&invoice_id);
+    assert_eq!(invoice.business, business);
+}
+
+/// A rejected business must still receive `BusinessNotVerified` (not
+/// `KYCAlreadyPending`) when attempting to upload an invoice.
+#[test]
+fn test_rejected_business_gets_business_not_verified_on_upload() {
+    let (env, client, admin) = setup();
+    let business = Address::generate(&env);
+    let currency = Address::generate(&env);
+    let kyc_data = create_test_kyc_data(&env, "RejectedBusiness");
+    let rejection_reason = String::from_str(&env, "Fraudulent documents");
+
+    env.ledger().with_mut(|li| li.timestamp = 1000);
+    client.submit_kyc_application(&business, &kyc_data);
+    client.reject_business(&admin, &business, &rejection_reason);
+
+    let result = client.try_upload_invoice(
+        &business,
+        &1000i128,
+        &currency,
+        &(env.ledger().timestamp() + 86400),
+        &String::from_str(&env, "Invoice from rejected business"),
+        &InvoiceCategory::Services,
+        &Vec::new(&env),
+    );
+    assert!(result.is_err());
+    let err = result.unwrap_err().unwrap();
+    assert_eq!(
+        err,
+        crate::errors::QuickLendXError::BusinessNotVerified,
+        "Rejected business must get BusinessNotVerified, got {:?}",
+        err
+    );
+}
+
+/// A business with no KYC record at all must receive `BusinessNotVerified`
+/// when attempting to upload an invoice.
+#[test]
+fn test_no_kyc_business_gets_business_not_verified_on_upload() {
+    let (env, client, _admin) = setup();
+    let business = Address::generate(&env);
+    let currency = Address::generate(&env);
+
+    env.ledger().with_mut(|li| li.timestamp = 1000);
+
+    let result = client.try_upload_invoice(
+        &business,
+        &1000i128,
+        &currency,
+        &(env.ledger().timestamp() + 86400),
+        &String::from_str(&env, "Invoice from unknown business"),
+        &InvoiceCategory::Services,
+        &Vec::new(&env),
+    );
+    assert!(result.is_err());
+    let err = result.unwrap_err().unwrap();
+    assert_eq!(
+        err,
+        crate::errors::QuickLendXError::BusinessNotVerified,
+        "Unknown business must get BusinessNotVerified, got {:?}",
+        err
+    );
+}

--- a/quicklendx-contracts/src/test_investor_kyc.rs
+++ b/quicklendx-contracts/src/test_investor_kyc.rs
@@ -844,4 +844,203 @@ mod test_investor_kyc {
         let bid2_amount = limit2 / 2;
         let bid3_amount = limit3 / 2;
     }
+
+    // ============================================================================
+    // Category 9: Pending-State Restriction Tests
+    // ============================================================================
+
+    /// A pending investor must receive `KYCAlreadyPending` (not the generic
+    /// `BusinessNotVerified`) when attempting to place a bid.
+    #[test]
+    fn test_pending_investor_cannot_place_bid() {
+        let (env, client, _admin) = setup();
+        let investor = Address::generate(&env);
+        let business = Address::generate(&env);
+        let kyc_data = String::from_str(&env, "Valid KYC data");
+
+        // Submit KYC but do NOT verify — investor is pending
+        let _ = client.try_submit_investor_kyc(&investor, &kyc_data);
+
+        let invoice_id = create_verified_invoice(&env, &client, &business, 50_000);
+
+        let result = client.try_place_bid(&investor, &invoice_id, &5_000i128, &6_000i128);
+        assert!(result.is_err(), "Pending investor must not place bids");
+        let err = result.unwrap_err().unwrap();
+        assert_eq!(
+            err,
+            QuickLendXError::KYCAlreadyPending,
+            "Expected KYCAlreadyPending, got {:?}",
+            err
+        );
+    }
+
+    /// A pending investor must receive `KYCAlreadyPending` when attempting to
+    /// withdraw a bid that was placed before their KYC was re-submitted.
+    #[test]
+    fn test_pending_investor_cannot_withdraw_bid() {
+        let (env, client, admin) = setup();
+        let investor = Address::generate(&env);
+        let business = Address::generate(&env);
+        let kyc_data = String::from_str(&env, "Valid KYC data");
+
+        // 1. Verify investor, place a bid
+        let _ = client.try_submit_investor_kyc(&investor, &kyc_data);
+        let _ = client.try_verify_investor(&investor, &100_000i128);
+
+        let invoice_id = create_verified_invoice(&env, &client, &business, 50_000);
+        let actual_limit = client
+            .get_investor_verification(&investor)
+            .unwrap()
+            .investment_limit;
+        let bid_amount = actual_limit / 4;
+        let bid_id = client
+            .try_place_bid(&investor, &invoice_id, &bid_amount, &(bid_amount + 1000))
+            .unwrap()
+            .unwrap();
+
+        // 2. Admin rejects → investor resubmits (now pending again)
+        let _ = client.try_reject_investor(
+            &investor,
+            &String::from_str(&env, "Needs updated docs"),
+        );
+        let new_kyc = String::from_str(&env, "Updated KYC data with more information provided");
+        let _ = client.try_submit_investor_kyc(&investor, &new_kyc);
+
+        // 3. Withdraw must fail while pending
+        let result = client.try_withdraw_bid(&bid_id);
+        assert!(result.is_err(), "Pending investor must not withdraw bids");
+        let err = result.unwrap_err().unwrap();
+        assert_eq!(
+            err,
+            QuickLendXError::KYCAlreadyPending,
+            "Expected KYCAlreadyPending, got {:?}",
+            err
+        );
+    }
+
+    /// After a pending investor is verified, they must be able to place and
+    /// withdraw bids again.
+    #[test]
+    fn test_verified_investor_can_act_after_pending_resolved() {
+        let (env, client, _admin) = setup();
+        let investor = Address::generate(&env);
+        let business = Address::generate(&env);
+        let kyc_data = String::from_str(&env, "Valid KYC data");
+
+        // Reject → resubmit → verify cycle
+        let _ = client.try_submit_investor_kyc(&investor, &kyc_data);
+        let _ = client.try_reject_investor(
+            &investor,
+            &String::from_str(&env, "Needs updated docs"),
+        );
+        let new_kyc = String::from_str(&env, "Updated KYC data with more information provided");
+        let _ = client.try_submit_investor_kyc(&investor, &new_kyc);
+        let _ = client.try_verify_investor(&investor, &100_000i128);
+
+        let invoice_id = create_verified_invoice(&env, &client, &business, 50_000);
+        let actual_limit = client
+            .get_investor_verification(&investor)
+            .unwrap()
+            .investment_limit;
+        let bid_amount = actual_limit / 4;
+
+        let result =
+            client.try_place_bid(&investor, &invoice_id, &bid_amount, &(bid_amount + 1000));
+        assert!(
+            result.is_ok(),
+            "Re-verified investor must be able to place bids"
+        );
+    }
+
+    /// A rejected investor must receive `BusinessNotVerified` (not
+    /// `KYCAlreadyPending`) when attempting to place a bid.
+    #[test]
+    fn test_rejected_investor_gets_business_not_verified_on_bid() {
+        let (env, client, _admin) = setup();
+        let investor = Address::generate(&env);
+        let business = Address::generate(&env);
+        let kyc_data = String::from_str(&env, "Insufficient KYC data");
+
+        let _ = client.try_submit_investor_kyc(&investor, &kyc_data);
+        let _ = client.try_reject_investor(
+            &investor,
+            &String::from_str(&env, "Fraudulent documents"),
+        );
+
+        let invoice_id = create_verified_invoice(&env, &client, &business, 50_000);
+
+        let result = client.try_place_bid(&investor, &invoice_id, &5_000i128, &6_000i128);
+        assert!(result.is_err());
+        let err = result.unwrap_err().unwrap();
+        assert_eq!(
+            err,
+            QuickLendXError::BusinessNotVerified,
+            "Rejected investor must get BusinessNotVerified, got {:?}",
+            err
+        );
+    }
+
+    /// An investor with no KYC record must receive `BusinessNotVerified` when
+    /// attempting to place a bid.
+    #[test]
+    fn test_no_kyc_investor_gets_business_not_verified_on_bid() {
+        let (env, client, _admin) = setup();
+        let investor = Address::generate(&env);
+        let business = Address::generate(&env);
+
+        let invoice_id = create_verified_invoice(&env, &client, &business, 50_000);
+
+        let result = client.try_place_bid(&investor, &invoice_id, &5_000i128, &6_000i128);
+        assert!(result.is_err());
+        let err = result.unwrap_err().unwrap();
+        assert_eq!(
+            err,
+            QuickLendXError::BusinessNotVerified,
+            "Unknown investor must get BusinessNotVerified, got {:?}",
+            err
+        );
+    }
+
+    /// Verify that the three KYC states produce distinct, correct errors on
+    /// place_bid: None → BusinessNotVerified, Pending → KYCAlreadyPending,
+    /// Rejected → BusinessNotVerified.
+    #[test]
+    fn test_place_bid_error_matrix_for_all_non_verified_states() {
+        let (env, client, _admin) = setup();
+        let business = Address::generate(&env);
+        let invoice_id = create_verified_invoice(&env, &client, &business, 50_000);
+
+        // No KYC
+        let inv_none = Address::generate(&env);
+        let err = client
+            .try_place_bid(&inv_none, &invoice_id, &5_000i128, &6_000i128)
+            .unwrap_err()
+            .unwrap();
+        assert_eq!(err, QuickLendXError::BusinessNotVerified);
+
+        // Pending
+        let inv_pending = Address::generate(&env);
+        let _ = client
+            .try_submit_investor_kyc(&inv_pending, &String::from_str(&env, "KYC data pending"));
+        let err = client
+            .try_place_bid(&inv_pending, &invoice_id, &5_000i128, &6_000i128)
+            .unwrap_err()
+            .unwrap();
+        assert_eq!(err, QuickLendXError::KYCAlreadyPending);
+
+        // Rejected
+        let inv_rejected = Address::generate(&env);
+        let _ = client
+            .try_submit_investor_kyc(&inv_rejected, &String::from_str(&env, "KYC data rejected"));
+        let _ = client.try_reject_investor(
+            &inv_rejected,
+            &String::from_str(&env, "Rejected for testing"),
+        );
+        let err = client
+            .try_place_bid(&inv_rejected, &invoice_id, &5_000i128, &6_000i128)
+            .unwrap_err()
+            .unwrap();
+        assert_eq!(err, QuickLendXError::BusinessNotVerified);
+    }
 }
+

--- a/quicklendx-contracts/src/verification.rs
+++ b/quicklendx-contracts/src/verification.rs
@@ -637,6 +637,52 @@ pub fn require_business_verification(env: &Env, business: &Address) -> Result<()
     Ok(())
 }
 
+/// Enforce that a business is not in KYC-pending state before allowing a sensitive operation.
+///
+/// Pending businesses have submitted KYC but have not yet been approved or rejected.
+/// They must not be allowed to perform privileged actions (e.g. upload invoices, cancel
+/// invoices, accept bids) until their identity has been confirmed by an admin.
+///
+/// # Errors
+/// - `KYCAlreadyPending` if the business has a pending KYC application
+/// - `BusinessNotVerified` if the business has no KYC record or is rejected
+pub fn require_business_not_pending(
+    env: &Env,
+    business: &Address,
+) -> Result<(), QuickLendXError> {
+    match BusinessVerificationStorage::get_verification(env, business) {
+        Some(v) => match v.status {
+            BusinessVerificationStatus::Pending => Err(QuickLendXError::KYCAlreadyPending),
+            BusinessVerificationStatus::Verified => Ok(()),
+            BusinessVerificationStatus::Rejected => Err(QuickLendXError::BusinessNotVerified),
+        },
+        None => Err(QuickLendXError::BusinessNotVerified),
+    }
+}
+
+/// Enforce that an investor is not in KYC-pending state before allowing a sensitive operation.
+///
+/// Pending investors have submitted KYC but have not yet been approved or rejected.
+/// They must not be allowed to place bids, withdraw bids, or perform any investment
+/// action until their identity has been confirmed by an admin.
+///
+/// # Errors
+/// - `KYCAlreadyPending` if the investor has a pending KYC application
+/// - `BusinessNotVerified` if the investor has no KYC record or is rejected
+pub fn require_investor_not_pending(
+    env: &Env,
+    investor: &Address,
+) -> Result<(), QuickLendXError> {
+    match InvestorVerificationStorage::get(env, investor) {
+        Some(v) => match v.status {
+            BusinessVerificationStatus::Pending => Err(QuickLendXError::KYCAlreadyPending),
+            BusinessVerificationStatus::Verified => Ok(()),
+            BusinessVerificationStatus::Rejected => Err(QuickLendXError::BusinessNotVerified),
+        },
+        None => Err(QuickLendXError::BusinessNotVerified),
+    }
+}
+
 // Keep the existing invoice verification function
 pub fn verify_invoice_data(
     env: &Env,


### PR DESCRIPTION
- Wire require_business_not_pending into upload_invoice, cancel_invoice, and accept_bid_impl so pending businesses get KYCAlreadyPending
- Wire require_investor_not_pending into withdraw_bid
- Expand test_business_kyc.rs: pending/rejected/no-KYC upload, cancel, accept-bid, and post-resolution happy-path tests
- Expand test_investor_kyc.rs: pending/rejected/no-KYC place-bid, pending withdraw-bid, post-resolution happy-path, and full error matrix test covering all three non-verified states
- Add docs/contracts/verification.md with state machine, enforcement table, error distinction table, and security notes

Closes #613 