### PR TITLE
test: add analytics boundary and empty-range behavior tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,7 @@
 target
+.omx/
+.remember/
+
+# Windows build artifacts (not part of the contract)
+*.exe
+*.pdb

--- a/docs/contracts/analytics-usage.md
+++ b/docs/contracts/analytics-usage.md
@@ -81,7 +81,87 @@ let (platform, performance) = contract.get_analytics_summary();
 contract.export_analytics_data("csv", filters); // Requires admin auth
 ```
 
+## TimePeriod Edge-Case & Boundary Semantics
+
+### Period Date Calculation
+
+`get_period_dates(current_timestamp, period)` uses **`saturating_sub`** for all
+arithmetic, so results are always valid `u64` pairs with `start ≤ end`.
+
+| Period    | Window formula                          |
+|-----------|-----------------------------------------|
+| Daily     | `[ts − 86_400, ts]`                     |
+| Weekly    | `[ts − 604_800, ts]`                    |
+| Monthly   | `[ts − 2_592_000, ts]`                  |
+| Quarterly | `[ts − 7_776_000, ts]`                  |
+| Yearly    | `[ts − 31_536_000, ts]`                 |
+| AllTime   | `[0, ts]` — entire history              |
+
+### Boundary Inclusion
+
+Both edges are **inclusive**:
+
+```
+invoice.created_at >= start_date && invoice.created_at <= end_date
+```
+
+An invoice created at exactly `start_date` or exactly `end_date` is always
+counted. An invoice one second before `start_date` is always excluded.
+
+### Near-Zero Timestamps (Saturating Underflow)
+
+When `current_timestamp` is smaller than the period's nominal duration the
+subtraction saturates to `0` rather than wrapping:
+
+```
+// ts = 1, Daily (86_400 s): 1.saturating_sub(86_400) = 0
+// window becomes [0, 1] — a one-second window, not a panic or overflow
+```
+
+At `current_timestamp = 0` every variant returns `(0, 0)` — a degenerate
+zero-length window. All query functions return zero/empty results in this state
+without panicking.
+
+### Zero-Length Ranges
+
+A zero-length range (`start == end`) is valid. When no invoices have
+`created_at == start == end`, every aggregated counter is 0. The contract never
+returns an error for degenerate windows.
+
+### Empty Range Guarantees
+
+Regardless of period or timestamp, if no data matches the window:
+
+- `total_volume`, `total_fees`, `total_profits` → `0`
+- `total_invoices`, `invoices_uploaded`, `investments_made` → `0`
+- `success_rate`, `default_rate`, `average_return_rate` → `0`
+- No panics, no unrecoverable errors.
+
+### Growth Stability
+
+- Stored reports are **immutable snapshots**. Adding invoices after a report is
+  generated never alters the stored copy.
+- `total_invoices` in `PlatformMetrics` grows monotonically: each successful
+  `store_invoice` call increases the count by exactly 1.
+- `AllTime` always captures every invoice ever stored, regardless of when
+  subsequent reports are generated.
+
+## Security Assumptions
+
+1. **No cross-business data leakage** — `generate_business_report` filters by
+   `business_address`; Business A's report never includes Business B's invoices.
+2. **Read-only analytics** — `get_platform_metrics`, `get_performance_metrics`,
+   `get_financial_metrics`, and `get_analytics_summary` require no auth and
+   expose only aggregated totals, not individual user records.
+3. **Admin-gated writes** — `update_platform_metrics` and
+   `update_performance_metrics` require admin authorization; unauthenticated
+   callers receive an error.
+4. **No sensitive data in reports** — Business and investor reports contain
+   aggregated statistics only; private invoice details and raw investment amounts
+   are not surfaced.
+
 ## Notes
 - Admin-only and authenticated functions require proper authorization.
 - All metrics and reports are available via the contract client interface.
-- See test_analytics.rs for comprehensive test coverage and usage patterns.
+- See `quicklendx-contracts/src/test/test_analytics.rs` for boundary/edge tests
+  and `src/test_analytics_consistency.rs` for business-report invariant tests.

--- a/quicklendx-contracts/src/analytics.rs
+++ b/quicklendx-contracts/src/analytics.rs
@@ -316,7 +316,13 @@ impl AnalyticsCalculator {
         v.min(10000).max(0)
     }
 
-    /// Calculate comprehensive platform metrics
+    /// Calculate a snapshot of comprehensive platform metrics from on-chain state.
+    ///
+    /// Iterates all invoices by status to derive totals, rates, and averages.
+    /// Returns zero for every field when the contract has no data (empty state).
+    ///
+    /// # Security
+    /// Read-only — no auth required. Does not expose individual user data.
     pub fn calculate_platform_metrics(env: &Env) -> Result<PlatformMetrics, QuickLendXError> {
         let current_timestamp = env.ledger().timestamp();
 
@@ -515,7 +521,20 @@ impl AnalyticsCalculator {
         })
     }
 
-    /// Calculate financial metrics
+    /// Calculate financial metrics for the given `TimePeriod`.
+    ///
+    /// Only invoices whose `created_at` falls within `[start_date, end_date]`
+    /// (both ends inclusive) contribute to volume, fees, and profits.
+    /// Returns all-zero fields when no invoices match the window.
+    ///
+    /// # Edge cases
+    /// - At `timestamp = 0`, every timed period produces `start == end == 0`; the
+    ///   window is degenerate (zero-length) and all totals will be zero.
+    /// - `AllTime` always uses `start = 0`, so it captures every invoice ever created.
+    ///
+    /// # Security
+    /// Read-only — no auth required. Aggregated totals only; no individual invoice
+    /// details are returned.
     pub fn calculate_financial_metrics(
         env: &Env,
         period: TimePeriod,
@@ -773,7 +792,25 @@ impl AnalyticsCalculator {
         })
     }
 
-    /// Generate business report
+    /// Generate and persist a `BusinessReport` for `business` over `period`.
+    ///
+    /// Counts invoices, funding events, volume, success/default rates, and
+    /// category breakdowns scoped to invoices whose `created_at` is within
+    /// the period window `[start_date, end_date]` (both inclusive).
+    ///
+    /// The report is stored on-chain and retrievable via `AnalyticsStorage::get_business_report`.
+    /// Each call produces a new report with a fresh ID; existing stored reports
+    /// are never mutated — they remain immutable snapshots of the ledger state
+    /// at the moment of generation.
+    ///
+    /// # Edge cases
+    /// - If no invoices fall within the period window, all counters are 0.
+    /// - A near-zero `current_timestamp` causes timed periods to saturate to
+    ///   `start = 0` via `saturating_sub`, making the window `[0, ts]`.
+    ///
+    /// # Security
+    /// Does not expose private user data from other businesses.
+    /// Callers should authenticate the business address before surfacing results.
     pub fn generate_business_report(
         env: &Env,
         business: &Address,
@@ -904,7 +941,14 @@ impl AnalyticsCalculator {
         Ok(report)
     }
 
-    /// Generate investor report
+    /// Generate and persist an `InvestorReport` for `investor` over `period`.
+    ///
+    /// Filters investments by `funded_at` within `[start_date, end_date]`.
+    /// Returns all-zero counts when the investor has no activity in the window.
+    /// Each call creates an immutable snapshot with a fresh report ID.
+    ///
+    /// # Security
+    /// Aggregated; does not expose other investors' private data.
     pub fn generate_investor_report(
         env: &Env,
         investor: &Address,
@@ -1086,7 +1130,25 @@ impl AnalyticsCalculator {
         Ok(())
     }
 
-    /// Get period dates based on time period
+    /// Compute `(start_date, end_date)` for `period` relative to `current_timestamp`.
+    ///
+    /// All arithmetic uses `saturating_sub` so the result is always well-defined:
+    ///
+    /// | Period    | start                         | end                |
+    /// |-----------|-------------------------------|--------------------|
+    /// | Daily     | `ts.saturating_sub(86_400)`   | `ts`               |
+    /// | Weekly    | `ts.saturating_sub(604_800)`  | `ts`               |
+    /// | Monthly   | `ts.saturating_sub(2_592_000)`| `ts`               |
+    /// | Quarterly | `ts.saturating_sub(7_776_000)`| `ts`               |
+    /// | Yearly    | `ts.saturating_sub(31_536_000)`| `ts`              |
+    /// | AllTime   | `0`                           | `ts`               |
+    ///
+    /// # Edge cases
+    /// - When `current_timestamp` is less than the period duration, `start`
+    ///   saturates to `0`, producing a shorter-than-nominal window.
+    /// - At `current_timestamp = 0`, every variant returns `(0, 0)` — a
+    ///   degenerate zero-length window. Callers must handle this gracefully.
+    /// - `AllTime` always returns `start = 0`, capturing the full history.
     pub fn get_period_dates(current_timestamp: u64, period: TimePeriod) -> (u64, u64) {
         match period {
             TimePeriod::Daily => {

--- a/quicklendx-contracts/src/lib.rs
+++ b/quicklendx-contracts/src/lib.rs
@@ -96,6 +96,8 @@ mod test_max_invoices_per_business;
 // #[cfg(test)]
 // mod test_notifications;
 // #[cfg(test)]
+#[cfg(test)]
+mod test_analytics_consistency;
 mod test_bid_ranking;
 pub mod types;
 mod verification;

--- a/quicklendx-contracts/src/test.rs
+++ b/quicklendx-contracts/src/test.rs
@@ -1,7 +1,7 @@
 // Analytics test suites - these modules are activated via lib.rs
 // (mod test_analytics_consistency) and via the integration-test path
 // once all client methods have been exported.
-// mod test_analytics;
+mod test_analytics;
 // mod test_analytics_export_query;
 // mod test_business_report_consistency;
 // Temporarily disabled: these suites target legacy client return shapes/APIs.

--- a/quicklendx-contracts/src/test/test_analytics.rs
+++ b/quicklendx-contracts/src/test/test_analytics.rs
@@ -1,815 +1,530 @@
-/// Focused analytics tests for investor report consistency.
+/// Analytics boundary and empty-range behavior tests (Issue #785).
 ///
-/// Coverage:
-/// - Investor report generation from persisted investments
-/// - Persistence and retrieval round-trips
-/// - Deterministic repeated generation for the same ledger snapshot
-/// - Empty-history investors
-/// - Period filtering
-/// - Business report persistence regression
+/// Covers all `TimePeriod` edge cases, zero-length period ranges,
+/// empty-window queries, and stability under data growth.
+///
+/// Test inventory:
+///  1.  All periods at ts=0 saturate to (start=0, end=0)
+///  2.  Daily at exactly ts=86_400 — window [0, 86_400]
+///  3.  Weekly at exactly ts=7×86_400
+///  4.  Monthly at exactly ts=30×86_400
+///  5.  Quarterly at exactly ts=90×86_400
+///  6.  Yearly at exactly ts=365×86_400
+///  7.  AllTime start is always 0, end always equals ts
+///  8.  Invariant: start ≤ end for every period and representative timestamp
+///  9.  Large timestamp (mid-u64) — no overflow on any period
+/// 10.  Zero-length window: AllTime at genesis (start==end==0)
+/// 11.  ts=1 — every timed period saturates start to 0
+/// 12.  Invoice created at exactly start_date is included (≥ boundary)
+/// 13.  Invoice created one second before start_date is excluded
+/// 14.  Invoice created at exactly end_date is included (≤ boundary)
+/// 15.  Business report over empty daily window returns all-zero counts
+/// 16.  Old invoices outside daily window are excluded from the report
+/// 17.  Financial metrics return zero volume for an empty daily window
+/// 18.  Financial metrics AllTime returns zero when there are no invoices
+/// 19.  Investor report over an empty period returns zero investments
+/// 20.  Platform metrics on a fresh contract are all zero
+/// 21.  Stored business report is immutable after new invoices are added
+/// 22.  total_invoices grows by exactly one per upload
+/// 23.  AllTime captures every invoice as the dataset grows
+/// 24.  Two reports generated at the same timestamp have identical data
+/// 25.  Analytics summary platform field matches get_platform_metrics
+/// 26.  Business A report never includes Business B invoices
+/// 27.  Financial metrics daily window excludes invoices older than 24 h
 use super::*;
-use crate::analytics::TimePeriod;
-use crate::investment::{Investment, InvestmentStatus, InvestmentStorage};
-use crate::invoice::{InvoiceCategory, InvoiceStatus};
+use crate::analytics::{AnalyticsCalculator, TimePeriod};
+use crate::invoice::InvoiceCategory;
 use soroban_sdk::{
     testutils::{Address as _, Ledger},
-    Address, BytesN, Env, String, Vec,
+    Address, Env, String, Vec,
 };
 
-fn setup_contract(env: &Env) -> (QuickLendXContractClient<'_>, Address, Address) {
+// ─── helpers ──────────────────────────────────────────────────────────────────
+
+fn setup(env: &Env) -> (QuickLendXContractClient<'_>, Address, Address) {
     let contract_id = env.register(QuickLendXContract, ());
-    let client = QuickLendXContractClient::new(&env, &contract_id);
-
-    let admin = Address::generate(&env);
-    let business = Address::generate(&env);
-    let currency = Address::generate(&env);
-
+    let client = QuickLendXContractClient::new(env, &contract_id);
+    let admin = Address::generate(env);
+    let business = Address::generate(env);
+    env.mock_all_auths();
     client.set_admin(&admin);
-    client.submit_kyc_application(&business, &String::from_str(&env, "Business KYC"));
-    client.verify_business(&admin, &business);
-
-    (env, client, admin, business, currency)
+    (client, admin, business)
 }
 
-fn upload_invoice(
+fn upload(
     env: &Env,
     client: &QuickLendXContractClient,
     business: &Address,
-    currency: &Address,
     amount: i128,
-    category: InvoiceCategory,
-    description: &str,
-) -> BytesN<32> {
+    desc: &str,
+) -> soroban_sdk::BytesN<32> {
     let currency = Address::generate(env);
     let due_date = env.ledger().timestamp() + 86_400;
     client.store_invoice(
         business,
         &amount,
-        currency,
-        &(env.ledger().timestamp() + 86_400),
-        &String::from_str(env, description),
-        &category,
+        &currency,
+        &due_date,
+        &String::from_str(env, desc),
+        &InvoiceCategory::Services,
         &Vec::new(env),
     )
 }
 
-// ============================================================================
-// PLATFORM METRICS TESTS
-// ============================================================================
+// ─── 1–9: TimePeriod edge arithmetic (pure — no contract needed) ──────────────
 
+/// 1. Every period at ts=0 saturates via saturating_sub to (start=0, end=0).
 #[test]
-fn test_platform_metrics_empty_data() {
-    let env = Env::default();
-    let (client, _admin, _business) = setup_contract(&env);
-
-    let metrics = client.get_platform_metrics().unwrap();
-    assert_eq!(metrics.total_invoices, 0);
-    assert_eq!(metrics.total_investments, 0);
-    assert_eq!(metrics.total_volume, 0);
-    assert_eq!(metrics.total_fees_collected, 0);
-    assert_eq!(metrics.average_invoice_amount, 0);
-    assert_eq!(metrics.average_investment_amount, 0);
-    assert_eq!(metrics.success_rate, 0);
-    assert_eq!(metrics.default_rate, 0);
+fn test_period_all_variants_at_zero_timestamp() {
+    for period in [
+        TimePeriod::Daily,
+        TimePeriod::Weekly,
+        TimePeriod::Monthly,
+        TimePeriod::Quarterly,
+        TimePeriod::Yearly,
+        TimePeriod::AllTime,
+    ] {
+        let (start, end) = AnalyticsCalculator::get_period_dates(0, period.clone());
+        assert_eq!(start, 0, "{period:?} start at ts=0 must be 0");
+        assert_eq!(end, 0, "{period:?} end at ts=0 must be 0");
+    }
 }
 
+/// 2. Daily at ts == 86_400 yields exactly a 24-hour window starting at 0.
 #[test]
-fn test_platform_metrics_empty_summary_defaults() {
-    let env = Env::default();
-    let (platform, performance) = crate::get_analytics_summary(env);
-
-    let metrics = client.get_platform_metrics().unwrap();
-    assert_eq!(metrics.total_invoices, 3);
-    assert_eq!(metrics.total_volume, 6000);
-    assert_eq!(metrics.average_invoice_amount, 2000);
+fn test_period_daily_at_exactly_one_day() {
+    let ts = 86_400u64;
+    let (start, end) = AnalyticsCalculator::get_period_dates(ts, TimePeriod::Daily);
+    assert_eq!(start, 0);
+    assert_eq!(end, ts);
+    assert_eq!(end - start, 86_400);
 }
 
+/// 3. Weekly at ts == 7×86_400 yields exactly a 7-day window.
 #[test]
-fn test_platform_metrics_with_multiple_invoices() {
-    let (env, client, _admin, business, currency) = setup();
-
-    upload_invoice(
-        &env,
-        &client,
-        &business,
-        &currency,
-        1_000,
-        InvoiceCategory::Services,
-        "Invoice A",
-    );
-    upload_invoice(
-        &env,
-        &client,
-        &business,
-        &currency,
-        2_000,
-        InvoiceCategory::Technology,
-        "Invoice B",
-    );
-
-    let metrics = client.get_platform_metrics().unwrap();
-    assert_eq!(metrics.total_invoices, 2);
-    // Investments include invoices that are Funded, Paid, or Defaulted
-    assert_eq!(metrics.total_investments, 2);
+fn test_period_weekly_at_exactly_one_week() {
+    let ts = 7 * 86_400u64;
+    let (start, end) = AnalyticsCalculator::get_period_dates(ts, TimePeriod::Weekly);
+    assert_eq!(start, 0);
+    assert_eq!(end, ts);
+    assert_eq!(end - start, 7 * 86_400);
 }
 
+/// 4. Monthly at ts == 30×86_400 yields exactly a 30-day window.
 #[test]
-fn test_platform_metrics_success_rate_paid_only_sparse_data() {
-    let env = Env::default();
-    let (client, _admin, business) = setup_contract(&env);
-
-    let inv1 = create_invoice(&env, &client, &business, 1000, "Paid-only inv");
-    client.update_invoice_status(&inv1, &InvoiceStatus::Verified);
-    client.update_invoice_status(&inv1, &InvoiceStatus::Funded);
-    client.update_invoice_status(&inv1, &InvoiceStatus::Paid);
-
-    let metrics = client.get_platform_metrics();
-    assert_eq!(metrics.total_invoices, 1);
-    assert_eq!(metrics.total_investments, 1);
-    assert_eq!(metrics.success_rate, 10000);
-    assert_eq!(metrics.default_rate, 0);
+fn test_period_monthly_at_exactly_thirty_days() {
+    let ts = 30 * 86_400u64;
+    let (start, end) = AnalyticsCalculator::get_period_dates(ts, TimePeriod::Monthly);
+    assert_eq!(start, 0);
+    assert_eq!(end, ts);
+    assert_eq!(end - start, 30 * 86_400);
 }
 
+/// 5. Quarterly at ts == 90×86_400 yields exactly a 90-day window.
 #[test]
-fn test_platform_metrics_default_rate_defaulted_only_sparse_data() {
-    let env = Env::default();
-    let (client, _admin, business) = setup_contract(&env);
-
-    let inv1 = create_invoice(&env, &client, &business, 1000, "Defaulted-only inv");
-    client.update_invoice_status(&inv1, &InvoiceStatus::Verified);
-    client.update_invoice_status(&inv1, &InvoiceStatus::Funded);
-    client.update_invoice_status(&inv1, &InvoiceStatus::Defaulted);
-
-    let metrics = client.get_platform_metrics();
-    assert_eq!(metrics.total_invoices, 1);
-    assert_eq!(metrics.total_investments, 1);
-    assert_eq!(metrics.success_rate, 0);
-    assert_eq!(metrics.default_rate, 10000);
+fn test_period_quarterly_at_exactly_ninety_days() {
+    let ts = 90 * 86_400u64;
+    let (start, end) = AnalyticsCalculator::get_period_dates(ts, TimePeriod::Quarterly);
+    assert_eq!(start, 0);
+    assert_eq!(end, ts);
+    assert_eq!(end - start, 90 * 86_400);
 }
 
+/// 6. Yearly at ts == 365×86_400 yields exactly a 365-day window.
 #[test]
-fn test_platform_metrics_success_and_default_rates_mixed_sparse_data() {
-    let env = Env::default();
-    let (client, _admin, business) = setup_contract(&env);
-
-    let inv_paid = create_invoice(&env, &client, &business, 1000, "Mixed paid");
-    client.update_invoice_status(&inv_paid, &InvoiceStatus::Verified);
-    client.update_invoice_status(&inv_paid, &InvoiceStatus::Funded);
-    client.update_invoice_status(&inv_paid, &InvoiceStatus::Paid);
-
-    let inv_defaulted = create_invoice(&env, &client, &business, 1000, "Mixed defaulted");
-    client.update_invoice_status(&inv_defaulted, &InvoiceStatus::Verified);
-    client.update_invoice_status(&inv_defaulted, &InvoiceStatus::Funded);
-    client.update_invoice_status(&inv_defaulted, &InvoiceStatus::Defaulted);
-
-    let metrics = client.get_platform_metrics();
-    assert_eq!(metrics.total_invoices, 2);
-    assert_eq!(metrics.total_investments, 2);
-    assert_eq!(metrics.success_rate, 5000);
-    assert_eq!(metrics.default_rate, 5000);
+fn test_period_yearly_at_exactly_three_sixty_five_days() {
+    let ts = 365 * 86_400u64;
+    let (start, end) = AnalyticsCalculator::get_period_dates(ts, TimePeriod::Yearly);
+    assert_eq!(start, 0);
+    assert_eq!(end, ts);
+    assert_eq!(end - start, 365 * 86_400);
 }
 
-// ============================================================================
-// PERFORMANCE METRICS TESTS
-// ============================================================================
-
+/// 7. AllTime always returns (0, ts) regardless of the current timestamp.
 #[test]
-fn test_performance_metrics_empty_data() {
-    let env = Env::default();
-    let (client, _admin, _business) = setup_contract(&env);
-
-    let metrics = client.get_performance_metrics().unwrap();
-    assert_eq!(metrics.average_settlement_time, 0);
-    assert_eq!(metrics.average_verification_time, 0);
-    assert_eq!(metrics.dispute_resolution_time, 0);
-    assert_eq!(metrics.transaction_success_rate, 0);
-    assert_eq!(metrics.error_rate, 0);
-    assert_eq!(metrics.user_satisfaction_score, 0);
+fn test_period_alltime_start_always_zero_end_always_ts() {
+    for ts in [0u64, 1, 86_400, 1_000_000, u64::MAX / 2] {
+        let (start, end) = AnalyticsCalculator::get_period_dates(ts, TimePeriod::AllTime);
+        assert_eq!(start, 0, "AllTime start must be 0 at ts={ts}");
+        assert_eq!(end, ts, "AllTime end must equal ts={ts}");
+    }
 }
 
+/// 8. Invariant: start ≤ end for every period at every representative timestamp.
 #[test]
-fn test_performance_metrics_with_invoices() {
-    let env = Env::default();
-    let (client, _admin, business) = setup_contract(&env);
-
-    let inv1 = create_invoice(&env, &client, &business, 1000, "Perf inv 1");
-    let inv2 = create_invoice(&env, &client, &business, 2000, "Perf inv 2");
-
-    // One paid, one defaulted
-    client.update_invoice_status(&inv1, &InvoiceStatus::Paid);
-    client.update_invoice_status(&inv2, &InvoiceStatus::Defaulted);
-
-    let metrics = client.get_performance_metrics().unwrap();
-    // 1 paid out of 2 total = 50% = 5000 bps
-    assert_eq!(metrics.transaction_success_rate, 5000);
-    // 1 defaulted out of 2 total = 50% = 5000 bps
-    assert_eq!(metrics.error_rate, 5000);
-}
-
-// ============================================================================
-// USER BEHAVIOR METRICS TESTS
-// ============================================================================
-
-#[test]
-fn test_user_behavior_new_user() {
-    let env = Env::default();
-    let (client, _admin, _business) = setup_contract(&env);
-
-    let new_user = Address::generate(&env);
-    let behavior = client.get_user_behavior_metrics(&new_user);
-
-    assert_eq!(behavior.user_address, new_user);
-    assert_eq!(behavior.total_invoices_uploaded, 0);
-    assert_eq!(behavior.total_investments_made, 0);
-    assert_eq!(behavior.total_bids_placed, 0);
-    assert_eq!(behavior.last_activity, 0);
-    assert_eq!(behavior.risk_score, 25); // low default risk
-}
-
-#[test]
-fn test_user_behavior_metrics_tracks_uploaded_invoices() {
-    let (env, client, _admin, business, currency) = setup();
-
-    upload_invoice(
-        &env,
-        &client,
-        &business,
-        &currency,
-        1_000,
-        InvoiceCategory::Services,
-        "Behavior invoice 1",
-    );
-    upload_invoice(
-        &env,
-        &client,
-        &business,
-        &currency,
-        2_500,
-        InvoiceCategory::Consulting,
-        "Behavior invoice 2",
-    );
-
-    let metrics = crate::get_user_behavior_metrics(env.clone(), business.clone());
-    assert_eq!(metrics.user_address, business);
-    assert_eq!(metrics.total_invoices_uploaded, 2);
-    assert_eq!(metrics.total_investments_made, 0);
-    assert_eq!(metrics.risk_score, 25);
-    assert!(metrics.last_activity > 0);
-}
-
-#[test]
-fn test_financial_metrics_respects_period_filter_and_categories() {
-    let (env, client, _admin, business, currency) = setup();
-
-    let old_invoice = upload_invoice(
-        &env,
-        &client,
-        &business,
-        &currency,
-        1_000,
-        InvoiceCategory::Services,
-        "Old invoice",
-    );
-    let mut old = InvoiceStorage::get_invoice(&env, &old_invoice).unwrap();
-    old.created_at = env.ledger().timestamp() - (31 * 24 * 60 * 60);
-    InvoiceStorage::store_invoice(&env, &old);
-
-    upload_invoice(
-        &env,
-        &client,
-        &business,
-        &currency,
-        2_500,
-        InvoiceCategory::Technology,
-        "Recent invoice",
-    );
-
-    let monthly = crate::get_financial_metrics(env.clone(), TimePeriod::Monthly);
-    assert_eq!(monthly.total_volume, 2_500);
-
-    let mut technology_volume = 0i128;
-    for (category, volume) in monthly.volume_by_category.iter() {
-        if category == InvoiceCategory::Technology {
-            technology_volume = volume;
+fn test_period_start_never_exceeds_end_invariant() {
+    let timestamps = [0u64, 1, 86_399, 86_400, 86_401, 7 * 86_400, 1_000_000, u64::MAX / 2];
+    for ts in timestamps {
+        for period in [
+            TimePeriod::Daily,
+            TimePeriod::Weekly,
+            TimePeriod::Monthly,
+            TimePeriod::Quarterly,
+            TimePeriod::Yearly,
+            TimePeriod::AllTime,
+        ] {
+            let (start, end) = AnalyticsCalculator::get_period_dates(ts, period.clone());
+            assert!(
+                start <= end,
+                "{period:?} at ts={ts}: start({start}) > end({end})"
+            );
         }
     }
-    assert_eq!(technology_volume, 2_500);
-
-    let all_time = crate::get_financial_metrics(env, TimePeriod::AllTime);
-    assert_eq!(all_time.total_volume, 3_500);
 }
 
+/// 9. A large timestamp (mid-u64) never causes overflow on any period.
 #[test]
-fn test_performance_metrics_reflect_paid_and_defaulted_invoices() {
-    let (env, client, _admin, business, currency) = setup();
-
-    let paid_invoice = upload_invoice(
-        &env,
-        &client,
-        &business,
-        &currency,
-        1_000,
-        InvoiceCategory::Services,
-        "Paid invoice",
-    );
-    let defaulted_invoice = upload_invoice(
-        &env,
-        &client,
-        &business,
-        &currency,
-        2_000,
-        InvoiceCategory::Services,
-        "Defaulted invoice",
-    );
-
-    client.update_invoice_status(&paid_invoice, &InvoiceStatus::Paid);
-    client.update_invoice_status(&defaulted_invoice, &InvoiceStatus::Defaulted);
-
-    let metrics = AnalyticsCalculator::calculate_performance_metrics(&env).unwrap();
-    assert_eq!(metrics.transaction_success_rate, 5_000);
-    assert_eq!(metrics.error_rate, 5_000);
+fn test_period_large_timestamp_no_overflow() {
+    let ts = u64::MAX / 2;
+    for period in [
+        TimePeriod::Daily,
+        TimePeriod::Weekly,
+        TimePeriod::Monthly,
+        TimePeriod::Quarterly,
+        TimePeriod::Yearly,
+        TimePeriod::AllTime,
+    ] {
+        let (start, end) = AnalyticsCalculator::get_period_dates(ts, period.clone());
+        assert!(start <= end, "{period:?} at ts={ts}: start > end");
+        assert_eq!(end, ts, "{period:?} end must equal ts");
+    }
 }
 
+// ─── 10–11: Zero-length and near-zero ranges ──────────────────────────────────
+
+/// 10. At genesis (ts=0), AllTime yields a degenerate window where start == end == 0.
 #[test]
-fn test_business_report_generation_matches_invoice_state() {
-    let (env, client, _admin, business, currency) = setup();
-
-    let funded = upload_invoice(
-        &env,
-        &client,
-        &business,
-        &currency,
-        1_000,
-        InvoiceCategory::Services,
-        "Funded invoice",
-    );
-    client.update_invoice_status(&funded, &InvoiceStatus::Funded);
-
-    let paid = upload_invoice(
-        &env,
-        &client,
-        &business,
-        &currency,
-        2_000,
-        InvoiceCategory::Technology,
-        "Paid invoice",
-    );
-    client.update_invoice_status(&paid, &InvoiceStatus::Paid);
-
-    let report =
-        crate::generate_business_report(env.clone(), business.clone(), TimePeriod::AllTime)
-            .unwrap();
-
-    assert_eq!(report.business_address, business);
-    assert_eq!(report.invoices_uploaded, 2);
-    assert_eq!(report.invoices_funded, 1);
-    assert_eq!(report.total_volume, 3000);
-}
-
-#[test]
-fn test_business_report_stored_and_retrievable() {
-    let env = Env::default();
-    env.ledger().set_timestamp(1_000_000);
-    let (client, _admin, business) = setup_contract(&env);
-
-    create_invoice(&env, &client, &business, 5_000, "Business report invoice");
-
-    let generated = client.generate_business_report(&business, &TimePeriod::AllTime);
-    let stored = client
-        .get_business_report(&generated.report_id)
-        .expect("generated business report must be stored");
-
-    assert_eq!(stored.report_id, generated.report_id);
-    assert_eq!(stored.business_address, generated.business_address);
-    assert_eq!(stored.invoices_uploaded, 1);
-    assert_eq!(stored.total_volume, 5_000);
-}
-
-#[test]
-fn test_investor_report_empty_history_is_stored_and_retrievable() {
-    let env = Env::default();
-    env.ledger().set_timestamp(2_000_000);
-    let (client, _admin, _business) = setup_contract(&env);
-
-    let investor = Address::generate(&env);
-    let generated = client.generate_investor_report(&investor, &TimePeriod::Monthly);
-    let stored = client
-        .get_investor_report(&generated.report_id)
-        .expect("empty-history investor report must be stored");
-
-#[test]
-fn test_performance_metrics_storage_round_trip() {
-    let env = Env::default();
-    let contract_id = env.register(QuickLendXContract, ());
-    let client = QuickLendXContractClient::new(&env, &contract_id);
-
-    let admin = Address::generate(&env);
-    env.mock_all_auths();
-    client.set_admin(&admin);
-
-    // Admin updates performance metrics
-    client.update_performance_metrics();
-
-    // Result should be retrievable via summary
-    let summary = client.get_analytics_summary();
-    assert_eq!(summary.1.average_settlement_time, 0);
-    assert_eq!(summary.1.user_satisfaction_score, 0);
-}
-
-// ============================================================================
-// ADMIN-ONLY UPDATE TESTS
-// ============================================================================
-
-#[test]
-fn test_update_platform_metrics_requires_admin() {
-    let env = Env::default();
-    let contract_id = env.register(QuickLendXContract, ());
-    let client = QuickLendXContractClient::new(&env, &contract_id);
-
-    // No admin set - should fail
-    let result = client.try_update_platform_metrics();
-    assert!(result.is_err());
-}
-
-#[test]
-fn test_update_performance_metrics_requires_admin() {
-    let env = Env::default();
-    let contract_id = env.register(QuickLendXContract, ());
-    let client = QuickLendXContractClient::new(&env, &contract_id);
-
-    // No admin set - should fail
-    let result = client.try_update_performance_metrics();
-    assert!(result.is_err());
-}
-
-// ============================================================================
-// PERIOD DATE CALCULATION TESTS
-// ============================================================================
-
-#[test]
-fn test_period_dates_all_periods() {
-    // Use a timestamp large enough that yearly subtraction won't underflow
-    let current_timestamp: u64 = 100_000_000;
-
-    let (start, end) = AnalyticsCalculator::get_period_dates(current_timestamp, TimePeriod::Daily);
-    assert_eq!(end, current_timestamp);
-    assert_eq!(start, current_timestamp - 86400);
-
-    let (start, end) = AnalyticsCalculator::get_period_dates(current_timestamp, TimePeriod::Weekly);
-    assert_eq!(end, current_timestamp);
-    assert_eq!(start, current_timestamp - 7 * 86400);
-
-    let (start, end) =
-        AnalyticsCalculator::get_period_dates(current_timestamp, TimePeriod::Monthly);
-    assert_eq!(end, current_timestamp);
-    assert_eq!(start, current_timestamp - 30 * 86400);
-
-    let (start, end) =
-        AnalyticsCalculator::get_period_dates(current_timestamp, TimePeriod::Quarterly);
-    assert_eq!(end, current_timestamp);
-    assert_eq!(start, current_timestamp - 90 * 86400);
-
-    let (start, end) = AnalyticsCalculator::get_period_dates(current_timestamp, TimePeriod::Yearly);
-    assert_eq!(end, current_timestamp);
-    assert_eq!(start, current_timestamp - 365 * 86400);
-}
-
-#[test]
-fn test_period_dates_all_time() {
-    let current_timestamp: u64 = 500_000;
-
-    let (start, end) =
-        AnalyticsCalculator::get_period_dates(current_timestamp, TimePeriod::AllTime);
+fn test_zero_length_alltime_range_at_genesis() {
+    let (start, end) = AnalyticsCalculator::get_period_dates(0, TimePeriod::AllTime);
     assert_eq!(start, 0);
-    assert_eq!(end, current_timestamp);
+    assert_eq!(end, 0);
+    // Degenerate: the window has zero width.
+    assert_eq!(start, end);
 }
 
-// ============================================================================
-// ANALYTICS SUMMARY TEST
-// ============================================================================
-
+/// 11. At ts=1 every timed period's start saturates to 0 (window smaller than duration).
 #[test]
-fn test_analytics_summary_returns_tuple() {
+fn test_period_all_timed_near_zero_saturate_start_to_zero() {
+    for period in [
+        TimePeriod::Daily,
+        TimePeriod::Weekly,
+        TimePeriod::Monthly,
+        TimePeriod::Quarterly,
+        TimePeriod::Yearly,
+    ] {
+        let (start, end) = AnalyticsCalculator::get_period_dates(1, period.clone());
+        assert_eq!(start, 0, "{period:?} at ts=1 must saturate to start=0");
+        assert_eq!(end, 1);
+    }
+}
+
+// ─── 12–14: Period boundary inclusion / exclusion ─────────────────────────────
+
+/// 12. An invoice created at exactly start_date (≥ boundary) is included.
+///
+/// Daily window for a report at ts=T is [T-86_400, T].
+/// Upload at ts=T-86_400 so created_at == start_date, then report at ts=T.
+#[test]
+fn test_invoice_at_exact_start_date_is_included() {
     let env = Env::default();
-    let (client, _admin, business) = setup_contract(&env);
+    let day = 86_400u64;
+    env.ledger().set_timestamp(day);
+    let (client, _, business) = setup(&env);
+    upload(&env, &client, &business, 1_000, "start-boundary");
 
-    create_invoice(&env, &client, &business, 1000, "Summary inv");
-
-    let (platform, performance) = client.get_analytics_summary();
-    assert_eq!(platform.total_invoices, 1);
-    assert_eq!(platform.total_volume, 1000);
-    // Performance should still be default / calculated
-    assert_eq!(performance.average_settlement_time, 0);
-}
-
-
-
-// ============================================================================
-// PLATFORM METRICS
-// ============================================================================
-
-#[test]
-fn test_platform_metrics_empty_state() {
-    let env = Env::default();
-    let (client, _, _) = setup_contract(&env);
-
-    let metrics = client.get_platform_metrics().unwrap();
-
-    assert_eq!(metrics.total_invoices, 0);
-    assert_eq!(metrics.total_investments, 0);
-    assert_eq!(metrics.total_volume, 0);
-    assert_eq!(metrics.total_fees_collected, 0);
-    assert_eq!(metrics.average_invoice_amount, 0);
-    assert_eq!(metrics.average_investment_amount, 0);
-    assert_eq!(metrics.success_rate, 0);
-    assert_eq!(metrics.default_rate, 0);
-}
-
-#[test]
-fn test_platform_metrics_update() {
-    let env = Env::default();
-    let (client, admin, _) = setup_contract(&env);
-
-    env.mock_all_auths();
-    client.set_admin(&admin);
-
-    client.update_platform_metrics();
-
-    let metrics = client.get_platform_metrics().unwrap();
-
-    assert!(metrics.total_invoices >= 0);
-    assert!(metrics.total_volume >= 0);
-}
-
-// ============================================================================
-// PERFORMANCE METRICS
-// ============================================================================
-
-#[test]
-fn test_performance_metrics_empty_state() {
-    let env = Env::default();
-    let (client, _, _) = setup_contract(&env);
-
-    let metrics = client.get_performance_metrics().unwrap();
-
-    assert_eq!(metrics.average_settlement_time, 0);
-    assert_eq!(metrics.average_verification_time, 0);
-    assert_eq!(metrics.dispute_resolution_time, 0);
-    assert_eq!(metrics.transaction_success_rate, 0);
-    assert_eq!(metrics.error_rate, 0);
-    assert_eq!(metrics.user_satisfaction_score, 0);
-}
-
-#[test]
-fn test_performance_metrics_update() {
-    let env = Env::default();
-    let (client, admin, _) = setup_contract(&env);
-
-    env.mock_all_auths();
-    client.set_admin(&admin);
-
-    client.update_performance_metrics();
-
-    let metrics = client.get_performance_metrics().unwrap();
-
-    assert!(metrics.transaction_success_rate >= 0);
-    assert!(metrics.error_rate >= 0);
-}
-
-// ============================================================================
-// ANALYTICS SUMMARY (ISSUE#600)
-// ============================================================================
-
-#[test]
-fn test_analytics_summary_empty_state_fallback() {
-    let env = Env::default();
-    let (client, _, _) = setup_contract(&env);
-
-    let (platform, performance) = client.get_analytics_summary();
-
-    assert_eq!(platform.total_invoices, 0);
-    assert_eq!(platform.total_investments, 0);
-    assert_eq!(platform.total_volume, 0);
-    assert_eq!(platform.total_fees_collected, 0);
-    assert_eq!(platform.average_invoice_amount, 0);
-    assert_eq!(platform.average_investment_amount, 0);
-    assert_eq!(platform.success_rate, 0);
-    assert_eq!(platform.default_rate, 0);
-
-    assert_eq!(performance.average_settlement_time, 0);
-    assert_eq!(performance.average_verification_time, 0);
-    assert_eq!(performance.dispute_resolution_time, 0);
-    assert_eq!(performance.transaction_success_rate, 0);
-    assert_eq!(performance.error_rate, 0);
-    assert_eq!(performance.user_satisfaction_score, 0);
-}
-
-#[test]
-fn test_analytics_summary_after_updates() {
-    let env = Env::default();
-    let (client, admin, _) = setup_contract(&env);
-
-    env.mock_all_auths();
-    client.set_admin(&admin);
-
-    client.update_platform_metrics();
-    client.update_performance_metrics();
-
-    let (platform, performance) = client.get_analytics_summary();
-
-    assert!(platform.total_invoices >= 0);
-    assert!(performance.transaction_success_rate >= 0);
-}
-// ============================================================================
-// USER BEHAVIOR UPDATE AND STORAGE TEST
-// ============================================================================
-
-#[test]
-fn test_update_user_behavior_metrics() {
-    let env = Env::default();
-    let (client, _admin, business) = setup_contract(&env);
-
-    create_invoice(&env, &client, &business, 1000, "Update behavior inv");
-
-    // Update stores the behavior
-    client.update_user_behavior_metrics(&business);
-
-    // Subsequent get should reflect stored data
-    let behavior = client.get_user_behavior_metrics(&business);
-    assert_eq!(behavior.total_invoices_uploaded, 1);
-}
-
-// ============================================================================
-// ANALYTICS TRENDS AND TIME PERIODS TESTS (Issue #365)
-// ============================================================================
-
-#[test]
-fn test_time_period_daily_calculation() {
-    let current_timestamp: u64 = 1_000_000;
-    let (start, end) = AnalyticsCalculator::get_period_dates(current_timestamp, TimePeriod::Daily);
-
-    assert_eq!(end, current_timestamp);
-    assert_eq!(start, current_timestamp - 86400); // 24 hours in seconds
-    assert_eq!(end - start, 86400);
-}
-
-#[test]
-fn test_time_period_weekly_calculation() {
-    let current_timestamp: u64 = 1_000_000;
-    let (start, end) = AnalyticsCalculator::get_period_dates(current_timestamp, TimePeriod::Weekly);
-
-    assert_eq!(end, current_timestamp);
-    assert_eq!(start, current_timestamp - 7 * 86400); // 7 days
-    assert_eq!(end - start, 7 * 86400);
-}
-
-#[test]
-fn test_time_period_monthly_calculation() {
-    let current_timestamp: u64 = 10_000_000;
-    let (start, end) =
-        AnalyticsCalculator::get_period_dates(current_timestamp, TimePeriod::Monthly);
-
-    assert_eq!(end, current_timestamp);
-    assert_eq!(start, current_timestamp - 30 * 86400); // 30 days
-    assert_eq!(end - start, 30 * 86400);
-}
-
-#[test]
-fn test_investor_report_generation_is_consistent_for_same_snapshot() {
-    let env = Env::default();
-    env.ledger().set_timestamp(3_000_000);
-    let (client, _admin, business) = setup_contract(&env);
-
-    let investor = Address::generate(&env);
-    let invoice_id = create_invoice(&env, &client, &business, 10_000, "Consistent report invoice");
-    client.update_invoice_status(&invoice_id, &InvoiceStatus::Paid);
-    seed_investment(
-        &env,
-        &client,
-        &investor,
-        &invoice_id,
-        8_000,
-        env.ledger().timestamp(),
-        InvestmentStatus::Completed,
+    env.ledger().set_timestamp(2 * day);
+    let report = client.generate_business_report(&business, &TimePeriod::Daily);
+    assert_eq!(
+        report.invoices_uploaded, 1,
+        "invoice at exact start_date must be included"
     );
-
-    let first = client.generate_investor_report(&investor, &TimePeriod::AllTime);
-    let second = client.generate_investor_report(&investor, &TimePeriod::AllTime);
-
-    assert_ne!(first.report_id, second.report_id);
-    assert_investor_reports_match_except_id(&first, &second);
 }
 
+/// 13. An invoice created one second before start_date falls outside the window.
 #[test]
-fn test_investor_report_persistence_matches_generated_snapshot() {
+fn test_invoice_one_second_before_start_date_is_excluded() {
     let env = Env::default();
-    env.ledger().set_timestamp(4_000_000);
-    let (client, _admin, business) = setup_contract(&env);
+    let day = 86_400u64;
+    // Upload at day-1, which will be one second before the daily start (day).
+    env.ledger().set_timestamp(day - 1);
+    let (client, _, business) = setup(&env);
+    upload(&env, &client, &business, 1_000, "before-boundary");
 
-    let investor = Address::generate(&env);
-
-    let paid_invoice = create_invoice(&env, &client, &business, 20_000, "Paid investment");
-    client.update_invoice_status(&paid_invoice, &InvoiceStatus::Paid);
-    seed_investment(
-        &env,
-        &client,
-        &investor,
-        &paid_invoice,
-        15_000,
-        env.ledger().timestamp(),
-        InvestmentStatus::Completed,
+    // Report at 2*day: daily window is [day, 2*day]; invoice at day-1 is outside.
+    env.ledger().set_timestamp(2 * day);
+    let report = client.generate_business_report(&business, &TimePeriod::Daily);
+    assert_eq!(
+        report.invoices_uploaded, 0,
+        "invoice one second before start_date must be excluded"
     );
-
-    let defaulted_invoice = create_invoice(&env, &client, &business, 12_000, "Defaulted investment");
-    client.update_invoice_status(&defaulted_invoice, &InvoiceStatus::Defaulted);
-    seed_investment(
-        &env,
-        &client,
-        &investor,
-        &defaulted_invoice,
-        9_000,
-        env.ledger().timestamp(),
-        InvestmentStatus::Defaulted,
-    );
-
-    let generated = client.generate_investor_report(&investor, &TimePeriod::AllTime);
-    let stored = client
-        .get_investor_report(&generated.report_id)
-        .expect("generated report must be persisted");
-
-    assert_eq!(stored.report_id, generated.report_id);
-    assert_investor_reports_match_except_id(&generated, &stored);
-    assert_eq!(stored.investments_made, 2);
-    assert_eq!(stored.total_invested, 24_000);
-    assert_eq!(stored.success_rate, 5_000);
-    assert_eq!(stored.default_rate, 5_000);
 }
 
+/// 14. An invoice created at exactly end_date (≤ boundary) is included.
 #[test]
-fn test_investor_report_retrieval_is_deterministic() {
+fn test_invoice_at_exact_end_date_is_included() {
     let env = Env::default();
-    env.ledger().set_timestamp(5_000_000);
-    let (client, _admin, _business) = setup_contract(&env);
+    let ts = 2 * 86_400u64;
+    env.ledger().set_timestamp(ts);
+    let (client, _, business) = setup(&env);
+    // created_at == ts == end_date for every period.
+    upload(&env, &client, &business, 2_000, "end-boundary");
 
-    let investor = Address::generate(&env);
-    let generated = client.generate_investor_report(&investor, &TimePeriod::AllTime);
-
-    let first = client
-        .get_investor_report(&generated.report_id)
-        .expect("stored report must exist");
-    let second = client
-        .get_investor_report(&generated.report_id)
-        .expect("stored report must remain stable");
-
-    assert_eq!(first.report_id, second.report_id);
-    assert_investor_reports_match_except_id(&first, &second);
+    let report = client.generate_business_report(&business, &TimePeriod::Daily);
+    assert_eq!(
+        report.invoices_uploaded, 1,
+        "invoice at exact end_date must be included"
+    );
 }
 
+// ─── 15–20: Empty-range behavior ──────────────────────────────────────────────
+
+/// 15. A business report over an empty daily window returns all-zero counts.
 #[test]
-fn test_investor_report_period_filter_excludes_out_of_range_history() {
+fn test_business_report_empty_daily_window_all_zeros() {
     let env = Env::default();
-    env.ledger().set_timestamp(6_000_000);
-    let (client, _admin, business) = setup_contract(&env);
+    env.ledger().set_timestamp(10_000_000);
+    let (client, _, business) = setup(&env);
 
-    let investor = Address::generate(&env);
-
-    let within_period = create_invoice(&env, &client, &business, 9_000, "Recent investment");
-    client.update_invoice_status(&within_period, &InvoiceStatus::Paid);
-    seed_investment(
-        &env,
-        &client,
-        &investor,
-        &within_period,
-        7_000,
-        env.ledger().timestamp(),
-        InvestmentStatus::Completed,
-    );
-
-    let older_invoice = create_invoice(&env, &client, &business, 11_000, "Older investment");
-    client.update_invoice_status(&older_invoice, &InvoiceStatus::Paid);
-    seed_investment(
-        &env,
-        &client,
-        &investor,
-        &older_invoice,
-        8_000,
-        env.ledger().timestamp().saturating_sub(40 * 86_400),
-        InvestmentStatus::Completed,
-    );
-
-    let report = client.generate_investor_report(&investor, &TimePeriod::Monthly);
-
-    assert_eq!(report.investments_made, 1);
-    assert_eq!(report.total_invested, 7_000);
-    assert_eq!(report.success_rate, 10_000);
+    let report = client.generate_business_report(&business, &TimePeriod::Daily);
+    assert_eq!(report.invoices_uploaded, 0);
+    assert_eq!(report.invoices_funded, 0);
+    assert_eq!(report.total_volume, 0);
+    assert_eq!(report.success_rate, 0);
     assert_eq!(report.default_rate, 0);
 }
 
+/// 16. Invoices uploaded more than 24 hours ago are excluded from the daily report.
 #[test]
-fn test_get_investor_report_returns_none_for_unknown_id() {
+fn test_business_report_old_invoices_outside_daily_window_excluded() {
     let env = Env::default();
-    let (client, _admin, _business) = setup_contract(&env);
+    let day = 86_400u64;
+    env.ledger().set_timestamp(2 * day);
+    let (client, _, business) = setup(&env);
+    upload(&env, &client, &business, 5_000, "old-inv");
 
-    let missing_id = BytesN::from_array(&env, &[0u8; 32]);
-    assert!(client.get_investor_report(&missing_id).is_none());
+    // Jump forward 2 days: invoice falls outside [3d, 4d] daily window.
+    env.ledger().set_timestamp(4 * day);
+    let report = client.generate_business_report(&business, &TimePeriod::Daily);
+    assert_eq!(report.invoices_uploaded, 0);
+    assert_eq!(report.total_volume, 0);
+}
+
+/// 17. Financial metrics for an empty daily window return zero volume.
+#[test]
+fn test_financial_metrics_empty_daily_window_zero_volume() {
+    let env = Env::default();
+    let day = 86_400u64;
+    env.ledger().set_timestamp(2 * day);
+    let (client, _, business) = setup(&env);
+    upload(&env, &client, &business, 9_000, "outside-daily");
+
+    env.ledger().set_timestamp(4 * day);
+    let metrics = client.get_financial_metrics(&TimePeriod::Daily);
+    assert_eq!(metrics.total_volume, 0);
+    assert_eq!(metrics.total_fees, 0);
+    assert_eq!(metrics.total_profits, 0);
+}
+
+/// 18. Financial metrics AllTime returns zero when no invoices have been created.
+#[test]
+fn test_financial_metrics_alltime_zero_with_no_invoices() {
+    let env = Env::default();
+    env.ledger().set_timestamp(1_000_000);
+    let (client, _, _) = setup(&env);
+
+    let metrics = client.get_financial_metrics(&TimePeriod::AllTime);
+    assert_eq!(metrics.total_volume, 0);
+    assert_eq!(metrics.total_fees, 0);
+    assert_eq!(metrics.total_profits, 0);
+    assert_eq!(metrics.average_return_rate, 0);
+}
+
+/// 19. An investor analytics report over an empty period has zero investments.
+#[test]
+fn test_investor_analytics_empty_period_zero_investments() {
+    let env = Env::default();
+    env.ledger().set_timestamp(5_000_000);
+    let (client, _, _) = setup(&env);
+    let investor = Address::generate(&env);
+
+    // Call the analytics calculator directly (the contract endpoint with this name
+    // is the investment funding function, not the analytics generator).
+    let report = crate::analytics::AnalyticsCalculator::generate_investor_report(
+        &env,
+        &investor,
+        TimePeriod::Monthly,
+    )
+    .expect("empty investor report must not error");
+
+    assert_eq!(report.investments_made, 0);
+    assert_eq!(report.total_invested, 0);
+    assert_eq!(report.success_rate, 0);
+    assert_eq!(report.default_rate, 0);
+
+    // The stored report must also be retrievable via the contract.
+    let stored = client
+        .get_investor_report(&report.report_id)
+        .expect("generated report must be persisted");
+    assert_eq!(stored.investments_made, 0);
+    assert_eq!(stored.report_id, report.report_id);
+}
+
+/// 20. Platform metrics on a brand-new contract are all zero.
+#[test]
+fn test_platform_metrics_empty_state_all_zeros() {
+    let env = Env::default();
+    env.ledger().set_timestamp(1_000_000);
+    let (client, _, _) = setup(&env);
+
+    let m = client.get_platform_metrics();
+    assert_eq!(m.total_invoices, 0);
+    assert_eq!(m.total_investments, 0);
+    assert_eq!(m.total_volume, 0);
+    assert_eq!(m.total_fees_collected, 0);
+    assert_eq!(m.average_invoice_amount, 0);
+    assert_eq!(m.average_investment_amount, 0);
+    assert_eq!(m.success_rate, 0);
+    assert_eq!(m.default_rate, 0);
+}
+
+// ─── 21–25: Growth stability ──────────────────────────────────────────────────
+
+/// 21. A stored business report is immutable after subsequent invoices are added.
+#[test]
+fn test_stored_report_immutable_after_new_invoices_added() {
+    let env = Env::default();
+    env.ledger().set_timestamp(1_000_000);
+    let (client, _, business) = setup(&env);
+    upload(&env, &client, &business, 1_000, "orig");
+
+    let first = client.generate_business_report(&business, &TimePeriod::AllTime);
+    let first_id = first.report_id.clone();
+
+    env.ledger().set_timestamp(1_000_001);
+    upload(&env, &client, &business, 99_999, "late");
+
+    let stored = client.get_business_report(&first_id).unwrap();
+    assert_eq!(stored.invoices_uploaded, first.invoices_uploaded);
+    assert_eq!(stored.total_volume, first.total_volume);
+    assert_eq!(stored.generated_at, first.generated_at);
+}
+
+/// 22. total_invoices grows by exactly 1 for every successful store_invoice call.
+#[test]
+fn test_platform_metrics_total_invoices_grows_per_upload() {
+    let env = Env::default();
+    env.ledger().set_timestamp(1_000_000);
+    let (client, _, business) = setup(&env);
+
+    assert_eq!(client.get_platform_metrics().total_invoices, 0);
+
+    upload(&env, &client, &business, 1_000, "g1");
+    assert_eq!(client.get_platform_metrics().total_invoices, 1);
+
+    upload(&env, &client, &business, 2_000, "g2");
+    assert_eq!(client.get_platform_metrics().total_invoices, 2);
+
+    upload(&env, &client, &business, 3_000, "g3");
+    assert_eq!(client.get_platform_metrics().total_invoices, 3);
+}
+
+/// 23. AllTime always reflects every invoice in the dataset as it grows.
+#[test]
+fn test_alltime_captures_all_invoices_under_growth() {
+    let env = Env::default();
+    env.ledger().set_timestamp(1_000_000);
+    let (client, _, business) = setup(&env);
+
+    upload(&env, &client, &business, 1_000, "g-1");
+    upload(&env, &client, &business, 2_000, "g-2");
+    upload(&env, &client, &business, 3_000, "g-3");
+
+    let r1 = client.generate_business_report(&business, &TimePeriod::AllTime);
+    assert_eq!(r1.invoices_uploaded, 3);
+    assert_eq!(r1.total_volume, 6_000);
+
+    upload(&env, &client, &business, 4_000, "g-4");
+    let r2 = client.generate_business_report(&business, &TimePeriod::AllTime);
+    assert_eq!(r2.invoices_uploaded, 4);
+    assert_eq!(r2.total_volume, 10_000);
+}
+
+/// 24. Two reports generated at the same ledger timestamp have identical computed
+///     fields but distinct report IDs (ID derives from sequence number too).
+#[test]
+fn test_two_reports_same_timestamp_identical_data_different_ids() {
+    let env = Env::default();
+    env.ledger().set_timestamp(2_000_000);
+    let (client, _, business) = setup(&env);
+    upload(&env, &client, &business, 7_500, "idemp");
+
+    let r1 = client.generate_business_report(&business, &TimePeriod::AllTime);
+    let r2 = client.generate_business_report(&business, &TimePeriod::AllTime);
+
+    assert_ne!(r1.report_id, r2.report_id, "IDs must differ even at the same timestamp");
+    assert_eq!(r1.invoices_uploaded, r2.invoices_uploaded);
+    assert_eq!(r1.total_volume, r2.total_volume);
+    assert_eq!(r1.success_rate, r2.success_rate);
+    assert_eq!(r1.default_rate, r2.default_rate);
+}
+
+/// 25. get_analytics_summary returns platform metrics consistent with get_platform_metrics.
+#[test]
+fn test_analytics_summary_platform_matches_platform_metrics() {
+    let env = Env::default();
+    env.ledger().set_timestamp(1_000_000);
+    let (client, _, business) = setup(&env);
+    upload(&env, &client, &business, 5_000, "sum-inv");
+
+    let platform = client.get_platform_metrics();
+    let (summary_platform, _) = client.get_analytics_summary();
+
+    assert_eq!(platform.total_invoices, summary_platform.total_invoices);
+    assert_eq!(platform.total_volume, summary_platform.total_volume);
+    assert_eq!(platform.success_rate, summary_platform.success_rate);
+    assert_eq!(platform.default_rate, summary_platform.default_rate);
+}
+
+// ─── 26–27: Data isolation / security ────────────────────────────────────────
+
+/// 26. A business report for address A never includes invoices owned by address B.
+#[test]
+fn test_business_report_does_not_leak_cross_business_data() {
+    let env = Env::default();
+    env.ledger().set_timestamp(1_000_000);
+    let (client, _, biz_a) = setup(&env);
+    let biz_b = Address::generate(&env);
+
+    upload(&env, &client, &biz_a, 1_000, "a-1");
+    upload(&env, &client, &biz_a, 2_000, "a-2");
+    upload(&env, &client, &biz_b, 9_999, "b-1");
+
+    let ra = client.generate_business_report(&biz_a, &TimePeriod::AllTime);
+    let rb = client.generate_business_report(&biz_b, &TimePeriod::AllTime);
+
+    assert_eq!(ra.invoices_uploaded, 2);
+    assert_eq!(ra.total_volume, 3_000);
+    assert_eq!(rb.invoices_uploaded, 1);
+    assert_eq!(rb.total_volume, 9_999);
+    // Neither report must see the other business's data.
+    assert_ne!(ra.total_volume, rb.total_volume);
+}
+
+/// 27. Financial metrics daily window excludes invoices older than 24 hours;
+///     AllTime correctly includes those same invoices.
+#[test]
+fn test_financial_metrics_daily_excludes_invoices_older_than_24h() {
+    let env = Env::default();
+    let day = 86_400u64;
+    env.ledger().set_timestamp(2 * day);
+    let (client, _, business) = setup(&env);
+    upload(&env, &client, &business, 5_000, "old-fin");
+
+    // Advance 2 days: the invoice now sits outside the [3d, 4d] daily window.
+    env.ledger().set_timestamp(4 * day);
+    let daily = client.get_financial_metrics(&TimePeriod::Daily);
+    assert_eq!(daily.total_volume, 0, "daily must not include a 2-day-old invoice");
+
+    let all_time = client.get_financial_metrics(&TimePeriod::AllTime);
+    assert_eq!(all_time.total_volume, 5_000, "AllTime must include all invoices");
 }


### PR DESCRIPTION
- Rewrite quicklendx-contracts/src/test/test_analytics.rs with 27 compilable boundary tests: TimePeriod edges at genesis/near-zero, zero-length range semantics, empty-window queries, and growth stability invariants
- Wire test_analytics and test_analytics_consistency modules (lib.rs, test.rs)
- Add NatSpec-style doc comments to analytics.rs public functions: get_period_dates, calculate_platform_metrics, calculate_financial_metrics, generate_business_report, generate_investor_report
- Expand docs/contracts/analytics-usage.md: boundary semantics table, empty-range guarantees, security assumptions section


Closes #785

