### PR TITLE
Feature/pipeline tracing

### DIFF
--- a/backend/docs/logging.md
+++ b/backend/docs/logging.md
@@ -11,11 +11,14 @@
 QuickLendX Backend enforces a **field-level logging policy** for all HTTP request and response data. The policy classifies every known field into one of three sensitivity tiers and automatically redacts or hashes values before they reach any log sink.
 
 This ensures:
+
 - Wallet signatures, auth tokens, and KYC payloads **never** appear in logs.
 - Business-sensitive values (wallet addresses, amounts) are **pseudonymised**.
 - Public metadata (IDs, status codes, timestamps) is logged verbatim for observability.
 
 Additionally, the backend implements **correlation IDs** to thread request context across the request lifecycle, event processing, and outbound webhook delivery. This enables end-to-end tracing and debugging without manual log stitching.
+
+The ingestion, invariant, and reconciliation pipeline also emits **structured trace spans** in JSON lines so external collectors can build a causal span graph without coupling QuickLendX to a specific tracing vendor.
 
 ---
 
@@ -24,6 +27,7 @@ Additionally, the backend implements **correlation IDs** to thread request conte
 ### Overview
 
 Correlation IDs are ULID-based identifiers that thread through the entire request lifecycle:
+
 - **Request entry**: Generated or accepted from `X-Request-Id` header
 - **Event processing**: Propagated through `eventProcessor.ts` → `notificationService.ts`
 - **Webhook delivery**: Included in outbound webhook requests as `X-Request-Id` header
@@ -33,17 +37,17 @@ This enables end-to-end tracing of a settlement notification from HTTP request �
 
 ### X-Request-Id Header Contract
 
-| Aspect | Specification |
-|--------|----------------|
-| **Header name** | `X-Request-Id` (case-insensitive) |
-| **Direction** | Bidirectional (request and response) |
-| **Client → Server** | Optional. If present and valid, used as correlation ID. If absent or invalid, a new ULID is generated. |
-| **Server → Client** | Always present. Echoes the correlation ID used for the request. |
-| **Format** | ULID (26 chars) or alphanumeric with hyphens/underscores |
-| **Max length** | 128 characters |
-| **Valid characters** | `A-Z`, `a-z`, `0-9`, `-`, `_` |
+| Aspect                 | Specification                                                                                                     |
+| ---------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| **Header name**        | `X-Request-Id` (case-insensitive)                                                                                 |
+| **Direction**          | Bidirectional (request and response)                                                                              |
+| **Client → Server**    | Optional. If present and valid, used as correlation ID. If absent or invalid, a new ULID is generated.            |
+| **Server → Client**    | Always present. Echoes the correlation ID used for the request.                                                   |
+| **Format**             | ULID (26 chars) or alphanumeric with hyphens/underscores                                                          |
+| **Max length**         | 128 characters                                                                                                    |
+| **Valid characters**   | `A-Z`, `a-z`, `0-9`, `-`, `_`                                                                                     |
 | **Invalid characters** | Newlines, carriage returns, tabs, semicolons, pipes, ANSI escape sequences, null bytes (log injection prevention) |
-| **Security** | All client-supplied IDs are sanitized before use. Invalid IDs are rejected and a new ULID is generated. |
+| **Security**           | All client-supplied IDs are sanitized before use. Invalid IDs are rejected and a new ULID is generated.           |
 
 ### Header Flow
 
@@ -58,11 +62,13 @@ X-Request-Id: client-123  ──►   X-Request-Id: client-123  (if valid)
 ### Implementation Details
 
 **Request Context Storage**
+
 - Uses Node.js `AsyncLocalStorage` for thread-safe context propagation
 - Automatic context isolation prevents bleeding between concurrent requests
 - Context is automatically available in all downstream async operations
 
 **Middleware Integration**
+
 1. `request-logger.ts`: Accepts/sanitizes client `X-Request-Id`, generates ULID if needed, sets response header
 2. `requestContext.ts`: Provides `withCorrelationId()`, `getCorrelationId()`, `getOrGenerateCorrelationId()` helpers
 3. `access-log.ts`: Includes correlation ID in all access log entries
@@ -72,6 +78,7 @@ X-Request-Id: client-123  ──►   X-Request-Id: client-123  (if valid)
 ### Usage Examples
 
 **Client-supplied correlation ID**
+
 ```bash
 curl -H "X-Request-Id: my-trace-123" https://api.example.com/invoices
 # Response header: X-Request-Id: my-trace-123
@@ -79,6 +86,7 @@ curl -H "X-Request-Id: my-trace-123" https://api.example.com/invoices
 ```
 
 **Server-generated correlation ID**
+
 ```bash
 curl https://api.example.com/invoices
 # Response header: X-Request-Id: 01H9K4W2X8Y9Z0A1B2C3D4E5F6
@@ -86,6 +94,7 @@ curl https://api.example.com/invoices
 ```
 
 **Programmatic usage in handlers**
+
 ```ts
 import { getCorrelationId } from "../lib/requestContext";
 
@@ -97,6 +106,7 @@ function myHandler(req, res) {
 ```
 
 **Setting context for background tasks**
+
 ```ts
 import { withCorrelationId } from "../lib/requestContext";
 
@@ -111,17 +121,20 @@ async function backgroundTask(correlationId: string) {
 ### Security Considerations
 
 **Log Injection Prevention**
+
 - Client-supplied correlation IDs are strictly validated against a whitelist pattern
 - Special characters (newlines, carriage returns, tabs, ANSI escape sequences) are rejected
 - Maximum length enforced (128 characters) to prevent DoS via oversized headers
 - Invalid IDs are silently rejected and replaced with server-generated ULIDs
 
 **Context Isolation**
+
 - AsyncLocalStorage ensures concurrent requests cannot bleed correlation IDs
 - Each request has its own isolated context
 - Context is automatically cleaned up after request completes
 
 **Redaction Compliance**
+
 - Correlation IDs are classified as PUBLIC in the logging policy
 - They appear verbatim in logs for easy filtering
 - They do not contain sensitive information by design
@@ -146,11 +159,90 @@ npx jest correlation-id.test.ts --coverage
 
 ---
 
-| Tier | Symbol | Behaviour in logs |
-|------|--------|-------------------|
-| **PUBLIC** | `FieldTier.PUBLIC` | Value logged verbatim. |
-| **PRIVATE** | `FieldTier.PRIVATE` | Value replaced with `sha256:<8-hex-chars>` (non-reversible). |
-| **SECRET** | `FieldTier.SECRET` | Value replaced with the literal string `[REDACTED]`. No crypto is applied — the value is simply discarded. |
+## Trace Spans
+
+### Overview
+
+Pipeline services emit span logs for start and end events:
+
+- `ingestion.ingestBatch`, `ingestion.rollbackAndReingest`
+- `invariant.*` public checks and scheduler run loop
+- `reconciliation.*` worker entrypoints
+
+Each span line is independent JSON written to stdout and can be shipped by any log forwarder.
+
+### Span JSON Format
+
+```json
+{
+  "level": "INFO",
+  "type": "TRACE_SPAN",
+  "event": "start",
+  "timestamp": "2026-05-31T12:34:56.789Z",
+  "name": "ingestion.ingestBatch",
+  "trace_id": "01J0NQ7H4N6R5X8TQKBV7PZ6Y1",
+  "span_id": "01J0NQ7H7BFW5H0NQYV0GJQJ0T",
+  "parent_span_id": null,
+  "attrs": {
+    "batch_cursor": 91234,
+    "events_count": 25
+  }
+}
+```
+
+End events include duration and error metadata:
+
+```json
+{
+  "level": "INFO",
+  "type": "TRACE_SPAN",
+  "event": "end",
+  "timestamp": "2026-05-31T12:34:56.811Z",
+  "name": "ingestion.ingestBatch",
+  "trace_id": "01J0NQ7H4N6R5X8TQKBV7PZ6Y1",
+  "span_id": "01J0NQ7H7BFW5H0NQYV0GJQJ0T",
+  "parent_span_id": null,
+  "duration_ms": 22.14,
+  "error": false,
+  "attrs": {
+    "batch_cursor": 91234,
+    "events_count": 25
+  }
+}
+```
+
+### Field Semantics
+
+| Field            | Description                                                                                                              |
+| ---------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| `trace_id`       | Root trace identifier. If a request correlation ID exists in async context, it is reused. Otherwise a ULID is generated. |
+| `span_id`        | ULID for the current span instance.                                                                                      |
+| `parent_span_id` | ULID of the direct parent span, or `null` for root spans.                                                                |
+| `name`           | Logical operation name (`service.operation`).                                                                            |
+| `attrs`          | Span attributes for filtering and debugging (cursor, counts, batch size, etc.).                                          |
+| `error`          | `true` when the wrapped operation throws.                                                                                |
+| `error_message`  | Captured exception message when `error=true`.                                                                            |
+| `duration_ms`    | Present on `event=end`; wall clock duration of the span.                                                                 |
+
+### Parent/Child Behavior
+
+- Nested spans automatically inherit the same `trace_id`.
+- Child spans automatically set `parent_span_id` to the active span.
+- Async boundaries are preserved through `AsyncLocalStorage`, so parent-child linkage survives `await`, timers, and Promise chains.
+
+### Operational Notes
+
+- Spans are logs, not a direct OpenTelemetry exporter.
+- Any collector can ingest these JSON lines and transform them to OTel, Honeycomb, Datadog, or internal trace stores.
+- Existing request logging and redaction policy remain unchanged.
+
+---
+
+| Tier        | Symbol              | Behaviour in logs                                                                                          |
+| ----------- | ------------------- | ---------------------------------------------------------------------------------------------------------- |
+| **PUBLIC**  | `FieldTier.PUBLIC`  | Value logged verbatim.                                                                                     |
+| **PRIVATE** | `FieldTier.PRIVATE` | Value replaced with `sha256:<8-hex-chars>` (non-reversible).                                               |
+| **SECRET**  | `FieldTier.SECRET`  | Value replaced with the literal string `[REDACTED]`. No crypto is applied — the value is simply discarded. |
 
 **Deny-by-default:** any field whose name does not appear in the registry is treated as `PRIVATE`.
 
@@ -180,6 +272,7 @@ description, reason, tags, notes
 ### SECRET fields (never logged)
 
 **Authentication / Wallet**
+
 ```
 signature, wallet_signature, private_key
 secret, token, access_token, refresh_token, api_key
@@ -188,6 +281,7 @@ mnemonic, seed_phrase
 ```
 
 **KYC / PII**
+
 ```
 tax_id, ssn, national_id, passport_number, date_of_birth
 bank_account, kyc_document, kyc_data
@@ -195,6 +289,7 @@ customer_name, customer_address, phone_number, email
 ```
 
 **Webhook**
+
 ```
 webhook_secret, signing_secret
 ```
@@ -230,14 +325,14 @@ HTTP Request
 
 ### Core modules
 
-| File | Purpose |
-|------|---------|
-| `src/lib/logging/policy.ts` | Field registry, classification helpers, redaction engine, `findSecretLeak` assertion helper |
-| `src/lib/requestContext.ts` | AsyncLocalStorage-based correlation ID context management, sanitization, propagation helpers |
+| File                               | Purpose                                                                                                                                            |
+| ---------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `src/lib/logging/policy.ts`        | Field registry, classification helpers, redaction engine, `findSecretLeak` assertion helper                                                        |
+| `src/lib/requestContext.ts`        | AsyncLocalStorage-based correlation ID context management, sanitization, propagation helpers                                                       |
 | `src/middleware/request-logger.ts` | Express middleware — accepts/sanitizes X-Request-Id header, generates ULID if needed, captures and redacts request/response, emits structured JSON |
-| `src/middleware/access-log.ts` | Access logging middleware for sensitive data with correlation ID support |
-| `src/services/eventProcessor.ts` | Event processing with correlation ID logging |
-| `src/services/webhook/delivery.ts` | Webhook delivery with correlation ID propagation to outbound requests |
+| `src/middleware/access-log.ts`     | Access logging middleware for sensitive data with correlation ID support                                                                           |
+| `src/services/eventProcessor.ts`   | Event processing with correlation ID logging                                                                                                       |
+| `src/services/webhook/delivery.ts` | Webhook delivery with correlation ID propagation to outbound requests                                                                              |
 
 ---
 
@@ -261,13 +356,13 @@ import { classifyField, isSecret, redactObject } from "../lib/logging/policy";
 
 // Classify a single field
 classifyField("authorization"); // → "secret"
-classifyField("invoice_id");    // → "public"
-classifyField("amount");        // → "private"
+classifyField("invoice_id"); // → "public"
+classifyField("amount"); // → "private"
 
 // Type-guards
-isSecret("tax_id");   // true
-isPublic("status");   // true
-isPrivate("amount");  // true
+isSecret("tax_id"); // true
+isPublic("status"); // true
+isPrivate("amount"); // true
 
 // Redact a whole object
 const safe = redactObject(rawBody);
@@ -347,13 +442,13 @@ Each request produces one JSON line on `stdout`:
 
 ## Security Assumptions
 
-| Assumption | Rationale |
-|------------|-----------|
-| Log sinks are **untrusted** surfaces | Logs may be forwarded to third-party aggregators. No SECRET value must ever reach them. |
-| Hash prefix only (8 hex chars) | Full SHA-256 of short values like wallet addresses is brute-forceable. An 8-char prefix is correlation-safe but not reversible. |
-| No crypto on SECRET tier | Applying any transformation to a secret value (even hashing) is a risk vector. Replacement with `[REDACTED]` is the only safe operation. |
-| Deny-by-default | A newly added field that is not in the registry falls back to PRIVATE, not PUBLIC. |
-| `res.json` is the sole capture point | Only structured JSON responses are inspected. Binary streams and redirects are not captured. |
+| Assumption                           | Rationale                                                                                                                                |
+| ------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| Log sinks are **untrusted** surfaces | Logs may be forwarded to third-party aggregators. No SECRET value must ever reach them.                                                  |
+| Hash prefix only (8 hex chars)       | Full SHA-256 of short values like wallet addresses is brute-forceable. An 8-char prefix is correlation-safe but not reversible.          |
+| No crypto on SECRET tier             | Applying any transformation to a secret value (even hashing) is a risk vector. Replacement with `[REDACTED]` is the only safe operation. |
+| Deny-by-default                      | A newly added field that is not in the registry falls back to PRIVATE, not PUBLIC.                                                       |
+| `res.json` is the sole capture point | Only structured JSON responses are inspected. Binary streams and redirects are not captured.                                             |
 
 ---
 
@@ -368,9 +463,9 @@ Each request produces one JSON line on `stdout`:
 // Example: adding a new private field
 const FIELD_POLICY: Record<string, FieldTier> = {
   // ...
-  ledger_index: FieldTier.PUBLIC,   // safe to log verbatim
-  fee_amount:   FieldTier.PRIVATE,  // hash before logging
-  seed_phrase:  FieldTier.SECRET,   // already exists — never log
+  ledger_index: FieldTier.PUBLIC, // safe to log verbatim
+  fee_amount: FieldTier.PRIVATE, // hash before logging
+  seed_phrase: FieldTier.SECRET, // already exists — never log
 };
 ```
 
@@ -388,10 +483,10 @@ npm test
 
 ### Test coverage (our files)
 
-| File | Stmts | Branch | Funcs | Lines |
-|------|-------|--------|-------|-------|
-| `lib/logging/policy.ts` | 98.5% | 98.3% | 100% | 98.3% |
-| `middleware/request-logger.ts` | 100% | 100% | 100% | 100% |
+| File                           | Stmts | Branch | Funcs | Lines |
+| ------------------------------ | ----- | ------ | ----- | ----- |
+| `lib/logging/policy.ts`        | 98.5% | 98.3%  | 100%  | 98.3% |
+| `middleware/request-logger.ts` | 100%  | 100%   | 100%  | 100%  |
 
 ### Key test categories
 

--- a/backend/src/lib/tracing.ts
+++ b/backend/src/lib/tracing.ts
@@ -1,0 +1,157 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+import { ulid } from "ulid";
+import { getCorrelationId } from "./requestContext";
+
+export type SpanAttributes = Record<string, unknown>;
+
+export interface Span {
+  name: string;
+  traceId: string;
+  spanId: string;
+  parentSpanId: string | null;
+  attrs: SpanAttributes;
+  startedAtMs: number;
+  startedAtNs: bigint;
+  ended: boolean;
+}
+
+interface SpanContext {
+  traceId: string;
+  spanId: string;
+}
+
+interface SpanLogEntry {
+  level: "INFO";
+  type: "TRACE_SPAN";
+  event: "start" | "end";
+  timestamp: string;
+  name: string;
+  trace_id: string;
+  span_id: string;
+  parent_span_id: string | null;
+  duration_ms?: number;
+  error?: boolean;
+  error_message?: string;
+  attrs: SpanAttributes;
+}
+
+const spanContextStorage = new AsyncLocalStorage<SpanContext>();
+
+function isPromise<T>(value: T | Promise<T>): value is Promise<T> {
+  return !!value && typeof (value as Promise<T>).then === "function";
+}
+
+function emitSpanLog(entry: SpanLogEntry): void {
+  process.stdout.write(`${JSON.stringify(entry)}\n`);
+}
+
+function buildTraceId(parent?: SpanContext): string {
+  if (parent?.traceId) {
+    return parent.traceId;
+  }
+
+  const inboundRequestId = getCorrelationId();
+  return inboundRequestId && inboundRequestId.length > 0
+    ? inboundRequestId
+    : ulid();
+}
+
+export function startSpan(name: string, attrs: SpanAttributes = {}): Span {
+  const parent = spanContextStorage.getStore();
+
+  const span: Span = {
+    name,
+    traceId: buildTraceId(parent),
+    spanId: ulid(),
+    parentSpanId: parent?.spanId ?? null,
+    attrs,
+    startedAtMs: Date.now(),
+    startedAtNs: process.hrtime.bigint(),
+    ended: false,
+  };
+
+  emitSpanLog({
+    level: "INFO",
+    type: "TRACE_SPAN",
+    event: "start",
+    timestamp: new Date(span.startedAtMs).toISOString(),
+    name: span.name,
+    trace_id: span.traceId,
+    span_id: span.spanId,
+    parent_span_id: span.parentSpanId,
+    attrs: span.attrs,
+  });
+
+  return span;
+}
+
+export function endSpan(span: Span, err?: unknown): void {
+  if (span.ended) {
+    return;
+  }
+
+  span.ended = true;
+  const endedAtNs = process.hrtime.bigint();
+  const durationMs = Number(endedAtNs - span.startedAtNs) / 1_000_000;
+
+  emitSpanLog({
+    level: "INFO",
+    type: "TRACE_SPAN",
+    event: "end",
+    timestamp: new Date().toISOString(),
+    name: span.name,
+    trace_id: span.traceId,
+    span_id: span.spanId,
+    parent_span_id: span.parentSpanId,
+    duration_ms: durationMs,
+    error: err !== undefined,
+    error_message:
+      err instanceof Error ? err.message : err ? String(err) : undefined,
+    attrs: span.attrs,
+  });
+}
+
+export function withSpan<T>(
+  name: string,
+  attrs: SpanAttributes,
+  fn: () => Promise<T>,
+): Promise<T>;
+export function withSpan<T>(
+  name: string,
+  attrs: SpanAttributes,
+  fn: () => T,
+): T;
+export function withSpan<T>(
+  name: string,
+  attrs: SpanAttributes,
+  fn: () => T | Promise<T>,
+): T | Promise<T> {
+  const span = startSpan(name, attrs);
+
+  return spanContextStorage.run(
+    { traceId: span.traceId, spanId: span.spanId },
+    () => {
+      try {
+        const result = fn();
+
+        if (isPromise(result)) {
+          return result
+            .then((value) => {
+              endSpan(span);
+              return value;
+            })
+            .catch((err) => {
+              endSpan(span, err);
+              throw err;
+            });
+        }
+
+        endSpan(span);
+        return result;
+      } catch (err) {
+        endSpan(span, err);
+        throw err;
+      }
+    },
+  );
+}

--- a/backend/src/lib/tracing.ts
+++ b/backend/src/lib/tracing.ts
@@ -63,7 +63,7 @@ export function startSpan(name: string, attrs: SpanAttributes = {}): Span {
     name,
     traceId: buildTraceId(parent),
     spanId: ulid(),
-    parentSpanId: parent?.spanId ?? null,
+    parentSpanId: parent ? parent.spanId : null,
     attrs,
     startedAtMs: Date.now(),
     startedAtNs: process.hrtime.bigint(),

--- a/backend/src/services/ingestion.ts
+++ b/backend/src/services/ingestion.ts
@@ -9,6 +9,7 @@
  */
 
 // lagMonitor is loaded dynamically to avoid circular deps in test env
+import { withSpan } from "../lib/tracing";
 
 export interface IndexedEvent {
   ledger: number;
@@ -53,36 +54,50 @@ export interface IngestionResult {
 export async function ingestBatch(
   store: IngestionStore,
   events: IndexedEvent[],
-  batchCursor: number
+  batchCursor: number,
 ): Promise<IngestionResult> {
-  const currentCursor = await store.getCursor();
+  return withSpan(
+    "ingestion.ingestBatch",
+    { batch_cursor: batchCursor, events_count: events.length },
+    async () => {
+      const currentCursor = await store.getCursor();
 
-  // Idempotency: if we've already processed up to or past this cursor, skip.
-  if (currentCursor !== null && batchCursor <= currentCursor) {
-    return { committed: false, cursor: currentCursor, eventsProcessed: 0, skipped: true };
-  }
+      // Idempotency: if we've already processed up to or past this cursor, skip.
+      if (currentCursor !== null && batchCursor <= currentCursor) {
+        return {
+          committed: false,
+          cursor: currentCursor,
+          eventsProcessed: 0,
+          skipped: true,
+        };
+      }
 
-  // Validate all events before writing anything — prevents partial state.
-  for (const event of events) {
-    validateEvent(event);
-  }
+      // Validate all events before writing anything — prevents partial state.
+      for (const event of events) {
+        validateEvent(event);
+      }
 
-  // Delegate the atomic commit to the store.
-  await store.commitBatch(events, batchCursor);
+      // Delegate the atomic commit to the store.
+      await store.commitBatch(events, batchCursor);
 
-  // Record metric for monitoring (non-fatal if it fails)
-  try {
-    (await import('./lagMonitor')).lagMonitor.recordIngestion(batchCursor, events.length);
-  } catch {
-    // Metrics failure must not break ingestion
-  }
+      // Record metric for monitoring (non-fatal if it fails)
+      try {
+        (await import("./lagMonitor")).lagMonitor.recordIngestion(
+          batchCursor,
+          events.length,
+        );
+      } catch {
+        // Metrics failure must not break ingestion
+      }
 
-  return {
-    committed: true,
-    cursor: batchCursor,
-    eventsProcessed: events.length,
-    skipped: false,
-  };
+      return {
+        committed: true,
+        cursor: batchCursor,
+        eventsProcessed: events.length,
+        skipped: false,
+      };
+    },
+  );
 }
 
 /**
@@ -99,46 +114,52 @@ export async function ingestBatch(
 export async function rollbackAndReingest(
   store: IngestionStore,
   targetCursor: number,
-  fetchBatch: (cursor: number) => Promise<{ rawEvents: IndexedEvent[] }>
+  fetchBatch: (cursor: number) => Promise<{ rawEvents: IndexedEvent[] }>,
 ): Promise<{ newCursor: number }> {
-  // 1. Rollback to the last known good cursor
-  await store.rollbackTo(targetCursor);
+  return withSpan(
+    "ingestion.rollbackAndReingest",
+    { target_cursor: targetCursor },
+    async () => {
+      // 1. Rollback to the last known good cursor
+      await store.rollbackTo(targetCursor);
 
-  // Emit rollback metric (non-fatal if it fails)
-  try {
-    (await import('./lagMonitor')).lagMonitor.recordRollback(targetCursor);
-  } catch {
-    // Metrics failure must not break recovery
-  }
-
-  // 2. Re-ingest from targetCursor + 1 forward until caught up
-  let currentCursor = targetCursor;
-  const maxIterations = 10_000; // safety valve
-
-  for (let i = 0; i < maxIterations; i++) {
-    const nextCursor = currentCursor + 1;
-    try {
-      const batch = await fetchBatch(nextCursor);
-      if (!batch.rawEvents || batch.rawEvents.length === 0) {
-        // No more batches available — we're caught up
-        break;
+      // Emit rollback metric (non-fatal if it fails)
+      try {
+        (await import("./lagMonitor")).lagMonitor.recordRollback(targetCursor);
+      } catch {
+        // Metrics failure must not break recovery
       }
 
-      const result = await ingestBatch(store, batch.rawEvents, nextCursor);
-      currentCursor = result.cursor;
+      // 2. Re-ingest from targetCursor + 1 forward until caught up
+      let currentCursor = targetCursor;
+      const maxIterations = 10_000; // safety valve
 
-      if (result.skipped) {
-        // Already at or past this cursor, keep going
-        continue;
+      for (let i = 0; i < maxIterations; i++) {
+        const nextCursor = currentCursor + 1;
+        try {
+          const batch = await fetchBatch(nextCursor);
+          if (!batch.rawEvents || batch.rawEvents.length === 0) {
+            // No more batches available — we're caught up
+            break;
+          }
+
+          const result = await ingestBatch(store, batch.rawEvents, nextCursor);
+          currentCursor = result.cursor;
+
+          if (result.skipped) {
+            // Already at or past this cursor, keep going
+            continue;
+          }
+        } catch (err) {
+          throw new Error(
+            `Re-ingestion failed at cursor ${nextCursor}: ${err instanceof Error ? err.message : String(err)}`,
+          );
+        }
       }
-    } catch (err) {
-      throw new Error(
-        `Re-ingestion failed at cursor ${nextCursor}: ${err instanceof Error ? err.message : String(err)}`
-      );
-    }
-  }
 
-  return { newCursor: currentCursor };
+      return { newCursor: currentCursor };
+    },
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -187,7 +208,7 @@ export class InMemoryIngestionStore implements IngestionStore {
     if (cursor < 0) {
       throw new Error("Cannot rollback below genesis: cursor must be >= 0");
     }
-    this.events = this.events.filter(e => e.ledger <= cursor);
+    this.events = this.events.filter((e) => e.ledger <= cursor);
     this.cursor = cursor;
   }
 

--- a/backend/src/services/invariantService.ts
+++ b/backend/src/services/invariantService.ts
@@ -7,6 +7,7 @@ import {
   BidStatus,
   SettlementStatus,
 } from "../types/contract";
+import { withSpan } from "../lib/tracing";
 
 const MAX_SAMPLE_IDS = 5;
 
@@ -145,24 +146,26 @@ function scanMismatchSettlements(
 export async function checkOrphans(
   provider: InvariantDataProvider,
 ): Promise<InvariantReport> {
-  const [invoices, bids, settlements, disputes] = await Promise.all([
-    provider.getInvoices(),
-    provider.getBids(),
-    provider.getSettlements(),
-    provider.getDisputes(),
-  ]);
+  return withSpan("invariant.checkOrphans", {}, async () => {
+    const [invoices, bids, settlements, disputes] = await Promise.all([
+      provider.getInvoices(),
+      provider.getBids(),
+      provider.getSettlements(),
+      provider.getDisputes(),
+    ]);
 
-  const validInvoiceIds = new Set(invoices.map((i) => i.id));
-  return {
-    orphanBids: scanOrphans(bids as HasInvoiceId[], validInvoiceIds),
-    orphanSettlements: scanOrphans(
-      settlements as HasInvoiceId[],
-      validInvoiceIds,
-    ),
-    orphanDisputes: scanOrphans(disputes as HasInvoiceId[], validInvoiceIds),
-    mismatchSettlements: scanMismatchSettlements(bids, settlements),
-    timestamp: new Date().toISOString(),
-  };
+    const validInvoiceIds = new Set(invoices.map((i) => i.id));
+    return {
+      orphanBids: scanOrphans(bids as HasInvoiceId[], validInvoiceIds),
+      orphanSettlements: scanOrphans(
+        settlements as HasInvoiceId[],
+        validInvoiceIds,
+      ),
+      orphanDisputes: scanOrphans(disputes as HasInvoiceId[], validInvoiceIds),
+      mismatchSettlements: scanMismatchSettlements(bids, settlements),
+      timestamp: new Date().toISOString(),
+    };
+  });
 }
 
 // ── Cursor sequence ───────────────────────────────────────────────────────────
@@ -173,25 +176,31 @@ export async function checkOrphans(
  * indicate a regression (duplicate replay or rollback without re-index).
  */
 export function checkCursorSequence(cursors: number[]): CursorRegressionReport {
-  const regressions: Array<{
-    index: number;
-    previous: number;
-    current: number;
-  }> = [];
-  for (let i = 1; i < cursors.length; i++) {
-    if (cursors[i] <= cursors[i - 1]) {
-      regressions.push({
-        index: i,
-        previous: cursors[i - 1],
-        current: cursors[i],
-      });
-    }
-  }
-  return {
-    hasRegression: regressions.length > 0,
-    regressionCount: regressions.length,
-    regressions,
-  };
+  return withSpan(
+    "invariant.checkCursorSequence",
+    { cursor_count: cursors.length },
+    () => {
+      const regressions: Array<{
+        index: number;
+        previous: number;
+        current: number;
+      }> = [];
+      for (let i = 1; i < cursors.length; i++) {
+        if (cursors[i] <= cursors[i - 1]) {
+          regressions.push({
+            index: i,
+            previous: cursors[i - 1],
+            current: cursors[i],
+          });
+        }
+      }
+      return {
+        hasRegression: regressions.length > 0,
+        regressionCount: regressions.length,
+        regressions,
+      };
+    },
+  );
 }
 
 // ── Accounting totals ─────────────────────────────────────────────────────────
@@ -205,37 +214,39 @@ export function checkCursorSequence(cursors: number[]): CursorRegressionReport {
 export async function checkAccountingTotals(
   provider: InvariantDataProvider,
 ): Promise<AccountingReport> {
-  const [bids, settlements] = await Promise.all([
-    provider.getBids(),
-    provider.getSettlements(),
-  ]);
+  return withSpan("invariant.checkAccountingTotals", {}, async () => {
+    const [bids, settlements] = await Promise.all([
+      provider.getBids(),
+      provider.getSettlements(),
+    ]);
 
-  const acceptedBidByInvoice = new Map<string, Bid>();
-  for (const bid of bids) {
-    if (bid.status === BidStatus.Accepted) {
-      acceptedBidByInvoice.set(bid.invoice_id, bid);
+    const acceptedBidByInvoice = new Map<string, Bid>();
+    for (const bid of bids) {
+      if (bid.status === BidStatus.Accepted) {
+        acceptedBidByInvoice.set(bid.invoice_id, bid);
+      }
     }
-  }
 
-  const mismatchIds: string[] = [];
-  for (const settlement of settlements) {
-    if (settlement.status !== SettlementStatus.Paid) continue;
-    const bid = acceptedBidByInvoice.get(settlement.invoice_id);
-    if (!bid) {
-      mismatchIds.push(settlement.invoice_id);
-      continue;
+    const mismatchIds: string[] = [];
+    for (const settlement of settlements) {
+      if (settlement.status !== SettlementStatus.Paid) continue;
+      const bid = acceptedBidByInvoice.get(settlement.invoice_id);
+      if (!bid) {
+        mismatchIds.push(settlement.invoice_id);
+        continue;
+      }
+      if (BigInt(settlement.amount) !== BigInt(bid.bid_amount)) {
+        mismatchIds.push(settlement.invoice_id);
+      }
     }
-    if (BigInt(settlement.amount) !== BigInt(bid.bid_amount)) {
-      mismatchIds.push(settlement.invoice_id);
-    }
-  }
 
-  return {
-    mismatches: {
-      count: mismatchIds.length,
-      sampleIds: mismatchIds.slice(0, MAX_SAMPLE_IDS),
-    },
-  };
+    return {
+      mismatches: {
+        count: mismatchIds.length,
+        sampleIds: mismatchIds.slice(0, MAX_SAMPLE_IDS),
+      },
+    };
+  });
 }
 
 // ── Full suite ────────────────────────────────────────────────────────────────
@@ -249,27 +260,33 @@ export async function runFullInvariantSuite(
   provider: InvariantDataProvider,
   cursorHistory: number[],
 ): Promise<FullInvariantReport> {
-  const [orphans, accounting] = await Promise.all([
-    checkOrphans(provider),
-    checkAccountingTotals(provider),
-  ]);
-  const cursorSequence = checkCursorSequence(cursorHistory);
+  return withSpan(
+    "invariant.runFullInvariantSuite",
+    { cursor_history_count: cursorHistory.length },
+    async () => {
+      const [orphans, accounting] = await Promise.all([
+        checkOrphans(provider),
+        checkAccountingTotals(provider),
+      ]);
+      const cursorSequence = checkCursorSequence(cursorHistory);
 
-  const pass =
-    orphans.orphanBids.count === 0 &&
-    orphans.orphanSettlements.count === 0 &&
-    orphans.orphanDisputes.count === 0 &&
-    orphans.mismatchSettlements.count === 0 &&
-    !cursorSequence.hasRegression &&
-    accounting.mismatches.count === 0;
+      const pass =
+        orphans.orphanBids.count === 0 &&
+        orphans.orphanSettlements.count === 0 &&
+        orphans.orphanDisputes.count === 0 &&
+        orphans.mismatchSettlements.count === 0 &&
+        !cursorSequence.hasRegression &&
+        accounting.mismatches.count === 0;
 
-  return {
-    orphans,
-    cursorSequence,
-    accounting,
-    timestamp: new Date().toISOString(),
-    pass,
-  };
+      return {
+        orphans,
+        cursorSequence,
+        accounting,
+        timestamp: new Date().toISOString(),
+        pass,
+      };
+    },
+  );
 }
 
 // ── Persistence ───────────────────────────────────────────────────────────────
@@ -375,39 +392,43 @@ function recordMetrics(report: FullInvariantReport): void {
 // ── Alerting ────────────────────────────────────────────────────────────────
 
 export function emitInvariantAlert(report: FullInvariantReport): void {
-  if (report.pass) return;
+  withSpan("invariant.emitInvariantAlert", { pass: report.pass }, () => {
+    if (report.pass) return;
 
-  const violations: string[] = [];
-  if (report.orphans.orphanBids.count > 0)
-    violations.push(`orphan_bids: ${report.orphans.orphanBids.count}`);
-  if (report.orphans.orphanSettlements.count > 0)
-    violations.push(
-      `orphan_settlements: ${report.orphans.orphanSettlements.count}`,
-    );
-  if (report.orphans.orphanDisputes.count > 0)
-    violations.push(`orphan_disputes: ${report.orphans.orphanDisputes.count}`);
-  if (report.orphans.mismatchSettlements.count > 0)
-    violations.push(
-      `mismatch_settlements: ${report.orphans.mismatchSettlements.count}`,
-    );
-  if (report.cursorSequence.hasRegression)
-    violations.push(
-      `cursor_regression: ${report.cursorSequence.regressionCount}`,
-    );
-  if (report.accounting.mismatches.count > 0)
-    violations.push(
-      `accounting_mismatches: ${report.accounting.mismatches.count}`,
-    );
+    const violations: string[] = [];
+    if (report.orphans.orphanBids.count > 0)
+      violations.push(`orphan_bids: ${report.orphans.orphanBids.count}`);
+    if (report.orphans.orphanSettlements.count > 0)
+      violations.push(
+        `orphan_settlements: ${report.orphans.orphanSettlements.count}`,
+      );
+    if (report.orphans.orphanDisputes.count > 0)
+      violations.push(
+        `orphan_disputes: ${report.orphans.orphanDisputes.count}`,
+      );
+    if (report.orphans.mismatchSettlements.count > 0)
+      violations.push(
+        `mismatch_settlements: ${report.orphans.mismatchSettlements.count}`,
+      );
+    if (report.cursorSequence.hasRegression)
+      violations.push(
+        `cursor_regression: ${report.cursorSequence.regressionCount}`,
+      );
+    if (report.accounting.mismatches.count > 0)
+      violations.push(
+        `accounting_mismatches: ${report.accounting.mismatches.count}`,
+      );
 
-  console.error(
-    JSON.stringify({
-      level: "ALERT",
-      type: "INVARIANT_VIOLATION",
-      timestamp: report.timestamp,
-      violations,
-      message: `Invariant violation detected: ${violations.join(", ")}`,
-    }),
-  );
+    console.error(
+      JSON.stringify({
+        level: "ALERT",
+        type: "INVARIANT_VIOLATION",
+        timestamp: report.timestamp,
+        violations,
+        message: `Invariant violation detected: ${violations.join(", ")}`,
+      }),
+    );
+  });
 }
 
 // ── Scheduler ───────────────────────────────────────────────────────────────
@@ -454,30 +475,36 @@ export class InvariantScheduler {
   }
 
   private async runCheck(): Promise<void> {
-    if (!this.provider) return;
+    await withSpan(
+      "invariant.scheduler.runCheck",
+      { cursor_history_count: this.cursorHistory.length },
+      async () => {
+        if (!this.provider) return;
 
-    try {
-      const report = await runFullInvariantSuite(
-        this.provider,
-        this.cursorHistory,
-      );
-      recordMetrics(report);
-      reportStore.add({
-        report,
-        cursorHistory: [...this.cursorHistory],
-        runAt: report.timestamp,
-      });
-      emitInvariantAlert(report);
-    } catch (err) {
-      console.error(
-        JSON.stringify({
-          level: "ERROR",
-          type: "INVARIANT_CHECK_FAILED",
-          timestamp: new Date().toISOString(),
-          error: err instanceof Error ? err.message : String(err),
-        }),
-      );
-    }
+        try {
+          const report = await runFullInvariantSuite(
+            this.provider,
+            this.cursorHistory,
+          );
+          recordMetrics(report);
+          reportStore.add({
+            report,
+            cursorHistory: [...this.cursorHistory],
+            runAt: report.timestamp,
+          });
+          emitInvariantAlert(report);
+        } catch (err) {
+          console.error(
+            JSON.stringify({
+              level: "ERROR",
+              type: "INVARIANT_CHECK_FAILED",
+              timestamp: new Date().toISOString(),
+              error: err instanceof Error ? err.message : String(err),
+            }),
+          );
+        }
+      },
+    );
   }
 
   isStarted(): boolean {

--- a/backend/src/services/reconciliationWorker.ts
+++ b/backend/src/services/reconciliationWorker.ts
@@ -1,8 +1,14 @@
-import { DriftReport, DriftItem, BackfillResult } from "../types/reconciliation";
+import {
+  DriftReport,
+  DriftItem,
+  BackfillResult,
+} from "../types/reconciliation";
 import { Invoice } from "../types/contract";
 import { rpcClient } from "./rpcClient";
 import { derivedTableStore } from "./replayService";
 import { MockDataProviders } from "./mockDataProviders";
+import { backfillService } from "./backfillService";
+import { withSpan } from "../lib/tracing";
 
 export class ReconciliationWorker {
   private static reports: DriftReport[] = [];
@@ -10,96 +16,121 @@ export class ReconciliationWorker {
   private static backfillBatchSize: number = 10;
   public static failBackfill: boolean = false;
 
-
   static async runReconciliation(): Promise<DriftReport> {
-    if (this.isRunning) {
-      throw new Error("Reconciliation already in progress");
-    }
-
-    this.isRunning = true;
-    try {
-      // Small pause to reduce contention with other services
-      await new Promise((resolve) => setTimeout(resolve, 50));
-
-      // Read indexed invoices from the derived table store.
-      // In test environment use the mock indexed data to keep tests hermetic.
-      const indexed: Invoice[] =
-        process.env.NODE_ENV === "test"
-          ? MockDataProviders.getIndexedInvoices()
-          : (await derivedTableStore.listInvoices?.()) || [];
-
-      // Fetch canonical on-chain invoices via reliable RPC client
-      let onChain: Invoice[] = [];
-      try {
-        // RPC method name is intentionally generic; tests may mock this call
-        onChain = await rpcClient.call<Invoice[]>("getInvoices", []);
-      } catch (rpcErr) {
-        // In test environment, fall back to mock on-chain data so reconciliation tests work without network
-        if (process.env.NODE_ENV === "test") {
-          onChain = MockDataProviders.getOnChainInvoices();
-        } else {
-          const report: DriftReport = {
-            timestamp: Math.floor(Date.now() / 1000),
-            totalRecordsChecked: 0,
-            driftCount: 0,
-            drifts: [],
-            error: rpcErr instanceof Error ? rpcErr.message : String(rpcErr),
-          } as any;
-
-          this.reports.push(report);
-          return report;
-        }
+    return withSpan("reconciliation.runReconciliation", {}, async () => {
+      if (this.isRunning) {
+        throw new Error("Reconciliation already in progress");
       }
-      const drifts: DriftItem[] = [];
 
-      // Check for missing or mismatched records
-      onChain.forEach((oc) => {
-        const idx = indexed.find((i) => i.id === oc.id);
-        if (!idx) {
-          drifts.push({
-            id: oc.id,
-            type: "Invoice",
-            driftType: "MISSING",
-            onChainValue: oc,
-          });
-        } else if (idx.status !== oc.status) {
-          drifts.push({
-            id: oc.id,
-            type: "Invoice",
-            driftType: "STATUS_MISMATCH",
-            indexedValue: idx.status,
-            onChainValue: oc.status,
-          });
+      this.isRunning = true;
+      try {
+        // Small pause to reduce contention with other services
+        await new Promise((resolve) => setTimeout(resolve, 50));
+
+        // Read indexed invoices from the derived table store.
+        // In test environment use the mock indexed data to keep tests hermetic.
+        const indexed: Invoice[] =
+          process.env.NODE_ENV === "test"
+            ? MockDataProviders.getIndexedInvoices()
+            : (await derivedTableStore.listInvoices?.()) || [];
+
+        // Fetch canonical on-chain invoices via reliable RPC client
+        let onChain: Invoice[] = [];
+        try {
+          // RPC method name is intentionally generic; tests may mock this call
+          onChain = await rpcClient.call<Invoice[]>("getInvoices", []);
+        } catch (rpcErr) {
+          // In test environment, fall back to mock on-chain data so reconciliation tests work without network
+          if (process.env.NODE_ENV === "test") {
+            onChain = MockDataProviders.getOnChainInvoices();
+          } else {
+            const report: DriftReport = {
+              timestamp: Math.floor(Date.now() / 1000),
+              totalRecordsChecked: 0,
+              driftCount: 0,
+              drifts: [],
+              error: rpcErr instanceof Error ? rpcErr.message : String(rpcErr),
+            } as any;
+
+            this.reports.push(report);
+            return report;
+          }
         }
-      });
+        const drifts: DriftItem[] = [];
 
-      const report: DriftReport = {
-        timestamp: Math.floor(Date.now() / 1000),
-        totalRecordsChecked: onChain.length,
-        driftCount: drifts.length,
-        drifts,
-      };
+        // Check for missing or mismatched records
+        onChain.forEach((oc) => {
+          const idx = indexed.find((i) => i.id === oc.id);
+          if (!idx) {
+            drifts.push({
+              id: oc.id,
+              type: "Invoice",
+              driftType: "MISSING",
+              onChainValue: oc,
+            });
+          } else if (idx.status !== oc.status) {
+            drifts.push({
+              id: oc.id,
+              type: "Invoice",
+              driftType: "STATUS_MISMATCH",
+              indexedValue: idx.status,
+              onChainValue: oc.status,
+            });
+          }
+        });
 
-      this.reports.push(report);
-      return report;
-    } finally {
-      this.isRunning = false;
-    }
+        const report: DriftReport = {
+          timestamp: Math.floor(Date.now() / 1000),
+          totalRecordsChecked: onChain.length,
+          driftCount: drifts.length,
+          drifts,
+        };
+
+        this.reports.push(report);
+        return report;
+      } finally {
+        this.isRunning = false;
+      }
+    });
   }
 
-  static async triggerBoundedBackfill(report: DriftReport): Promise<BackfillResult> {
-    return backfillService.triggerDriftBackfill(report, this.backfillBatchSize, ReconciliationWorker.failBackfill);
+  static async triggerBoundedBackfill(
+    report: DriftReport,
+  ): Promise<BackfillResult> {
+    return withSpan(
+      "reconciliation.triggerBoundedBackfill",
+      { drift_count: report.driftCount, batch_size: this.backfillBatchSize },
+      () =>
+        backfillService.triggerDriftBackfill(
+          report,
+          this.backfillBatchSize,
+          ReconciliationWorker.failBackfill,
+        ),
+    );
   }
 
   static getLatestReport(): DriftReport | null {
-    return this.reports.length > 0 ? this.reports[this.reports.length - 1] : null;
+    return withSpan(
+      "reconciliation.getLatestReport",
+      { report_count: this.reports.length },
+      () =>
+        this.reports.length > 0 ? this.reports[this.reports.length - 1] : null,
+    );
   }
 
   static getAllReports(): DriftReport[] {
-    return this.reports;
+    return withSpan(
+      "reconciliation.getAllReports",
+      { report_count: this.reports.length },
+      () => this.reports,
+    );
   }
 
   static isReconciliationRunning(): boolean {
-    return this.isRunning;
+    return withSpan(
+      "reconciliation.isReconciliationRunning",
+      {},
+      () => this.isRunning,
+    );
   }
 }

--- a/backend/src/tests/tracing.test.ts
+++ b/backend/src/tests/tracing.test.ts
@@ -1,0 +1,235 @@
+import { withCorrelationId } from "../lib/requestContext";
+import { endSpan, startSpan, withSpan } from "../lib/tracing";
+
+function collectSpanEntries(
+  writeCalls: Array<[any, ...any[]]>,
+): Array<Record<string, any>> {
+  return writeCalls
+    .map(([chunk]) =>
+      typeof chunk === "string" ? chunk : chunk.toString("utf8"),
+    )
+    .flatMap((line) => line.split("\n"))
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0)
+    .map((line) => JSON.parse(line))
+    .filter((entry) => entry.type === "TRACE_SPAN");
+}
+
+function median(values: number[]): number {
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted[mid];
+}
+
+function expectDefined<T>(value: T | undefined, label: string): T {
+  if (value === undefined) {
+    throw new Error(`${label} must be present`);
+  }
+  return value as T;
+}
+
+describe("tracing spans", () => {
+  let writeSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    writeSpy = jest
+      .spyOn(process.stdout, "write")
+      .mockImplementation(() => true);
+  });
+
+  afterEach(() => {
+    writeSpy.mockRestore();
+  });
+
+  it("preserves parent-child relationship across async boundaries", async () => {
+    await withCorrelationId("req-async-001", async () => {
+      await withSpan("pipeline.parent", { stage: "ingestion" }, async () => {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+        await withSpan("pipeline.child", { stage: "invariant" }, async () => {
+          await Promise.resolve();
+        });
+      });
+    });
+
+    const entries = collectSpanEntries(
+      writeSpy.mock.calls as Array<[any, ...any[]]>,
+    );
+    const parentStart = entries.find(
+      (entry) => entry.event === "start" && entry.name === "pipeline.parent",
+    );
+    const childStart = entries.find(
+      (entry) => entry.event === "start" && entry.name === "pipeline.child",
+    );
+
+    const safeParentStart = expectDefined(parentStart, "parent start span");
+    const safeChildStart = expectDefined(childStart, "child start span");
+    expect(safeChildStart.trace_id).toBe(safeParentStart.trace_id);
+    expect(safeChildStart.parent_span_id).toBe(safeParentStart.span_id);
+  });
+
+  it("ends a span with error=true when the wrapped function throws", async () => {
+    await expect(
+      withSpan("pipeline.failure", { stage: "reconciliation" }, async () => {
+        throw new Error("boom");
+      }),
+    ).rejects.toThrow("boom");
+
+    const entries = collectSpanEntries(
+      writeSpy.mock.calls as Array<[any, ...any[]]>,
+    );
+    const endEntry = entries.find(
+      (entry) => entry.event === "end" && entry.name === "pipeline.failure",
+    );
+
+    const safeEndEntry = expectDefined(endEntry, "failed span end entry");
+    expect(safeEndEntry.error).toBe(true);
+    expect(safeEndEntry.error_message).toBe("boom");
+  });
+
+  it("includes span attributes in both start and end logs", async () => {
+    await withSpan(
+      "pipeline.attributes",
+      { batch_cursor: 42, events_count: 3, service: "ingestion" },
+      async () => {
+        await Promise.resolve();
+      },
+    );
+
+    const entries = collectSpanEntries(
+      writeSpy.mock.calls as Array<[any, ...any[]]>,
+    );
+    const startEntry = entries.find(
+      (entry) =>
+        entry.event === "start" && entry.name === "pipeline.attributes",
+    );
+    const endEntry = entries.find(
+      (entry) => entry.event === "end" && entry.name === "pipeline.attributes",
+    );
+
+    const safeStartEntry = expectDefined(startEntry, "attribute start span");
+    const safeEndEntry = expectDefined(endEntry, "attribute end span");
+
+    expect(safeStartEntry.attrs).toMatchObject({
+      batch_cursor: 42,
+      events_count: 3,
+      service: "ingestion",
+    });
+    expect(safeEndEntry.attrs).toMatchObject({
+      batch_cursor: 42,
+      events_count: 3,
+      service: "ingestion",
+    });
+  });
+
+  it("uses inbound request id as trace_id when present", async () => {
+    await withCorrelationId("client-request-abc-123", async () => {
+      await withSpan("pipeline.root", { service: "ingestion" }, async () => {
+        await Promise.resolve();
+      });
+    });
+
+    const entries = collectSpanEntries(
+      writeSpy.mock.calls as Array<[any, ...any[]]>,
+    );
+    const rootStart = entries.find(
+      (entry) => entry.event === "start" && entry.name === "pipeline.root",
+    );
+
+    const safeRootStart = expectDefined(rootStart, "root start span");
+    expect(safeRootStart.trace_id).toBe("client-request-abc-123");
+  });
+
+  it("generates a ULID trace_id when no inbound request id is present", () => {
+    withSpan("pipeline.generated-trace", {}, () => {
+      return 1;
+    });
+
+    const entries = collectSpanEntries(
+      writeSpy.mock.calls as Array<[any, ...any[]]>,
+    );
+    const startEntry = entries.find(
+      (entry) =>
+        entry.event === "start" && entry.name === "pipeline.generated-trace",
+    );
+    const safeStartEntry = expectDefined(
+      startEntry,
+      "generated trace start span",
+    );
+
+    expect(typeof safeStartEntry.trace_id).toBe("string");
+    expect(safeStartEntry.trace_id.length).toBeGreaterThan(0);
+    expect(safeStartEntry.trace_id).not.toBe("client-request-abc-123");
+  });
+
+  it("keeps hot-loop tracing overhead under 1%", () => {
+    const innerWork = (): number => {
+      let acc = 0;
+      for (let i = 0; i < 500_000; i++) {
+        acc += (i * 7) % 13;
+      }
+      return acc;
+    };
+
+    const measure = (fn: () => void): number => {
+      const start = process.hrtime.bigint();
+      fn();
+      const end = process.hrtime.bigint();
+      return Number(end - start) / 1_000_000;
+    };
+
+    const runHotLoop = () => {
+      for (let i = 0; i < 600; i++) {
+        innerWork();
+      }
+    };
+
+    const runTraced = () => {
+      withSpan("pipeline.hotloop", { mode: "benchmark" }, () => runHotLoop());
+    };
+
+    runHotLoop();
+    runTraced();
+
+    const baselineMs = measure(runHotLoop);
+    const tracedMs = measure(runTraced);
+    const overheadRatio = (tracedMs - baselineMs) / baselineMs;
+
+    expect(overheadRatio).toBeLessThan(0.01);
+  });
+
+  it("does not emit duplicate end logs when endSpan is called twice", () => {
+    const span = startSpan("pipeline.idempotent-end", { service: "invariant" });
+
+    endSpan(span);
+    endSpan(span);
+
+    const entries = collectSpanEntries(
+      writeSpy.mock.calls as Array<[any, ...any[]]>,
+    );
+    const endEntries = entries.filter(
+      (entry) =>
+        entry.event === "end" && entry.name === "pipeline.idempotent-end",
+    );
+
+    expect(endEntries).toHaveLength(1);
+  });
+
+  it("marks sync throw spans as errors", () => {
+    expect(() =>
+      withSpan("pipeline.sync-throw", { stage: "ingestion" }, () => {
+        throw "sync-boom";
+      }),
+    ).toThrow("sync-boom");
+
+    const entries = collectSpanEntries(
+      writeSpy.mock.calls as Array<[any, ...any[]]>,
+    );
+    const endEntry = entries.find(
+      (entry) => entry.event === "end" && entry.name === "pipeline.sync-throw",
+    );
+    const safeEndEntry = expectDefined(endEntry, "sync throw span end");
+
+    expect(safeEndEntry.error).toBe(true);
+    expect(safeEndEntry.error_message).toBe("sync-boom");
+  });
+});

--- a/backend/src/tests/tracing.test.ts
+++ b/backend/src/tests/tracing.test.ts
@@ -214,6 +214,32 @@ describe("tracing spans", () => {
     expect(endEntries).toHaveLength(1);
   });
 
+  it("assigns parent_span_id when creating a child span inside an active span", () => {
+    withSpan("pipeline.explicit-parent", {}, () => {
+      const child = startSpan("pipeline.explicit-child", {
+        service: "invariant",
+      });
+      endSpan(child);
+    });
+
+    const entries = collectSpanEntries(
+      writeSpy.mock.calls as Array<[any, ...any[]]>,
+    );
+    const parentStart = entries.find(
+      (entry) =>
+        entry.event === "start" && entry.name === "pipeline.explicit-parent",
+    );
+    const childStart = entries.find(
+      (entry) =>
+        entry.event === "start" && entry.name === "pipeline.explicit-child",
+    );
+
+    const safeParentStart = expectDefined(parentStart, "explicit parent start");
+    const safeChildStart = expectDefined(childStart, "explicit child start");
+
+    expect(safeChildStart.parent_span_id).toBe(safeParentStart.span_id);
+  });
+
   it("marks sync throw spans as errors", () => {
     expect(() =>
       withSpan("pipeline.sync-throw", { stage: "ingestion" }, () => {


### PR DESCRIPTION
closes #1188

Adds vendor-neutral tracing spans across the backend ingestion, invariant, and reconciliation pipeline. The new tracing helper emits structured JSON span start/end events with [trace_id](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html), [span_id](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html), [parent_span_id](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html), attributes, duration, and error metadata, and it reuses the inbound request correlation ID when one is present so operators can follow a causal chain from request to reconciliation alert.

The work also wraps the public service entrypoints in ingestion, invariant checking, and reconciliation so spans are emitted at the right boundaries, and it documents the span format in backend logging docs. A new test suite covers async parent-child propagation, error handling, span attributes, inbound request ID inheritance, and hot-loop overhead.