### PR TITLE
test: cover bid TTL and expiry boundary behavior

### DIFF
--- a/docs/contracts/bidding.md
+++ b/docs/contracts/bidding.md
@@ -41,6 +41,41 @@ pub fn cancel_bid(env: &Env, bid_id: &BytesN<32>) -> bool {
 `require_auth()` is called on `bid.investor` — any other signer causes a
 host-level authorization failure before any state is mutated.
 
+## TTL Boundary and Expiry Semantics
+
+Bid expiry uses a strict boundary check in `Bid::is_expired`:
+
+```rust
+current_timestamp > expiration_timestamp
+```
+
+This creates an explicit, auditable rule:
+
+- At `current_timestamp == expiration_timestamp`, the bid is still valid.
+- At `current_timestamp == expiration_timestamp + 1`, the bid is expired.
+
+### Security rationale
+
+- Avoids ambiguous edge handling between `accept_bid` and cleanup paths.
+- Ensures cleanup and acceptance use the same predicate, preventing drift.
+- Protects against off-by-one regressions where a bid could be accepted after
+  being considered expired elsewhere (or vice versa).
+
+### Admin TTL bounds
+
+The bid TTL configuration is constrained to:
+
+- Minimum: `1` day (`MIN_BID_TTL_DAYS`)
+- Maximum: `30` days (`MAX_BID_TTL_DAYS`)
+
+Values outside this range return `InvalidBidTtl`.
+
+### Expired-bid acceptance guarantee
+
+`accept_bid` triggers expired-bid cleanup before status checks. If a bid has
+crossed the strict boundary (`now > expiration_timestamp`), it transitions out
+of `Placed` and cannot be accepted.
+
 ## cancel_bid vs withdraw_bid
 
 Both operations are investor-only and transition a `Placed` bid to a terminal
@@ -82,3 +117,9 @@ state. They produce **distinct** statuses:
 cd quicklendx-contracts
 cargo test test_bid
 ```
+
+Additional boundary coverage (Issue #795):
+
+- `test_accept_bid_at_exact_expiration_timestamp_succeeds`
+- `test_accept_bid_after_expiration_timestamp_fails`
+- `test_cleanup_expired_bids_exact_boundary_and_off_by_one`

--- a/quicklendx-contracts/src/bid.rs
+++ b/quicklendx-contracts/src/bid.rs
@@ -101,6 +101,15 @@ pub struct Bid {
 }
 
 impl Bid {
+    /// @notice Returns whether a bid is expired at `current_timestamp`.
+    /// @dev Expiration is evaluated with a strict comparison:
+    ///      `current_timestamp > expiration_timestamp`.
+    ///      This means a bid is still valid at the exact expiry timestamp and
+    ///      becomes expired starting from the next second. All cleanup and
+    ///      acceptance paths rely on this same predicate to avoid off-by-one
+    ///      divergence across call sites.
+    /// @param current_timestamp Current ledger timestamp.
+    /// @return true when the bid has moved strictly past its expiry boundary.
     pub fn is_expired(&self, current_timestamp: u64) -> bool {
         current_timestamp > self.expiration_timestamp
     }

--- a/quicklendx-contracts/src/test_bid.rs
+++ b/quicklendx-contracts/src/test_bid.rs
@@ -33,7 +33,7 @@ use crate::errors::QuickLendXError;
 use crate::invoice::InvoiceCategory;
 use crate::{QuickLendXContract, QuickLendXContractClient};
 use soroban_sdk::{
-    testutils::{Address as _, MockAuth, MockAuthInvoke},
+    testutils::{Address as _, Ledger, MockAuth, MockAuthInvoke},
     Address, BytesN, Env, IntoVal, String, Vec,
 };
 
@@ -427,5 +427,42 @@ fn test_investor_can_cancel_multiple_own_bids() {
     assert_eq!(
         client.get_bid(&bid_id_2).unwrap().status,
         crate::bid::BidStatus::Cancelled
+    );
+}
+
+// ===========================================================================
+// 7. TTL/EXPIRY BOUNDARIES — exact-timestamp and off-by-one protections
+// ===========================================================================
+
+/// At exact expiration timestamp, bid remains valid (strict `>` expiry rule).
+#[test]
+fn test_accept_bid_at_exact_expiration_timestamp_succeeds() {
+    let (env, client, admin, business) = setup();
+    client.set_bid_ttl_days(&1u64);
+
+    let (bid_id, _, invoice_id) = place_bid(&env, &client, &admin, &business);
+    let bid = client.get_bid(&bid_id).unwrap();
+    env.ledger().set_timestamp(bid.expiration_timestamp);
+
+    let result = client.try_accept_bid(&invoice_id, &bid_id);
+    assert!(result.is_ok(), "bid should remain valid at exact expiry timestamp");
+}
+
+/// One second after expiration timestamp, bid must not be accepted.
+#[test]
+fn test_accept_bid_after_expiration_timestamp_fails() {
+    let (env, client, admin, business) = setup();
+    client.set_bid_ttl_days(&1u64);
+
+    let (bid_id, _, invoice_id) = place_bid(&env, &client, &admin, &business);
+    let bid = client.get_bid(&bid_id).unwrap();
+    env.ledger()
+        .set_timestamp(bid.expiration_timestamp.saturating_add(1));
+
+    let result = client.try_accept_bid(&invoice_id, &bid_id);
+    assert!(result.is_err(), "expired bid must not be accepted");
+    assert_eq!(
+        result.unwrap_err().expect("expected contract error"),
+        QuickLendXError::InvalidStatus
     );
 }

--- a/quicklendx-contracts/src/test_overdue_expiration.rs
+++ b/quicklendx-contracts/src/test_overdue_expiration.rs
@@ -649,3 +649,49 @@ fn test_cleanup_expired_bids_integration() {
         "No more bids to clean"
     );
 }
+
+#[test]
+fn test_cleanup_expired_bids_exact_boundary_and_off_by_one() {
+    let (env, client, admin) = setup();
+    let business = create_verified_business(&env, &client, &admin);
+    let investor = create_verified_investor(&env, &client, &admin, 50_000);
+
+    client.set_bid_ttl_days(&1u64);
+
+    let currency = Address::generate(&env);
+    let due_date = env.ledger().timestamp() + 86400 * 20;
+    let invoice_id = client.store_invoice(
+        &business,
+        &10_000,
+        &currency,
+        &due_date,
+        &String::from_str(&env, "TTL boundary invoice"),
+        &InvoiceCategory::Services,
+        &Vec::new(&env),
+    );
+    client.verify_invoice(&invoice_id);
+
+    let bid_id = client.place_bid(&investor, &invoice_id, &4000, &4300);
+    let bid = client.get_bid(&bid_id).unwrap();
+
+    env.ledger().set_timestamp(bid.expiration_timestamp);
+    let cleaned_at_exact = client.cleanup_expired_bids(&invoice_id);
+    assert_eq!(
+        cleaned_at_exact, 0,
+        "cleanup must not expire bids at exact expiration timestamp"
+    );
+
+    env.ledger()
+        .set_timestamp(bid.expiration_timestamp.saturating_add(1));
+    let cleaned_after = client.cleanup_expired_bids(&invoice_id);
+    assert_eq!(
+        cleaned_after, 1,
+        "cleanup must expire bid one second after expiration timestamp"
+    );
+
+    assert_eq!(
+        client.cleanup_expired_bids(&invoice_id),
+        0,
+        "cleanup remains idempotent after removing expired bid"
+    );
+}


### PR DESCRIPTION
Closes #795

---

This PR closes issue number #795 

## Summary
- Adds exact-boundary expiry tests for bid acceptance in `test_bid.rs` (`t == expiration` allowed, `t == expiration + 1` rejected).
- Adds cleanup off-by-one regression coverage in `test_overdue_expiration.rs` for exact expiry and +1 second behavior.
- Documents strict expiry semantics and TTL bounds in `docs/contracts/bidding.md`.
- Adds NatSpec-style Rust doc comments clarifying strict expiry semantics in `bid.rs`.

## Security Notes
- Expired bids cannot be accepted once the ledger time is strictly past `expiration_timestamp`.
- Exact-boundary behavior is now explicitly tested to prevent future off-by-one regressions between acceptance and cleanup paths.
- TTL min/max policy remains enforced (`1..=30` days).

## Test Output
Command run:
`cd quicklendx-contracts && cargo test --verbose`

Result:
- Fails at compile stage due to a pre-existing parse error unrelated to this PR: `quicklendx-contracts/src/storage.rs:572` (`unexpected closing delimiter: }`).
- New boundary tests are added and ready to run once baseline syntax issues are resolved.