### PR TITLE
feat: harden fee system initialization and treasury configuration

### DIFF
--- a/docs/contracts/fees.md
+++ b/docs/contracts/fees.md
@@ -483,3 +483,78 @@ The fee system is designed for seamless upgrades:
 ## Conclusion
 
 The QuickLendX platform fee system provides a robust, secure, and transparent mechanism for collecting platform fees while maintaining flexibility for future enhancements. The integration with treasury routing ensures efficient fee management and supports the platform's economic model.
+
+---
+
+## Hardening: Initialization & Treasury Security
+
+This section documents the security hardening applied to the fee system initialization and treasury configuration flow.
+
+### Initialization Guard
+
+`FeeManager::initialize` is protected by a single-write guard using the `fee_init` storage key.
+
+```
+Storage key: "fee_init" (Symbol)
+Type:        bool (true)
+Scope:       instance storage
+```
+
+**Behavior:**
+- On first call: sets up fee structures and writes `fee_init = true`.
+- On any subsequent call: returns `InvalidFeeConfiguration` immediately, before any state mutation.
+
+This prevents an attacker (or misconfigured deployment script) from overwriting fee structures after the contract is live.
+
+### Explicit Admin Authorization
+
+All admin-gated fee functions call `admin.require_auth()` at the top of both the public API layer (`lib.rs`) and the module layer (`fees.rs`). This defense-in-depth ensures auth is enforced even if one layer is bypassed or refactored.
+
+| Function | `lib.rs` auth | `fees.rs` auth |
+|---|---|---|
+| `initialize_fee_system` | `admin.require_auth()` | `admin.require_auth()` |
+| `configure_treasury` | — (caller provides admin) | `admin.require_auth()` |
+| `update_platform_fee` / `update_platform_fee_bps` | `admin.require_auth()` | `admin.require_auth()` |
+
+### Treasury Address Validation
+
+`configure_treasury` rejects two classes of invalid addresses before persisting any state:
+
+#### Self-assignment (contract address)
+
+Setting the treasury to the contract's own address would route all fees back into the contract with no way to withdraw them.
+
+```
+if treasury_address == env.current_contract_address() {
+    return Err(QuickLendXError::InvalidAddress);
+}
+```
+
+#### Duplicate address
+
+Re-configuring the treasury to the address already stored is a no-op at best and masks operational errors at worst.
+
+```
+if let Some(ref existing) = platform_config.treasury_address {
+    if *existing == treasury_address {
+        return Err(QuickLendXError::InvalidFeeConfiguration);
+    }
+}
+```
+
+Both checks run before any write, so rejected calls leave storage unchanged.
+
+### Error Reference (Fee Hardening)
+
+| Error | Code | Trigger |
+|---|---|---|
+| `InvalidFeeConfiguration` | 1850 | Re-initialization attempt; duplicate treasury address |
+| `InvalidAddress` | 1201 | Treasury set to contract's own address |
+| `InvalidFeeBasisPoints` | 1852 | Fee BPS exceeds 1000 (10%) |
+| `TreasuryNotConfigured` | 1851 | Fee routing attempted before treasury is set |
+
+### Security Assumptions
+
+- **Admin key security**: The admin `Address` passed at initialization must be controlled by the platform operator. Loss of the admin key means no further fee configuration is possible; there is no recovery path.
+- **Single initialization window**: The init guard is permanent. If fee structures must change post-deployment, use `update_platform_fee` (for BPS) or `configure_treasury` (for routing), not re-initialization.
+- **Treasury address trust**: The contract does not validate that the treasury address is a live account or holds any minimum balance. Operators must verify the address is operational before configuring it.

--- a/quicklendx-contracts/src/fees.rs
+++ b/quicklendx-contracts/src/fees.rs
@@ -16,6 +16,8 @@ const VOLUME_KEY: Symbol = symbol_short!("volume");
 #[allow(dead_code)]
 const TREASURY_CONFIG_KEY: Symbol = symbol_short!("treasury");
 const PLATFORM_FEE_KEY: Symbol = symbol_short!("plt_fee");
+/// Guard key: set to `true` once `initialize` completes to prevent re-initialization.
+const FEES_INIT_KEY: Symbol = symbol_short!("fee_init");
 
 /// Fee types supported by the platform
 #[contracttype]
@@ -130,7 +132,13 @@ pub struct FeeManager;
 
 impl FeeManager {
     pub fn initialize(env: &Env, admin: &Address) -> Result<(), QuickLendXError> {
-        // Auth handled by ProtocolInitializer
+        // Explicit admin authorization: the caller must be the designated admin.
+        admin.require_auth();
+
+        // Guard: reject re-initialization to prevent overwriting live fee config.
+        if env.storage().instance().has(&FEES_INIT_KEY) {
+            return Err(QuickLendXError::InvalidFeeConfiguration);
+        }
 
         // Initialize default fee structures
         let default_fees = vec![
@@ -176,6 +184,9 @@ impl FeeManager {
             .instance()
             .set(&PLATFORM_FEE_KEY, &platform_fee_config);
 
+        // Mark the fee system as initialized.
+        env.storage().instance().set(&FEES_INIT_KEY, &true);
+
         Ok(())
     }
 
@@ -187,6 +198,19 @@ impl FeeManager {
     ) -> Result<TreasuryConfig, QuickLendXError> {
         admin.require_auth();
 
+        // Reject self-assignment: treasury must not be the contract itself.
+        if treasury_address == env.current_contract_address() {
+            return Err(QuickLendXError::InvalidAddress);
+        }
+
+        // Fetch existing config and reject duplicate treasury address.
+        let mut platform_config = Self::get_platform_fee_config(env)?;
+        if let Some(ref existing) = platform_config.treasury_address {
+            if *existing == treasury_address {
+                return Err(QuickLendXError::InvalidFeeConfiguration);
+            }
+        }
+
         let treasury_config = TreasuryConfig {
             treasury_address: treasury_address.clone(),
             is_active: true,
@@ -194,8 +218,6 @@ impl FeeManager {
             updated_by: admin.clone(),
         };
 
-        // Update platform fee config with treasury
-        let mut platform_config = Self::get_platform_fee_config(env)?;
         platform_config.treasury_address = Some(treasury_address.clone());
         platform_config.updated_at = env.ledger().timestamp();
         platform_config.updated_by = admin.clone();
@@ -210,10 +232,11 @@ impl FeeManager {
     /// Update platform fee basis points
     pub fn update_platform_fee(
         env: &Env,
-        _admin: &Address,
+        admin: &Address,
         fee_bps: u32,
     ) -> Result<(), QuickLendXError> {
-        // Auth is checked by the caller
+        // Explicit admin authorization.
+        admin.require_auth();
 
         if fee_bps > 1000 {
             return Err(QuickLendXError::InvalidFeeBasisPoints);

--- a/quicklendx-contracts/src/lib.rs
+++ b/quicklendx-contracts/src/lib.rs
@@ -1639,8 +1639,9 @@ impl QuickLendXContract {
     // Fee and Revenue Management Functions
     // ========================================
 
-    /// Initialize fee management system
+    /// Initialize fee management system (admin only, one-time)
     pub fn initialize_fee_system(env: Env, admin: Address) -> Result<(), QuickLendXError> {
+        admin.require_auth();
         fees::FeeManager::initialize(&env, &admin)
     }
 
@@ -1662,6 +1663,7 @@ impl QuickLendXContract {
     pub fn update_platform_fee_bps(env: Env, new_fee_bps: u32) -> Result<(), QuickLendXError> {
         let admin =
             BusinessVerificationStorage::get_admin(&env).ok_or(QuickLendXError::NotAdmin)?;
+        admin.require_auth();
 
         let old_config = fees::FeeManager::get_platform_fee_config(&env)?;
         let old_fee_bps = old_config.fee_bps;

--- a/quicklendx-contracts/src/test_fees.rs
+++ b/quicklendx-contracts/src/test_fees.rs
@@ -12,6 +12,13 @@ fn setup_admin(env: &Env, client: &QuickLendXContractClient) -> Address {
     admin
 }
 
+/// Helper: initialize admin via initialize_admin (first-time setup path)
+fn setup_admin_init(env: &Env, client: &QuickLendXContractClient) -> Address {
+    let admin = Address::generate(&env);
+    client.initialize_admin(&admin);
+    admin
+}
+
 /// Helper function to create and verify a business
 fn setup_business(env: &Env, client: &QuickLendXContractClient, admin: &Address) -> Address {
     let business = Address::generate(&env);
@@ -897,5 +904,162 @@ fn test_calculate_transaction_fees_late_payment_flag() {
     assert!(
         late_fees > base_fees,
         "Late payment must increase total fees"
+    );
+}
+
+// ============================================================================
+// HARDENING TESTS — Fee System Initialization & Treasury Configuration
+// ============================================================================
+
+/// initialize_fee_system must reject a second call (re-initialization guard).
+#[test]
+fn test_fee_system_double_init_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(crate::QuickLendXContract, ());
+    let client = QuickLendXContractClient::new(&env, &contract_id);
+    let admin = setup_admin(&env, &client);
+
+    client.initialize_fee_system(&admin);
+
+    let result = client.try_initialize_fee_system(&admin);
+    let err = result.err().expect("second init must fail");
+    let contract_error = err.expect("expected contract error");
+    assert_eq!(contract_error, QuickLendXError::InvalidFeeConfiguration);
+}
+
+/// initialize_fee_system must require admin authorization.
+#[test]
+fn test_fee_system_init_requires_admin_auth() {
+    let env = Env::default();
+    let contract_id = env.register(crate::QuickLendXContract, ());
+    let client = QuickLendXContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let attacker = Address::generate(&env);
+
+    client.mock_all_auths().set_admin(&admin);
+
+    // Attacker signs for their own address, not the admin address.
+    let bad_auth = MockAuth {
+        address: &attacker,
+        invoke: &MockAuthInvoke {
+            contract: &contract_id,
+            fn_name: "initialize_fee_system",
+            args: (admin.clone(),).into_val(&env),
+            sub_invokes: &[],
+        },
+    };
+    let result = client
+        .mock_auths(&[bad_auth])
+        .try_initialize_fee_system(&admin);
+    assert!(
+        result.is_err(),
+        "initialize_fee_system must abort without admin authorization"
+    );
+}
+
+/// configure_treasury must reject the contract's own address as treasury.
+#[test]
+fn test_configure_treasury_rejects_contract_address() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(crate::QuickLendXContract, ());
+    let client = QuickLendXContractClient::new(&env, &contract_id);
+    let admin = setup_admin_init(&env, &client);
+
+    client.initialize_fee_system(&admin);
+
+    // Attempting to set the contract itself as treasury must be rejected.
+    let result = client.try_configure_treasury(&contract_id);
+    let err = result.err().expect("self-assignment must fail");
+    let contract_error = err.expect("expected contract error");
+    assert_eq!(contract_error, QuickLendXError::InvalidAddress);
+}
+
+/// configure_treasury must reject the same address when already configured (duplicate).
+#[test]
+fn test_configure_treasury_rejects_duplicate_address() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(crate::QuickLendXContract, ());
+    let client = QuickLendXContractClient::new(&env, &contract_id);
+    let admin = setup_admin_init(&env, &client);
+    let treasury = Address::generate(&env);
+
+    client.initialize_fee_system(&admin);
+    client.configure_treasury(&treasury);
+
+    // Setting the same treasury address a second time must be rejected.
+    let result = client.try_configure_treasury(&treasury);
+    let err = result.err().expect("duplicate treasury must fail");
+    let contract_error = err.expect("expected contract error");
+    assert_eq!(contract_error, QuickLendXError::InvalidFeeConfiguration);
+}
+
+/// configure_treasury must allow updating to a different (non-duplicate) address.
+#[test]
+fn test_configure_treasury_allows_update_to_different_address() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(crate::QuickLendXContract, ());
+    let client = QuickLendXContractClient::new(&env, &contract_id);
+    let admin = setup_admin_init(&env, &client);
+    let treasury1 = Address::generate(&env);
+    let treasury2 = Address::generate(&env);
+
+    client.initialize_fee_system(&admin);
+    client.configure_treasury(&treasury1);
+    // Updating to a distinct address must succeed.
+    client.configure_treasury(&treasury2);
+
+    let stored = client.get_treasury_address();
+    assert_eq!(stored, Some(treasury2));
+}
+
+/// configure_treasury must fail if called before fee system initialization.
+#[test]
+fn test_configure_treasury_requires_prior_init() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(crate::QuickLendXContract, ());
+    let client = QuickLendXContractClient::new(&env, &contract_id);
+    let treasury = Address::generate(&env);
+
+    // No initialize_fee_system called — platform fee config doesn't exist yet.
+    let result = client.try_configure_treasury(&treasury);
+    assert!(
+        result.is_err(),
+        "configure_treasury must fail without prior fee system init"
+    );
+}
+
+/// update_platform_fee_bps must require explicit admin authorization.
+#[test]
+fn test_update_platform_fee_bps_requires_admin_auth() {
+    let env = Env::default();
+    let contract_id = env.register(crate::QuickLendXContract, ());
+    let client = QuickLendXContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let attacker = Address::generate(&env);
+
+    client.mock_all_auths().set_admin(&admin);
+    client.mock_all_auths().initialize_fee_system(&admin);
+
+    // Attacker cannot authorize fee update for admin.
+    let bad_auth = MockAuth {
+        address: &attacker,
+        invoke: &MockAuthInvoke {
+            contract: &contract_id,
+            fn_name: "update_platform_fee_bps",
+            args: (500u32,).into_val(&env),
+            sub_invokes: &[],
+        },
+    };
+    let result = client
+        .mock_auths(&[bad_auth])
+        .try_update_platform_fee_bps(&500);
+    assert!(
+        result.is_err(),
+        "update_platform_fee_bps must abort without admin authorization"
     );
 }

--- a/quicklendx-contracts/src/test_fees_extended.rs
+++ b/quicklendx-contracts/src/test_fees_extended.rs
@@ -393,3 +393,126 @@ fn test_treasury_persists_across_updates() {
     assert!(treasury_addr.is_some());
     assert_eq!(treasury_addr.unwrap(), treasury);
 }
+
+// ============================================================================
+// HARDENING EXTENDED TESTS — Initialization Guard & Treasury Validation
+// ============================================================================
+
+/// Second initialize_fee_system call returns InvalidFeeConfiguration.
+#[test]
+fn test_double_init_returns_invalid_fee_configuration() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(crate::QuickLendXContract, ());
+    let client = QuickLendXContractClient::new(&env, &contract_id);
+    let admin = setup_admin(&env, &client);
+
+    client.initialize_fee_system(&admin);
+
+    let result = client.try_initialize_fee_system(&admin);
+    let err = result.err().expect("re-init must return error");
+    let contract_error = err.expect("expected typed contract error");
+    assert_eq!(contract_error, QuickLendXError::InvalidFeeConfiguration);
+}
+
+/// Fee structures initialized in first call survive a rejected second call.
+#[test]
+fn test_fee_structures_unchanged_after_rejected_reinit() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(crate::QuickLendXContract, ());
+    let client = QuickLendXContractClient::new(&env, &contract_id);
+    let admin = setup_admin(&env, &client);
+
+    client.initialize_fee_system(&admin);
+
+    // A custom update after first init.
+    client.update_fee_structure(&admin, &crate::fees::FeeType::Platform, &300, &50, &5_000, &true);
+    assert_eq!(client.get_fee_structure(&crate::fees::FeeType::Platform).base_fee_bps, 300);
+
+    // Re-init attempt is rejected — custom update must be preserved.
+    let _ = client.try_initialize_fee_system(&admin);
+    assert_eq!(client.get_fee_structure(&crate::fees::FeeType::Platform).base_fee_bps, 300);
+}
+
+/// configure_treasury rejects the contract address as InvalidAddress.
+#[test]
+fn test_treasury_self_assignment_returns_invalid_address() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(crate::QuickLendXContract, ());
+    let client = QuickLendXContractClient::new(&env, &contract_id);
+    let admin = setup_admin_init(&env, &client);
+
+    client.initialize_fee_system(&admin);
+
+    let result = client.try_configure_treasury(&contract_id);
+    let err = result.err().expect("self-assignment must fail");
+    let contract_error = err.expect("expected typed contract error");
+    assert_eq!(contract_error, QuickLendXError::InvalidAddress);
+}
+
+/// Duplicate treasury configuration returns InvalidFeeConfiguration.
+#[test]
+fn test_duplicate_treasury_returns_invalid_fee_configuration() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(crate::QuickLendXContract, ());
+    let client = QuickLendXContractClient::new(&env, &contract_id);
+    let admin = setup_admin_init(&env, &client);
+    let treasury = Address::generate(&env);
+
+    client.initialize_fee_system(&admin);
+    client.configure_treasury(&treasury);
+
+    let result = client.try_configure_treasury(&treasury);
+    let err = result.err().expect("duplicate must fail");
+    let contract_error = err.expect("expected typed contract error");
+    assert_eq!(contract_error, QuickLendXError::InvalidFeeConfiguration);
+}
+
+/// Treasury address can be updated to a new distinct address after initial set.
+#[test]
+fn test_treasury_update_to_new_address_succeeds() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(crate::QuickLendXContract, ());
+    let client = QuickLendXContractClient::new(&env, &contract_id);
+    let admin = setup_admin_init(&env, &client);
+    let treasury_a = Address::generate(&env);
+    let treasury_b = Address::generate(&env);
+
+    client.initialize_fee_system(&admin);
+    client.configure_treasury(&treasury_a);
+    client.configure_treasury(&treasury_b);
+
+    assert_eq!(client.get_treasury_address(), Some(treasury_b));
+}
+
+/// Revenue distribution config uses the treasury address that was last set.
+#[test]
+fn test_revenue_distribution_uses_updated_treasury() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(crate::QuickLendXContract, ());
+    let client = QuickLendXContractClient::new(&env, &contract_id);
+    let admin = setup_admin(&env, &client);
+    let user = setup_investor(&env, &client, &admin);
+    let treasury_a = Address::generate(&env);
+    let treasury_b = Address::generate(&env);
+
+    client.initialize_fee_system(&admin);
+    client.configure_treasury(&treasury_a);
+    // Update to a different treasury before configuring revenue distribution.
+    client.configure_treasury(&treasury_b);
+
+    client.configure_revenue_distribution(&admin, &treasury_b, &10000, &0, &0, &false, &1);
+
+    let mut fees_by_type = Map::new(&env);
+    fees_by_type.set(crate::fees::FeeType::Platform, 500);
+    client.collect_transaction_fees(&user, &fees_by_type, &500);
+
+    let period = env.ledger().timestamp() / 2_592_000;
+    let (treasury_amount, _, _) = client.distribute_revenue(&admin, &period);
+    assert_eq!(treasury_amount, 500);
+}


### PR DESCRIPTION
## Summary

Hardens the fee system initialization and treasury configuration flow against unauthorized or malformed state transitions.

- **Init guard**: `FeeManager::initialize` now writes a `fee_init` flag on first call and returns `InvalidFeeConfiguration` on any subsequent call, preventing re-initialization attacks.
- **Explicit auth**: `admin.require_auth()` is enforced at both the `lib.rs` (public API) and `fees.rs` (module) layers for `initialize_fee_system` and `update_platform_fee` (defense-in-depth).
- **Treasury validation**: `configure_treasury` rejects the contract's own address (`InvalidAddress`) and duplicate addresses (`InvalidFeeConfiguration`) before writing any state.
- **Tests**: 7 new tests in `test_fees.rs` and 6 in `test_fees_extended.rs` covering all hardened paths.
- **Docs**: `docs/contracts/fees.md` updated with a new *Hardening* section documenting the init guard, auth table, validation rules, error reference, and security assumptions.

## Test plan

- [ ] `cargo test -p quicklendx-contracts` passes with no failures
- [ ] `test_fee_system_double_init_rejected` — second init returns `InvalidFeeConfiguration`
- [ ] `test_fee_system_init_requires_admin_auth` — unauthorized init is rejected
- [ ] `test_configure_treasury_rejects_contract_address` — returns `InvalidAddress`
- [ ] `test_configure_treasury_rejects_duplicate_address` — returns `InvalidFeeConfiguration`
- [ ] `test_configure_treasury_allows_update_to_different_address` — succeeds
- [ ] `test_update_platform_fee_bps_requires_admin_auth` — unauthorized update is rejected

Closes #549


