### PR TITLE
test: bound invoice metadata and enforce normalization rules

### DIFF
--- a/docs/contracts/invoice.md
+++ b/docs/contracts/invoice.md
@@ -117,3 +117,33 @@ Expected output:
 running 22 tests
 test result: ok. 22 passed; 0 failed; 0 ignored
 ```
+
+## Metadata Bounds and Normalization
+
+To prevent unbounded storage growth and ambiguous query keys, invoice metadata
+enforces strict limits and canonicalization rules.
+
+### Bounded vectors
+
+- Invoice tags: maximum `10` normalized tags per invoice.
+- Structured metadata line items: maximum `100` line items.
+- Invoice ratings: maximum `100` ratings retained per invoice.
+
+Any attempt to exceed these bounds is rejected before storage mutation.
+
+### Tag normalization rules
+
+Tags are canonicalized using trim + ASCII lowercase before validation and
+duplicate checks. As a result:
+
+- `" Tech "`, `"tech"`, and `"TECH"` are treated as the same tag.
+- Duplicate canonical tags are rejected by invoice tag validation.
+- Per-invoice tag growth is capped even when tags are submitted in different
+  case/whitespace variants.
+
+### Security notes
+
+- Oversized metadata payloads are rejected early, reducing compute/storage DoS
+  surface.
+- Canonical duplicate handling prevents ambiguous indexing/query behavior.
+- Rating/tag caps keep per-invoice state growth predictable over time.

--- a/quicklendx-contracts/src/invoice.rs
+++ b/quicklendx-contracts/src/invoice.rs
@@ -1,4 +1,5 @@
 use crate::errors::QuickLendXError;
+use crate::protocol_limits::{check_string_length, MAX_FEEDBACK_LENGTH};
 use crate::storage::DataKey;
 use crate::verification::normalize_tag;
 use soroban_sdk::{Address, BytesN, Env, String, Vec};
@@ -8,6 +9,18 @@ pub use crate::types::{
     Dispute, DisputeStatus, Invoice, InvoiceCategory, InvoiceMetadata, InvoiceRating,
     InvoiceStatus, LineItemRecord, PaymentRecord,
 };
+
+/// Maximum normalized tags allowed per invoice.
+///
+/// Limiting tag cardinality prevents unbounded metadata growth and keeps
+/// tag-based query/index operations predictable.
+pub const MAX_INVOICE_TAGS: u32 = 10;
+
+/// Maximum ratings retained per invoice.
+///
+/// Bounding this vector prevents unbounded on-chain storage growth from
+/// repeated rating submissions over time.
+pub const MAX_RATINGS_PER_INVOICE: u32 = 100;
 
 impl Invoice {
     pub fn new(
@@ -26,7 +39,20 @@ impl Invoice {
 
         let mut normalized_tags = Vec::new(env);
         for tag in tags.iter() {
-            normalized_tags.push_back(normalize_tag(env, &tag)?);
+            let normalized = normalize_tag(env, &tag)?;
+            let mut exists = false;
+            for existing in normalized_tags.iter() {
+                if existing == normalized {
+                    exists = true;
+                    break;
+                }
+            }
+            if !exists {
+                if normalized_tags.len() >= MAX_INVOICE_TAGS {
+                    return Err(QuickLendXError::TagLimitExceeded);
+                }
+                normalized_tags.push_back(normalized);
+            }
         }
 
         Ok(Self {
@@ -237,6 +263,9 @@ impl Invoice {
     pub fn add_tag(&mut self, env: &Env, tag: String) -> Result<(), QuickLendXError> {
         let normalized = normalize_tag(env, &tag)?;
         if !self.has_tag(normalized.clone()) {
+            if self.tags.len() >= MAX_INVOICE_TAGS {
+                return Err(QuickLendXError::TagLimitExceeded);
+            }
             self.tags.push_back(normalized);
         }
         Ok(())
@@ -262,11 +291,15 @@ impl Invoice {
         rater: Address,
         rated_at: u64,
     ) -> Result<(), QuickLendXError> {
+        check_string_length(&feedback, MAX_FEEDBACK_LENGTH)?;
         if rating == 0 || rating > 5 {
             return Err(QuickLendXError::InvalidRating);
         }
         if self.status != InvoiceStatus::Funded && self.status != InvoiceStatus::Paid {
             return Err(QuickLendXError::NotFunded);
+        }
+        if self.ratings.len() >= MAX_RATINGS_PER_INVOICE {
+            return Err(QuickLendXError::OperationNotAllowed);
         }
         for existing in self.ratings.iter() {
             if existing.rated_by == rater {

--- a/quicklendx-contracts/src/test_invoice_metadata.rs
+++ b/quicklendx-contracts/src/test_invoice_metadata.rs
@@ -17,7 +17,10 @@
 use soroban_sdk::{testutils::Address as _, Address, BytesN, Env, String, Vec};
 
 use crate::errors::QuickLendXError;
-use crate::invoice::{Invoice, InvoiceCategory, InvoiceMetadata, LineItemRecord};
+use crate::invoice::{
+    Invoice, InvoiceCategory, InvoiceMetadata, LineItemRecord, MAX_INVOICE_TAGS,
+    MAX_RATINGS_PER_INVOICE,
+};
 use crate::storage::{Indexes, InvoiceStorage};
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -495,4 +498,94 @@ fn test_owner_succeeds_after_attacker_fails() {
         invoice.metadata_customer_name,
         Some(metadata.customer_name)
     );
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 14. Tag normalization deduplicates at invoice construction
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn test_invoice_new_deduplicates_trimmed_casefolded_tags() {
+    let env = Env::default();
+    let business = Address::generate(&env);
+    let currency = Address::generate(&env);
+
+    let mut tags = Vec::new(&env);
+    tags.push_back(String::from_str(&env, "  Tech  "));
+    tags.push_back(String::from_str(&env, "tech"));
+    tags.push_back(String::from_str(&env, "TECH"));
+
+    let invoice = Invoice::new(
+        &env,
+        business,
+        1000,
+        currency,
+        env.ledger().timestamp() + 86400,
+        String::from_str(&env, "Normalized tags"),
+        InvoiceCategory::Services,
+        tags,
+    )
+    .expect("invoice creation should normalize tags");
+
+    assert_eq!(
+        invoice.tags.len(),
+        1,
+        "trim/case-equivalent tags must collapse to one canonical value"
+    );
+    assert_eq!(invoice.tags.get(0).unwrap(), String::from_str(&env, "tech"));
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 15. Tag vector cap blocks unbounded growth
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn test_add_tag_rejects_when_max_tag_count_reached() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let business = Address::generate(&env);
+    let mut invoice = make_invoice(&env, &business);
+
+    for i in 0..MAX_INVOICE_TAGS {
+        let tag = String::from_str(&env, &format!("tag{}", i));
+        invoice.add_tag(&env, tag).expect("tag add should succeed");
+    }
+    assert_eq!(invoice.tags.len(), MAX_INVOICE_TAGS);
+
+    let err = invoice
+        .add_tag(&env, String::from_str(&env, "overflow-tag"))
+        .unwrap_err();
+    assert_eq!(err, QuickLendXError::TagLimitExceeded);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 16. Ratings vector cap blocks unbounded growth
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn test_add_rating_rejects_when_max_rating_count_reached() {
+    let env = Env::default();
+    let business = Address::generate(&env);
+    let mut invoice = make_invoice(&env, &business);
+
+    // add_rating is only valid when invoice is funded/paid.
+    invoice.status = crate::invoice::InvoiceStatus::Funded;
+
+    for i in 0..MAX_RATINGS_PER_INVOICE {
+        let rater = Address::generate(&env);
+        invoice
+            .add_rating(5, String::from_str(&env, "ok"), rater, i as u64 + 1)
+            .expect("rating add should succeed until max bound");
+    }
+
+    let err = invoice
+        .add_rating(
+            4,
+            String::from_str(&env, "excess"),
+            Address::generate(&env),
+            9999,
+        )
+        .unwrap_err();
+    assert_eq!(err, QuickLendXError::OperationNotAllowed);
 }

--- a/quicklendx-contracts/src/test_string_limits.rs
+++ b/quicklendx-contracts/src/test_string_limits.rs
@@ -1,6 +1,7 @@
 use super::*;
 use crate::invoice::{InvoiceMetadata, LineItemRecord};
 use crate::protocol_limits::*;
+use crate::verification::MAX_METADATA_LINE_ITEMS;
 use soroban_sdk::{testutils::Address as _, Address, Env, String, Vec};
 
 fn setup() -> (Env, QuickLendXContractClient<'static>, Address) {
@@ -272,5 +273,68 @@ fn test_tag_spaces_only_invalid_after_norm() {
     assert_eq!(
         res.err().unwrap().unwrap(),
         crate::errors::QuickLendXError::InvalidTag
+    );
+}
+
+/// Duplicate tags after trim/lower normalization are rejected.
+#[test]
+fn test_tag_duplicates_rejected_after_normalization() {
+    let env = Env::default();
+    let mut tags = Vec::new(&env);
+    tags.push_back(String::from_str(&env, "  Finance "));
+    tags.push_back(String::from_str(&env, "finance"));
+
+    let err = crate::verification::validate_invoice_tags(&env, &tags).unwrap_err();
+    assert_eq!(err, crate::errors::QuickLendXError::InvalidTag);
+}
+
+/// Metadata line item vector is hard bounded to prevent unbounded storage writes.
+#[test]
+fn test_invoice_metadata_line_items_count_limit() {
+    let env = Env::default();
+    let mut line_items = Vec::new(&env);
+    for _ in 0..MAX_METADATA_LINE_ITEMS {
+        line_items.push_back(LineItemRecord(
+            String::from_str(&env, "Item"),
+            1,
+            1,
+            1,
+        ));
+    }
+
+    let metadata_at_limit = InvoiceMetadata {
+        customer_name: String::from_str(&env, "Acme"),
+        customer_address: String::from_str(&env, "Address"),
+        tax_id: String::from_str(&env, "TIN"),
+        line_items: line_items.clone(),
+        notes: String::from_str(&env, "ok"),
+    };
+    assert!(
+        crate::verification::validate_invoice_metadata(
+            &metadata_at_limit,
+            MAX_METADATA_LINE_ITEMS as i128,
+        )
+        .is_ok()
+    );
+
+    line_items.push_back(LineItemRecord(
+        String::from_str(&env, "Item"),
+        1,
+        1,
+        1,
+    ));
+    let metadata_over_limit = InvoiceMetadata {
+        customer_name: String::from_str(&env, "Acme"),
+        customer_address: String::from_str(&env, "Address"),
+        tax_id: String::from_str(&env, "TIN"),
+        line_items,
+        notes: String::from_str(&env, "overflow"),
+    };
+    assert!(
+        crate::verification::validate_invoice_metadata(
+            &metadata_over_limit,
+            (MAX_METADATA_LINE_ITEMS + 1) as i128,
+        )
+        .is_err()
     );
 }

--- a/quicklendx-contracts/src/verification.rs
+++ b/quicklendx-contracts/src/verification.rs
@@ -9,6 +9,11 @@ use crate::protocol_limits::{
 use crate::types::{Dispute, DisputeStatus, Invoice, InvoiceMetadata, InvoiceStatus};
 use soroban_sdk::{contracttype, symbol_short, vec, Address, Env, String, Vec};
 
+/// Maximum normalized tags allowed on an invoice.
+pub const MAX_INVOICE_TAG_COUNT: u32 = 10;
+/// Maximum line items allowed in structured invoice metadata.
+pub const MAX_METADATA_LINE_ITEMS: u32 = 100;
+
 #[contracttype]
 #[derive(Clone, Eq, PartialEq)]
 #[cfg_attr(test, derive(Debug))]
@@ -1028,7 +1033,7 @@ pub fn validate_invoice_category(
 /// - `TagLimitExceeded` (1801): more than 10 tags supplied.
 /// - `InvalidTag` (1800): a tag is empty/too long after normalization, or is a duplicate.
 pub fn validate_invoice_tags(env: &Env, tags: &Vec<String>) -> Result<(), QuickLendXError> {
-    if tags.len() > 10 {
+    if tags.len() > MAX_INVOICE_TAG_COUNT {
         return Err(QuickLendXError::TagLimitExceeded);
     }
 
@@ -1459,6 +1464,9 @@ pub fn validate_invoice_metadata(
     check_string_length(&metadata.notes, MAX_NOTES_LENGTH)?;
 
     if metadata.line_items.len() == 0 {
+        return Err(QuickLendXError::InvalidDescription);
+    }
+    if metadata.line_items.len() > MAX_METADATA_LINE_ITEMS {
         return Err(QuickLendXError::InvalidDescription);
     }
 


### PR DESCRIPTION
Closes #783

---

This PR closes issue number #783 

## Summary
- Adds hard bounds for invoice metadata growth paths:
  - tag vector cap (`MAX_INVOICE_TAGS = 10`) enforced in `Invoice::new` and `Invoice::add_tag`.
  - rating vector cap (`MAX_RATINGS_PER_INVOICE = 100`) enforced in `Invoice::add_rating`.
  - metadata line-item cap (`MAX_METADATA_LINE_ITEMS = 100`) enforced in `validate_invoice_metadata`.
- Enforces consistent normalization behavior for tags (trim + lowercase + duplicate collapse/rejection across paths).
- Adds comprehensive regression tests for metadata/tag/rating bounds and normalization behavior in:
  - `quicklendx-contracts/src/test_invoice_metadata.rs`
  - `quicklendx-contracts/src/test_string_limits.rs`
- Updates invoice documentation with metadata bounds, normalization rules, and security notes in `docs/contracts/invoice.md`.
- Adds NatSpec-style Rust doc comments for public constants/items introduced in contract files.

## Security Notes
- Oversize metadata vectors are rejected before storage mutation to reduce storage-growth DoS risk.
- Tag canonicalization (trim/case normalization) is now enforced consistently to prevent ambiguous duplicate tags in query/index flows.
- Invoice rating growth is bounded to avoid unbounded per-invoice state expansion over time.

## Test Output
Command run:
`cd quicklendx-contracts && cargo test --verbose`

Result:
- Fails at compile stage due to a pre-existing parse error unrelated to this PR: `quicklendx-contracts/src/lib.rs:3237` (`unexpected closing delimiter: }`).
- New metadata-boundary/normalization tests are added and ready to run once baseline syntax issues are resolved.