### PR TITLE
docs: add UX risk copy guidelines (Closes #904)

### DIFF
--- a/docs/ ux/risk-copy-guidelines.md
+++ b/docs/ ux/risk-copy-guidelines.md
@@ -1,0 +1,142 @@
+# Risk Copy Guidelines for Financial Disclosures
+
+## Purpose
+
+This document provides copywriting rules and examples for disclosing fees, risks, expected vs realized returns, and dispute/default outcomes.
+
+---
+
+## Core Principles
+
+| Principle | Description |
+|-----------|-------------|
+| Clarity | Use plain language. Avoid jargon. |
+| Transparency | Disclose all material risks upfront. |
+| Accuracy | Never promise guaranteed returns. |
+| Accessibility | Target 6th-8th grade reading level. |
+
+---
+
+## Section 1: Expected vs Realized Returns
+
+### Do's
+
+| Do This | Reason |
+|---------|--------|
+| "Estimated APY: 4.2% (based on historical performance)" | Clarifies it's an estimate |
+| "Your actual returns may vary" | Manages expectations |
+| "Past performance does not guarantee future results" | Required disclosure |
+
+### Don'ts
+
+| Don't Do This | Why It's Misleading |
+|---------------|---------------------|
+| "You will earn 4.2%" | Implies guarantee |
+| "Guaranteed returns" | False promise |
+| "Risk-free yield" | No investment is risk-free |
+
+### Example Copy
+
+Protocol Earn
+Estimated APY: 4.2%
+Based on 90-day historical average. Actual returns may vary.
+Past performance does not guarantee future results.
+
+---
+
+## Section 2: Fees
+
+### Do's
+
+| Do This | Reason |
+|---------|--------|
+| Show all fees before user confirms transaction | Informed consent |
+| "0.5% protocol fee ($0.50 on a $100 deposit)" | Concrete example |
+| "No hidden fees" | Builds trust |
+
+### Don'ts
+
+| Don't Do This | Why It's Misleading |
+|---------------|---------------------|
+| Buried fee disclosures | Hides true cost |
+| "No fees" when there are gas fees | False claim |
+
+### Example Copy
+
+Fees
+- Protocol fee: 0.5% ($0.50 for every $100)
+- Network gas fee: Paid to Stellar network (varies)
+- Early withdrawal fee: 2% if withdrawn before 30 days
+
+---
+
+## Section 3: Risks
+
+### Do's
+
+| Do This | Reason |
+|---------|--------|
+| "Smart contracts are audited but not immune to bugs" | Honest limitation |
+| "You could lose part or all of your deposited funds" | Clear warning |
+
+### Don'ts
+
+| Don't Do This | Why It's Misleading |
+|---------------|---------------------|
+| No risk disclosure | Hides danger |
+| "Minimal risk" | Vague and misleading |
+
+### Example Copy
+
+Risk Disclosure
+
+⚠️ Smart contract risk: Audits reduce but do not eliminate risk of bugs.
+⚠️ Market risk: Asset prices can go down as well as up.
+⚠️ Liquidity risk: Withdrawals may be delayed during high traffic.
+
+You could lose part or all of your deposited funds.
+
+---
+
+## Section 4: Disputes / Defaults
+
+### Example Copy
+
+Dispute Resolution
+
+If you believe your transaction has an error:
+1. Contact support@quicklendx.com within 14 days
+2. Include your transaction ID
+3. Our team will respond within 5 business days
+
+---
+
+## Section 5: Required Disclosures
+
+### Standard Disclosures
+
+Important Disclosures:
+- Not a bank deposit — not FDIC or SIPC insured
+- Smart contracts are experimental — use at your own risk
+- You could lose part or all of your funds
+- Past performance does not guarantee future results
+
+### Compact Version (For Popups)
+
+Risk: You could lose funds. Smart contracts are experimental. Not FDIC insured.
+
+---
+
+## Section 6: Tone & Voice Guidelines
+
+| Situation | Tone | Example |
+|-----------|------|---------|
+| Normal operation | Professional, helpful | "Your transaction is confirmed. Estimated APY: 4.2%" |
+| Error or warning | Clear, direct | "⚠️ Insufficient balance. Please deposit more funds." |
+| Risk disclosure | Transparent, honest | "You could lose funds. Smart contracts carry risk." |
+
+---
+
+## Last Updated
+
+April 28, 2026


### PR DESCRIPTION
Closes #904

This PR adds UX copywriting guidelines for financial risk disclosures including:

- Rules for expected vs realized returns
- Fee disclosure guidelines
- Risk disclosure templates
- Dispute resolution example copy
- Required disclosures (FDIC/SIPC notice)
- Tone and voice guidelines

Files added:
- docs/ux/risk-copy-guidelines.md

No code changes. This is a documentation-only update.