### PR TITLE
feat: enforce schema validation and idempotency on events ingest

### DIFF
--- a/backend/src/routes/v1/index.ts
+++ b/backend/src/routes/v1/index.ts
@@ -11,8 +11,18 @@ import adminRoutes from "./admin";
 import monitoringRoutes from "./monitoring";
 import { lagMonitor } from "../../services/lagMonitor";
 import { degradedGuard } from "../../middleware/degraded-guard";
+import { eventProcessor } from "../../services/eventProcessor";
+import {
+  DefaultEventValidator,
+  getStableEventId,
+  validateEventBatch,
+  EventValidationResult,
+  SorobanEvent,
+} from "../../services/eventValidator";
+import { FileSystemRawEventStore } from "../../services/rawEventStore";
 
 const router = Router();
+const eventIdStore = new FileSystemRawEventStore(new DefaultEventValidator());
 
 router.use("/invoices", invoiceRoutes);
 router.use("/bids", bidRoutes);
@@ -64,14 +74,81 @@ router.post(
 // Event processing endpoint (for indexer to post events)
 router.post("/events", async (req, res) => {
   try {
-    const { eventProcessor } = await import("../../services/eventProcessor");
     const events = Array.isArray(req.body) ? req.body : [req.body];
+    const validation = validateEventBatch(events);
 
-    for (const event of events) {
-      await eventProcessor.processEvent(event);
+    if (validation.errors) {
+      res.status(400).json({
+        success: false,
+        results: validation.errors.map((error) => ({
+          status: "rejected",
+          error,
+        })),
+      });
+      return;
     }
 
-    res.json({ success: true, processed: events.length });
+    const response: Array<{
+      index: number;
+      id?: string;
+      type?: string;
+      status: "processed" | "duplicate" | "rejected" | "failed";
+      errors?: string[];
+      error?: string;
+    }> = [];
+
+    for (let i = 0; i < events.length; i++) {
+      const result = validation.results[i] as EventValidationResult;
+
+      if (!result.success) {
+        response.push({
+          index: i,
+          status: "rejected",
+          errors: result.errors,
+        });
+        continue;
+      }
+
+      const event = result.data;
+      const eventId = getStableEventId(event);
+
+      if (await eventIdStore.hasEventId(eventId)) {
+        response.push({
+          index: i,
+          id: eventId,
+          type: event.type,
+          status: "duplicate",
+        });
+        continue;
+      }
+
+      try {
+        await eventProcessor.processEvent(event);
+        await eventIdStore.storeEvents([event as SorobanEvent]);
+        response.push({
+          index: i,
+          id: eventId,
+          type: event.type,
+          status: "processed",
+        });
+      } catch (err) {
+        response.push({
+          index: i,
+          id: eventId,
+          type: event.type,
+          status: "failed",
+          error: "Processing failed",
+        });
+      }
+    }
+
+    const hasRejected = response.some((result) => result.status === "rejected");
+    const hasFailed = response.some((result) => result.status === "failed");
+
+    res.status(hasRejected ? 400 : hasFailed ? 500 : 200).json({
+      success: !hasRejected && !hasFailed,
+      results: response,
+    });
   } catch (error) {
     console.error("Error processing events:", error);
     res.status(500).json({ error: "Internal server error" });

--- a/backend/src/services/eventProcessor.ts
+++ b/backend/src/services/eventProcessor.ts
@@ -100,14 +100,20 @@ export class EventProcessor {
   public async processEvent(event: any): Promise<void> {
     const eventId = event.id || `${event.type}_${event.timestamp}`;
 
+    // Accept both legacy (flat) and new (payload-wrapped) event shapes
+    const get = (field: string) =>
+      event.payload && event.payload[field] !== undefined
+        ? event.payload[field]
+        : event[field];
+
     switch (event.type) {
       case 'InvoiceSettled':
         await this.processInvoiceSettled(
           eventId,
-          event.invoice_id,
-          event.business,
-          event.investor,
-          event.amount || event.investor_return,
+          get('invoice_id'),
+          get('business'),
+          get('investor'),
+          get('amount') || get('investor_return'),
           event.timestamp
         );
         break;
@@ -115,9 +121,9 @@ export class EventProcessor {
       case 'PaymentRecorded':
         await this.processPaymentRecorded(
           eventId,
-          event.invoice_id,
-          event.payer,
-          event.amount,
+          get('invoice_id'),
+          get('payer'),
+          get('amount'),
           event.timestamp
         );
         break;
@@ -125,8 +131,8 @@ export class EventProcessor {
       case 'DisputeCreated':
         await this.processDisputeCreated(
           eventId,
-          event.invoice_id,
-          event.initiator,
+          get('invoice_id'),
+          get('initiator'),
           event.timestamp
         );
         break;
@@ -134,14 +140,16 @@ export class EventProcessor {
       case 'DisputeResolved':
         await this.processDisputeResolved(
           eventId,
-          event.invoice_id,
-          event.resolved_by || event.admin,
+          get('invoice_id'),
+          get('resolved_by') || get('admin'),
           event.timestamp
         );
         break;
 
       default:
-        console.log(`Unhandled event type: ${event.type}`);
+        const err = new Error(`Unknown event type: ${event.type}`) as Error & { status: number };
+        err.status = 400;
+        throw err;
     }
   }
 }

--- a/backend/src/services/eventValidator.ts
+++ b/backend/src/services/eventValidator.ts
@@ -1,4 +1,143 @@
-import { RawEvent, EventValidator } from "../types/replay";
+import { z } from "zod";
+import { EventValidator, RawEvent, RawEventSchema } from "../types/replay";
+
+const isoDateTimeSchema = z.string().datetime();
+const amountSchema = z.string().min(1);
+
+const eventEnvelopeSchema = z.object({
+  id: z.string().min(1),
+  ledger: z.number().int().nonnegative(),
+  txHash: z.string().min(1),
+  timestamp: z.number().int().nonnegative(),
+  complianceHold: z.boolean().default(false),
+  indexedAt: isoDateTimeSchema,
+});
+
+export const InvoiceSettledSchema = eventEnvelopeSchema.extend({
+  type: z.literal("InvoiceSettled"),
+  payload: z
+    .object({
+      invoice_id: z.string().min(1),
+      business: z.string().min(1),
+      investor: z.string().min(1),
+      amount: amountSchema,
+    })
+    .passthrough(),
+});
+
+export const PaymentRecordedSchema = eventEnvelopeSchema.extend({
+  type: z.literal("PaymentRecorded"),
+  payload: z
+    .object({
+      invoice_id: z.string().min(1),
+      payer: z.string().min(1),
+      amount: amountSchema,
+    })
+    .passthrough(),
+});
+
+export const DisputeCreatedSchema = eventEnvelopeSchema.extend({
+  type: z.literal("DisputeCreated"),
+  payload: z
+    .object({
+      invoice_id: z.string().min(1),
+      initiator: z.string().min(1),
+    })
+    .passthrough(),
+});
+
+export const DisputeResolvedSchema = eventEnvelopeSchema.extend({
+  type: z.literal("DisputeResolved"),
+  payload: z
+    .object({
+      invoice_id: z.string().min(1),
+      resolved_by: z.string().min(1),
+    })
+    .passthrough(),
+});
+
+export const SorobanEventSchema = z.discriminatedUnion("type", [
+  InvoiceSettledSchema,
+  PaymentRecordedSchema,
+  DisputeCreatedSchema,
+  DisputeResolvedSchema,
+]);
+
+export const SorobanEventBatchSchema = z.array(SorobanEventSchema).max(100);
+
+export type SorobanEvent = z.infer<typeof SorobanEventSchema>;
+
+export interface EventValidationSuccess {
+  success: true;
+  data: SorobanEvent;
+}
+
+export interface EventValidationFailure {
+  success: false;
+  errors: string[];
+}
+
+export type EventValidationResult = EventValidationSuccess | EventValidationFailure;
+
+export interface EventBatchValidationResult {
+  success: boolean;
+  results: EventValidationResult[];
+  errors?: string[];
+}
+
+export function validateEvent(event: unknown): EventValidationResult {
+  const result = SorobanEventSchema.safeParse(event);
+
+  if (result.success) {
+    return { success: true, data: result.data };
+  }
+
+  return {
+    success: false,
+    errors: formatZodIssues(result.error.issues),
+  };
+}
+
+export function validateEventBatch(events: unknown): EventBatchValidationResult {
+  if (!Array.isArray(events)) {
+    return {
+      success: false,
+      results: [],
+      errors: ["Request body must be an event object or an array of event objects"],
+    };
+  }
+
+  if (events.length > 100) {
+    return {
+      success: false,
+      results: [],
+      errors: ["Batch size exceeds 100 events"],
+    };
+  }
+
+  const results = events.map((event) => validateEvent(event));
+
+  return {
+    success: results.every((result) => result.success),
+    results,
+  };
+}
+
+export function getStableEventId(event: SorobanEvent): string {
+  return event.id;
+}
+
+function formatZodIssues(issues: z.ZodIssue[]): string[] {
+  return issues.map((issue) => {
+    const path = issue.path.length > 0 ? issue.path.join(".") : "event";
+
+    if (issue.code === "invalid_union" || issue.code === "invalid_value") {
+      return `${path} is not an accepted Soroban event value`;
+    }
+
+    return `${path} is invalid`;
+  });
+}
 
 export class DefaultEventValidator implements EventValidator {
   private readonly maxPayloadSize: number;
@@ -6,147 +145,108 @@ export class DefaultEventValidator implements EventValidator {
   private readonly requiredFields: Set<string>;
 
   constructor(
-    maxPayloadSize: number = 1024 * 1024, // 1MB
+    maxPayloadSize: number = 1024 * 1024,
     allowedEventTypes?: string[]
   ) {
     this.maxPayloadSize = maxPayloadSize;
-    this.allowedEventTypes = new Set(allowedEventTypes || [
-      "InvoiceCreated",
-      "InvoiceSettled", 
-      "BidPlaced",
-      "BidAccepted",
-      "PaymentRecorded",
-      "DisputeCreated",
-      "DisputeResolved",
-      "SettlementCompleted"
+    this.allowedEventTypes = new Set(
+      allowedEventTypes || [
+        "InvoiceCreated",
+        "InvoiceSettled",
+        "BidPlaced",
+        "BidAccepted",
+        "PaymentRecorded",
+        "DisputeCreated",
+        "DisputeResolved",
+        "SettlementCompleted",
+      ]
+    );
+    this.requiredFields = new Set([
+      "id",
+      "ledger",
+      "txHash",
+      "type",
+      "payload",
+      "timestamp",
     ]);
-    
-    this.requiredFields = new Set(["id", "ledger", "txHash", "type", "payload", "timestamp"]);
   }
 
   async validateEvent(event: RawEvent): Promise<string[]> {
     const errors: string[] = [];
+    const envelope = RawEventSchema.safeParse(event);
 
-    // Check required fields
+    if (!envelope.success) {
+      errors.push(...formatZodIssues(envelope.error.issues));
+    }
+
     for (const field of this.requiredFields) {
       if (!(field in event)) {
         errors.push(`Missing required field: ${field}`);
       }
     }
 
-    // Validate field types and values
-    if (typeof event.id !== "string" || event.id.length === 0) {
-      errors.push("Event ID must be a non-empty string");
-    }
-
-    if (typeof event.ledger !== "number" || event.ledger < 0 || !Number.isInteger(event.ledger)) {
-      errors.push("Ledger must be a non-negative integer");
-    }
-
-    if (typeof event.txHash !== "string" || event.txHash.length === 0) {
-      errors.push("Transaction hash must be a non-empty string");
-    }
-
-    if (typeof event.type !== "string" || event.type.length === 0) {
-      errors.push("Event type must be a non-empty string");
-    } else if (!this.allowedEventTypes.has(event.type)) {
+    if (typeof event.type === "string" && !this.allowedEventTypes.has(event.type)) {
       errors.push(`Event type '${event.type}' is not allowed`);
     }
 
-    if (typeof event.timestamp !== "number" || event.timestamp < 0 || !Number.isInteger(event.timestamp)) {
-      errors.push("Timestamp must be a non-negative integer");
-    }
-
-    if (typeof event.complianceHold !== "boolean") {
-      errors.push("Compliance hold must be a boolean");
-    }
-
-    if (typeof event.indexedAt !== "string" || !this.isValidISODate(event.indexedAt)) {
-      errors.push("Indexed at must be a valid ISO 8601 date string");
-    }
-
-    // Validate payload
-    if (typeof event.payload !== "object" || event.payload === null) {
-      errors.push("Payload must be an object");
-    } else {
+    if (typeof event.payload === "object" && event.payload !== null) {
       const payloadSize = JSON.stringify(event.payload).length;
       if (payloadSize > this.maxPayloadSize) {
         errors.push(`Payload size ${payloadSize} exceeds maximum ${this.maxPayloadSize}`);
       }
 
-      // Check for potentially dangerous content
-      const payloadStr = JSON.stringify(event.payload);
-      if (this.containsSuspiciousContent(payloadStr)) {
+      if (this.containsSuspiciousContent(JSON.stringify(event.payload))) {
         errors.push("Payload contains potentially dangerous content");
       }
     }
 
-    return errors;
+    return [...new Set(errors)];
   }
 
   async sanitizeEvent(event: RawEvent): Promise<RawEvent> {
-    // Create a deep copy to avoid mutating the original
     const sanitized = JSON.parse(JSON.stringify(event)) as RawEvent;
 
-    // Sanitize string fields
     sanitized.id = this.sanitizeString(sanitized.id);
     sanitized.txHash = this.sanitizeString(sanitized.txHash);
     sanitized.type = this.sanitizeString(sanitized.type);
     sanitized.indexedAt = this.sanitizeString(sanitized.indexedAt);
-
-    // Sanitize payload recursively
-    sanitized.payload = this.sanitizeObject(sanitized.payload);
-
-    // Ensure compliance hold is boolean
+    sanitized.payload = this.sanitizeObject(sanitized.payload) as Record<string, unknown>;
     sanitized.complianceHold = Boolean(sanitized.complianceHold);
-
-    // Round timestamp to integer
     sanitized.timestamp = Math.floor(Number(sanitized.timestamp));
 
     return sanitized;
   }
 
-  private isValidISODate(dateString: string): boolean {
-    const date = new Date(dateString);
-    return !isNaN(date.getTime()) && dateString === date.toISOString();
-  }
-
   private containsSuspiciousContent(content: string): boolean {
-    // Check for common attack patterns
     const suspiciousPatterns = [
-      /<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi, // Script tags
-      /javascript:/gi, // JavaScript protocol
-      /on\w+\s*=/gi, // Event handlers
-      /data:text\/html/gi, // Data URLs
+      /<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi,
+      /javascript:/gi,
+      /on\w+\s*=/gi,
+      /data:text\/html/gi,
     ];
 
-    return suspiciousPatterns.some(pattern => pattern.test(content));
+    return suspiciousPatterns.some((pattern) => pattern.test(content));
   }
 
   private sanitizeString(str: string): string {
     if (typeof str !== "string") return "";
-    
-    // Remove null bytes and control characters except newlines and tabs
-    return str
-      .replace(/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/g, "")
-      .trim();
+
+    return str.replace(/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/g, "").trim();
   }
 
-  private sanitizeObject(obj: any): any {
+  private sanitizeObject(obj: unknown): unknown {
     if (obj === null || typeof obj !== "object") {
       return obj;
     }
 
     if (Array.isArray(obj)) {
-      return obj.map(item => this.sanitizeObject(item));
+      return obj.map((item) => this.sanitizeObject(item));
     }
 
-    const sanitized: any = {};
+    const sanitized: Record<string, unknown> = {};
     for (const [key, value] of Object.entries(obj)) {
-      // Sanitize key
       const sanitizedKey = this.sanitizeString(key);
-      
-      // Sanitize value based on type
+
       if (typeof value === "string") {
         sanitized[sanitizedKey] = this.sanitizeString(value);
       } else if (typeof value === "object" && value !== null) {

--- a/backend/src/services/rawEventStore.ts
+++ b/backend/src/services/rawEventStore.ts
@@ -60,6 +60,33 @@ export class FileSystemRawEventStore implements RawEventStore {
     await this.rotateFileIfNeeded();
   }
 
+  async hasEventId(eventId: string): Promise<boolean> {
+    await fs.mkdir(this.dataDir, { recursive: true });
+
+    try {
+      const data = await fs.readFile(this.eventsFile, "utf8");
+      const lines = data.trim().split("\n").filter(line => line.length > 0);
+
+      for (const line of lines) {
+        try {
+          const event = JSON.parse(line) as RawEvent;
+          if (event.id === eventId) {
+            return true;
+          }
+        } catch {
+          // Ignore malformed historical rows while scanning for idempotency.
+        }
+      }
+
+      return false;
+    } catch (error) {
+      if ((error as any).code === "ENOENT") {
+        return false;
+      }
+      throw error;
+    }
+  }
+
   async getEventsByLedgerRange(
     fromLedger: number, 
     toLedger: number, 
@@ -240,6 +267,10 @@ export class InMemoryRawEventStore implements RawEventStore {
     // Sort and add to store
     sanitizedEvents.sort((a, b) => a.ledger - b.ledger);
     this.events.push(...sanitizedEvents);
+  }
+
+  async hasEventId(eventId: string): Promise<boolean> {
+    return this.events.some(event => event.id === eventId);
   }
 
   async getEventsByLedgerRange(

--- a/backend/tests/eventProcessor.test.ts
+++ b/backend/tests/eventProcessor.test.ts
@@ -190,15 +190,13 @@ describe("EventProcessor", () => {
       });
     });
 
-    it("should ignore unknown event types", async () => {
+    it("should throw on unknown event types", async () => {
       const event = {
         type: "UnknownEvent",
         id: "unknown123",
         timestamp: 1234567894,
       };
-
-      await eventProcessor.processEvent(event);
-
+      await expect(eventProcessor.processEvent(event)).rejects.toThrow(/Unknown event type/);
       expect(mockNotificationService.processNotification).not.toHaveBeenCalled();
     });
   });

--- a/backend/tests/eventProcessor.validation.test.ts
+++ b/backend/tests/eventProcessor.validation.test.ts
@@ -1,0 +1,235 @@
+import express from 'express';
+import request from 'supertest';
+import { mkdtemp, rm } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { afterEach, describe, it, expect, jest } from '@jest/globals';
+import { validateEvent, validateEventBatch } from '../src/services/eventValidator';
+
+const validInvoiceSettled = {
+  id: 'evt1',
+  ledger: 1,
+  txHash: 'tx1',
+  type: 'InvoiceSettled',
+  payload: {
+    invoice_id: 'inv1',
+    business: 'biz1',
+    investor: 'invstr1',
+    amount: '1000',
+  },
+  timestamp: 1234567890,
+  complianceHold: false,
+  indexedAt: new Date().toISOString(),
+};
+
+const validPaymentRecorded = {
+  id: 'evt2',
+  ledger: 2,
+  txHash: 'tx2',
+  type: 'PaymentRecorded',
+  payload: {
+    invoice_id: 'inv2',
+    payer: 'payer1',
+    amount: '500',
+  },
+  timestamp: 1234567891,
+  complianceHold: true,
+  indexedAt: new Date().toISOString(),
+};
+
+const validDisputeCreated = {
+  id: 'evt3',
+  ledger: 3,
+  txHash: 'tx3',
+  type: 'DisputeCreated',
+  payload: {
+    invoice_id: 'inv3',
+    initiator: 'user1',
+  },
+  timestamp: 1234567892,
+  complianceHold: false,
+  indexedAt: new Date().toISOString(),
+};
+
+const validDisputeResolved = {
+  id: 'evt4',
+  ledger: 4,
+  txHash: 'tx4',
+  type: 'DisputeResolved',
+  payload: {
+    invoice_id: 'inv4',
+    resolved_by: 'admin1',
+  },
+  timestamp: 1234567893,
+  complianceHold: true,
+  indexedAt: new Date().toISOString(),
+};
+
+describe('eventValidator', () => {
+  it('accepts valid InvoiceSettled', () => {
+    const result = validateEvent(validInvoiceSettled);
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts valid PaymentRecorded', () => {
+    const result = validateEvent(validPaymentRecorded);
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts valid DisputeCreated', () => {
+    const result = validateEvent(validDisputeCreated);
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts valid DisputeResolved', () => {
+    const result = validateEvent(validDisputeResolved);
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects unknown event type', () => {
+    const bad = { ...validInvoiceSettled, type: 'UnknownType' };
+    const result = validateEvent(bad);
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.errors).toContain('type is not an accepted Soroban event value');
+    }
+  });
+
+  it('rejects missing required fields', () => {
+    const bad = { ...validInvoiceSettled };
+    if ('id' in bad) delete (bad as any).id;
+    const result = validateEvent(bad);
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects missing timestamp', () => {
+    const bad = { ...validInvoiceSettled };
+    delete (bad as any).timestamp;
+    const result = validateEvent(bad);
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.errors).toContain('timestamp is invalid');
+    }
+  });
+
+  it('rejects malformed batch', () => {
+    const batch = [validInvoiceSettled, { foo: 'bar' }];
+    const { success, results } = validateEventBatch(batch);
+    expect(success).toBe(false);
+    expect(results[1].success).toBe(false);
+  });
+
+  it('rejects oversized batch', () => {
+    const batch = Array(101).fill(validInvoiceSettled);
+    const { success, errors } = validateEventBatch(batch);
+    expect(success).toBe(false);
+    expect(errors?.[0]).toMatch(/Batch size exceeds/);
+  });
+
+  it('does not echo raw payload in error', () => {
+    const bad = { ...validInvoiceSettled, payload: undefined };
+    const result = validateEvent(bad);
+    expect(result.success).toBe(false);
+    // Should not contain the payload value
+    expect(JSON.stringify(result)).not.toContain('undefined');
+  });
+});
+
+describe('POST /events validation and idempotency', () => {
+  const originalCwd = process.cwd();
+  let tempDir: string | null = null;
+
+  afterEach(async () => {
+    process.chdir(originalCwd);
+    jest.resetModules();
+    jest.dontMock('../src/services/notificationService');
+
+    if (tempDir) {
+      await rm(tempDir, { recursive: true, force: true });
+      tempDir = null;
+    }
+  });
+
+  async function createTestApp(
+    processNotification: jest.Mock = jest.fn(async () => undefined)
+  ) {
+    tempDir = await mkdtemp(join(tmpdir(), 'quicklendx-events-'));
+    process.chdir(tempDir);
+    jest.resetModules();
+    jest.doMock('../src/services/notificationService', () => ({
+      notificationService: {
+        processNotification,
+      },
+    }));
+    jest.doMock(
+      'pg',
+      () => ({
+        Pool: jest.fn(() => ({
+          query: jest.fn(),
+          connect: jest.fn(),
+          end: jest.fn(),
+        })),
+      }),
+      { virtual: true }
+    );
+
+    const routes = (await import('../src/routes/v1')).default;
+    const app = express();
+    app.use(express.json());
+    app.use('/api/v1', routes);
+
+    return { app, processNotification };
+  }
+
+  it('processes a valid event once and no-ops a duplicate id', async () => {
+    const { app, processNotification } = await createTestApp();
+
+    await request(app)
+      .post('/api/v1/events')
+      .send(validInvoiceSettled)
+      .expect(200)
+      .expect((res) => {
+        expect(res.body.success).toBe(true);
+        expect(res.body.results[0]).toMatchObject({
+          id: 'evt1',
+          type: 'InvoiceSettled',
+          status: 'processed',
+        });
+      });
+
+    await request(app)
+      .post('/api/v1/events')
+      .send(validInvoiceSettled)
+      .expect(200)
+      .expect((res) => {
+        expect(res.body.success).toBe(true);
+        expect(res.body.results[0]).toMatchObject({
+          id: 'evt1',
+          type: 'InvoiceSettled',
+          status: 'duplicate',
+        });
+      });
+
+    expect(processNotification).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns per-event results for mixed valid and invalid batches', async () => {
+    const { app, processNotification } = await createTestApp();
+    const invalid = { ...validPaymentRecorded };
+    delete (invalid as any).timestamp;
+
+    await request(app)
+      .post('/api/v1/events')
+      .send([validInvoiceSettled, invalid])
+      .expect(400)
+      .expect((res) => {
+        expect(res.body.success).toBe(false);
+        expect(res.body.results).toHaveLength(2);
+        expect(res.body.results[0]).toMatchObject({ status: 'processed', id: 'evt1' });
+        expect(res.body.results[1]).toMatchObject({ status: 'rejected' });
+        expect(JSON.stringify(res.body.results[1])).not.toContain('inv2');
+      });
+
+    expect(processNotification).toHaveBeenCalledTimes(1);
+  });
+});

--- a/docs/events.md
+++ b/docs/events.md
@@ -1,0 +1,103 @@
+# QuickLendX Event Ingestion API
+
+This document describes the accepted event schemas for the POST `/api/v1/events` endpoint. Send either a single event object or an array of event objects. Unknown or malformed events are rejected with a structured 400 response and raw payload values are not echoed in validation errors.
+
+## Supported Event Types
+
+### InvoiceSettled
+```
+{
+  "id": "string (unique)",
+  "ledger": number,
+  "txHash": "string",
+  "type": "InvoiceSettled",
+  "payload": {
+    "invoice_id": "string",
+    "business": "string",
+    "investor": "string",
+    "amount": "string",
+    ...
+  },
+  "timestamp": number,
+  "complianceHold": boolean,
+  "indexedAt": "ISO 8601 string"
+}
+```
+
+### PaymentRecorded
+```
+{
+  "id": "string (unique)",
+  "ledger": number,
+  "txHash": "string",
+  "type": "PaymentRecorded",
+  "payload": {
+    "invoice_id": "string",
+    "payer": "string",
+    "amount": "string",
+    ...
+  },
+  "timestamp": number,
+  "complianceHold": boolean,
+  "indexedAt": "ISO 8601 string"
+}
+```
+
+### DisputeCreated
+```
+{
+  "id": "string (unique)",
+  "ledger": number,
+  "txHash": "string",
+  "type": "DisputeCreated",
+  "payload": {
+    "invoice_id": "string",
+    "initiator": "string",
+    ...
+  },
+  "timestamp": number,
+  "complianceHold": boolean,
+  "indexedAt": "ISO 8601 string"
+}
+```
+
+### DisputeResolved
+```
+{
+  "id": "string (unique)",
+  "ledger": number,
+  "txHash": "string",
+  "type": "DisputeResolved",
+  "payload": {
+    "invoice_id": "string",
+    "resolved_by": "string",
+    ...
+  },
+  "timestamp": number,
+  "complianceHold": boolean,
+  "indexedAt": "ISO 8601 string"
+}
+```
+
+## Validation Rules
+- All fields are required unless marked optional.
+- Unknown event types are rejected.
+- Each event must have a stable unique `id`; replaying a previously processed `id` is a no-op.
+- Processed event IDs are persisted in the raw event log backing store.
+- Oversized batches (>100 events) are rejected before event processing.
+- No raw event payloads are echoed in error responses.
+
+## Response Shape
+Successful events return `status: "processed"`. Duplicate events return `status: "duplicate"` and do not trigger notifications again. Invalid items return `status: "rejected"` with sanitized validation errors.
+
+Mixed batches return a per-event `results` array. If any item is rejected, the HTTP status is 400 while valid non-duplicate items in the same batch may still be processed.
+
+## Example Batch
+```
+[
+  { ...InvoiceSettled },
+  { ...PaymentRecorded },
+  { ...DisputeCreated },
+  { ...DisputeResolved }
+]
+```


### PR DESCRIPTION
## Summary

Closes #1046

Adds strict validation and idempotent routing for the `POST /api/v1/events` Soroban event ingestion endpoint.

## Changes

- Added Zod discriminated union validation for:
  - `InvoiceSettled`
  - `PaymentRecorded`
  - `DisputeCreated`
  - `DisputeResolved`
- Rejects unknown or malformed event types with HTTP 400 and sanitized per-event errors.
- Returns structured per-event results with `processed`, `duplicate`, `rejected`, or `failed` statuses.
- Persists processed event IDs through the raw event store backing log so replayed events are no-ops before side effects fire.
- Preserves the existing replay/raw-event validator API used by ingestion and replay services.
- Documents accepted event schemas and response behavior in `docs/events.md`.
- Adds tests for validation, missing timestamps, oversized batches, mixed valid/invalid batches, unknown types, and duplicate event IDs.

## Testing

- `npx.cmd tsc --noEmit`
- `npm.cmd test`
- `npm.cmd test -- --coverage`