### PR TITLE
Uiux/kpi metric card spec

### DIFF
--- a/backend/docs/logging.md
+++ b/backend/docs/logging.md
@@ -11,11 +11,14 @@
 QuickLendX Backend enforces a **field-level logging policy** for all HTTP request and response data. The policy classifies every known field into one of three sensitivity tiers and automatically redacts or hashes values before they reach any log sink.
 
 This ensures:
+
 - Wallet signatures, auth tokens, and KYC payloads **never** appear in logs.
 - Business-sensitive values (wallet addresses, amounts) are **pseudonymised**.
 - Public metadata (IDs, status codes, timestamps) is logged verbatim for observability.
 
 Additionally, the backend implements **correlation IDs** to thread request context across the request lifecycle, event processing, and outbound webhook delivery. This enables end-to-end tracing and debugging without manual log stitching.
+
+The ingestion, invariant, and reconciliation pipeline also emits **structured trace spans** in JSON lines so external collectors can build a causal span graph without coupling QuickLendX to a specific tracing vendor.
 
 ---
 
@@ -24,6 +27,7 @@ Additionally, the backend implements **correlation IDs** to thread request conte
 ### Overview
 
 Correlation IDs are ULID-based identifiers that thread through the entire request lifecycle:
+
 - **Request entry**: Generated or accepted from `X-Request-Id` header
 - **Event processing**: Propagated through `eventProcessor.ts` → `notificationService.ts`
 - **Webhook delivery**: Included in outbound webhook requests as `X-Request-Id` header
@@ -33,17 +37,17 @@ This enables end-to-end tracing of a settlement notification from HTTP request �
 
 ### X-Request-Id Header Contract
 
-| Aspect | Specification |
-|--------|----------------|
-| **Header name** | `X-Request-Id` (case-insensitive) |
-| **Direction** | Bidirectional (request and response) |
-| **Client → Server** | Optional. If present and valid, used as correlation ID. If absent or invalid, a new ULID is generated. |
-| **Server → Client** | Always present. Echoes the correlation ID used for the request. |
-| **Format** | ULID (26 chars) or alphanumeric with hyphens/underscores |
-| **Max length** | 128 characters |
-| **Valid characters** | `A-Z`, `a-z`, `0-9`, `-`, `_` |
+| Aspect                 | Specification                                                                                                     |
+| ---------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| **Header name**        | `X-Request-Id` (case-insensitive)                                                                                 |
+| **Direction**          | Bidirectional (request and response)                                                                              |
+| **Client → Server**    | Optional. If present and valid, used as correlation ID. If absent or invalid, a new ULID is generated.            |
+| **Server → Client**    | Always present. Echoes the correlation ID used for the request.                                                   |
+| **Format**             | ULID (26 chars) or alphanumeric with hyphens/underscores                                                          |
+| **Max length**         | 128 characters                                                                                                    |
+| **Valid characters**   | `A-Z`, `a-z`, `0-9`, `-`, `_`                                                                                     |
 | **Invalid characters** | Newlines, carriage returns, tabs, semicolons, pipes, ANSI escape sequences, null bytes (log injection prevention) |
-| **Security** | All client-supplied IDs are sanitized before use. Invalid IDs are rejected and a new ULID is generated. |
+| **Security**           | All client-supplied IDs are sanitized before use. Invalid IDs are rejected and a new ULID is generated.           |
 
 ### Header Flow
 
@@ -58,11 +62,13 @@ X-Request-Id: client-123  ──►   X-Request-Id: client-123  (if valid)
 ### Implementation Details
 
 **Request Context Storage**
+
 - Uses Node.js `AsyncLocalStorage` for thread-safe context propagation
 - Automatic context isolation prevents bleeding between concurrent requests
 - Context is automatically available in all downstream async operations
 
 **Middleware Integration**
+
 1. `request-logger.ts`: Accepts/sanitizes client `X-Request-Id`, generates ULID if needed, sets response header
 2. `requestContext.ts`: Provides `withCorrelationId()`, `getCorrelationId()`, `getOrGenerateCorrelationId()` helpers
 3. `access-log.ts`: Includes correlation ID in all access log entries
@@ -72,6 +78,7 @@ X-Request-Id: client-123  ──►   X-Request-Id: client-123  (if valid)
 ### Usage Examples
 
 **Client-supplied correlation ID**
+
 ```bash
 curl -H "X-Request-Id: my-trace-123" https://api.example.com/invoices
 # Response header: X-Request-Id: my-trace-123
@@ -79,6 +86,7 @@ curl -H "X-Request-Id: my-trace-123" https://api.example.com/invoices
 ```
 
 **Server-generated correlation ID**
+
 ```bash
 curl https://api.example.com/invoices
 # Response header: X-Request-Id: 01H9K4W2X8Y9Z0A1B2C3D4E5F6
@@ -86,6 +94,7 @@ curl https://api.example.com/invoices
 ```
 
 **Programmatic usage in handlers**
+
 ```ts
 import { getCorrelationId } from "../lib/requestContext";
 
@@ -97,6 +106,7 @@ function myHandler(req, res) {
 ```
 
 **Setting context for background tasks**
+
 ```ts
 import { withCorrelationId } from "../lib/requestContext";
 
@@ -111,17 +121,20 @@ async function backgroundTask(correlationId: string) {
 ### Security Considerations
 
 **Log Injection Prevention**
+
 - Client-supplied correlation IDs are strictly validated against a whitelist pattern
 - Special characters (newlines, carriage returns, tabs, ANSI escape sequences) are rejected
 - Maximum length enforced (128 characters) to prevent DoS via oversized headers
 - Invalid IDs are silently rejected and replaced with server-generated ULIDs
 
 **Context Isolation**
+
 - AsyncLocalStorage ensures concurrent requests cannot bleed correlation IDs
 - Each request has its own isolated context
 - Context is automatically cleaned up after request completes
 
 **Redaction Compliance**
+
 - Correlation IDs are classified as PUBLIC in the logging policy
 - They appear verbatim in logs for easy filtering
 - They do not contain sensitive information by design
@@ -146,11 +159,90 @@ npx jest correlation-id.test.ts --coverage
 
 ---
 
-| Tier | Symbol | Behaviour in logs |
-|------|--------|-------------------|
-| **PUBLIC** | `FieldTier.PUBLIC` | Value logged verbatim. |
-| **PRIVATE** | `FieldTier.PRIVATE` | Value replaced with `sha256:<8-hex-chars>` (non-reversible). |
-| **SECRET** | `FieldTier.SECRET` | Value replaced with the literal string `[REDACTED]`. No crypto is applied — the value is simply discarded. |
+## Trace Spans
+
+### Overview
+
+Pipeline services emit span logs for start and end events:
+
+- `ingestion.ingestBatch`, `ingestion.rollbackAndReingest`
+- `invariant.*` public checks and scheduler run loop
+- `reconciliation.*` worker entrypoints
+
+Each span line is independent JSON written to stdout and can be shipped by any log forwarder.
+
+### Span JSON Format
+
+```json
+{
+  "level": "INFO",
+  "type": "TRACE_SPAN",
+  "event": "start",
+  "timestamp": "2026-05-31T12:34:56.789Z",
+  "name": "ingestion.ingestBatch",
+  "trace_id": "01J0NQ7H4N6R5X8TQKBV7PZ6Y1",
+  "span_id": "01J0NQ7H7BFW5H0NQYV0GJQJ0T",
+  "parent_span_id": null,
+  "attrs": {
+    "batch_cursor": 91234,
+    "events_count": 25
+  }
+}
+```
+
+End events include duration and error metadata:
+
+```json
+{
+  "level": "INFO",
+  "type": "TRACE_SPAN",
+  "event": "end",
+  "timestamp": "2026-05-31T12:34:56.811Z",
+  "name": "ingestion.ingestBatch",
+  "trace_id": "01J0NQ7H4N6R5X8TQKBV7PZ6Y1",
+  "span_id": "01J0NQ7H7BFW5H0NQYV0GJQJ0T",
+  "parent_span_id": null,
+  "duration_ms": 22.14,
+  "error": false,
+  "attrs": {
+    "batch_cursor": 91234,
+    "events_count": 25
+  }
+}
+```
+
+### Field Semantics
+
+| Field            | Description                                                                                                              |
+| ---------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| `trace_id`       | Root trace identifier. If a request correlation ID exists in async context, it is reused. Otherwise a ULID is generated. |
+| `span_id`        | ULID for the current span instance.                                                                                      |
+| `parent_span_id` | ULID of the direct parent span, or `null` for root spans.                                                                |
+| `name`           | Logical operation name (`service.operation`).                                                                            |
+| `attrs`          | Span attributes for filtering and debugging (cursor, counts, batch size, etc.).                                          |
+| `error`          | `true` when the wrapped operation throws.                                                                                |
+| `error_message`  | Captured exception message when `error=true`.                                                                            |
+| `duration_ms`    | Present on `event=end`; wall clock duration of the span.                                                                 |
+
+### Parent/Child Behavior
+
+- Nested spans automatically inherit the same `trace_id`.
+- Child spans automatically set `parent_span_id` to the active span.
+- Async boundaries are preserved through `AsyncLocalStorage`, so parent-child linkage survives `await`, timers, and Promise chains.
+
+### Operational Notes
+
+- Spans are logs, not a direct OpenTelemetry exporter.
+- Any collector can ingest these JSON lines and transform them to OTel, Honeycomb, Datadog, or internal trace stores.
+- Existing request logging and redaction policy remain unchanged.
+
+---
+
+| Tier        | Symbol              | Behaviour in logs                                                                                          |
+| ----------- | ------------------- | ---------------------------------------------------------------------------------------------------------- |
+| **PUBLIC**  | `FieldTier.PUBLIC`  | Value logged verbatim.                                                                                     |
+| **PRIVATE** | `FieldTier.PRIVATE` | Value replaced with `sha256:<8-hex-chars>` (non-reversible).                                               |
+| **SECRET**  | `FieldTier.SECRET`  | Value replaced with the literal string `[REDACTED]`. No crypto is applied — the value is simply discarded. |
 
 **Deny-by-default:** any field whose name does not appear in the registry is treated as `PRIVATE`.
 
@@ -180,6 +272,7 @@ description, reason, tags, notes
 ### SECRET fields (never logged)
 
 **Authentication / Wallet**
+
 ```
 signature, wallet_signature, private_key
 secret, token, access_token, refresh_token, api_key
@@ -188,6 +281,7 @@ mnemonic, seed_phrase
 ```
 
 **KYC / PII**
+
 ```
 tax_id, ssn, national_id, passport_number, date_of_birth
 bank_account, kyc_document, kyc_data
@@ -195,6 +289,7 @@ customer_name, customer_address, phone_number, email
 ```
 
 **Webhook**
+
 ```
 webhook_secret, signing_secret
 ```
@@ -230,14 +325,14 @@ HTTP Request
 
 ### Core modules
 
-| File | Purpose |
-|------|---------|
-| `src/lib/logging/policy.ts` | Field registry, classification helpers, redaction engine, `findSecretLeak` assertion helper |
-| `src/lib/requestContext.ts` | AsyncLocalStorage-based correlation ID context management, sanitization, propagation helpers |
+| File                               | Purpose                                                                                                                                            |
+| ---------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `src/lib/logging/policy.ts`        | Field registry, classification helpers, redaction engine, `findSecretLeak` assertion helper                                                        |
+| `src/lib/requestContext.ts`        | AsyncLocalStorage-based correlation ID context management, sanitization, propagation helpers                                                       |
 | `src/middleware/request-logger.ts` | Express middleware — accepts/sanitizes X-Request-Id header, generates ULID if needed, captures and redacts request/response, emits structured JSON |
-| `src/middleware/access-log.ts` | Access logging middleware for sensitive data with correlation ID support |
-| `src/services/eventProcessor.ts` | Event processing with correlation ID logging |
-| `src/services/webhook/delivery.ts` | Webhook delivery with correlation ID propagation to outbound requests |
+| `src/middleware/access-log.ts`     | Access logging middleware for sensitive data with correlation ID support                                                                           |
+| `src/services/eventProcessor.ts`   | Event processing with correlation ID logging                                                                                                       |
+| `src/services/webhook/delivery.ts` | Webhook delivery with correlation ID propagation to outbound requests                                                                              |
 
 ---
 
@@ -261,13 +356,13 @@ import { classifyField, isSecret, redactObject } from "../lib/logging/policy";
 
 // Classify a single field
 classifyField("authorization"); // → "secret"
-classifyField("invoice_id");    // → "public"
-classifyField("amount");        // → "private"
+classifyField("invoice_id"); // → "public"
+classifyField("amount"); // → "private"
 
 // Type-guards
-isSecret("tax_id");   // true
-isPublic("status");   // true
-isPrivate("amount");  // true
+isSecret("tax_id"); // true
+isPublic("status"); // true
+isPrivate("amount"); // true
 
 // Redact a whole object
 const safe = redactObject(rawBody);
@@ -347,13 +442,13 @@ Each request produces one JSON line on `stdout`:
 
 ## Security Assumptions
 
-| Assumption | Rationale |
-|------------|-----------|
-| Log sinks are **untrusted** surfaces | Logs may be forwarded to third-party aggregators. No SECRET value must ever reach them. |
-| Hash prefix only (8 hex chars) | Full SHA-256 of short values like wallet addresses is brute-forceable. An 8-char prefix is correlation-safe but not reversible. |
-| No crypto on SECRET tier | Applying any transformation to a secret value (even hashing) is a risk vector. Replacement with `[REDACTED]` is the only safe operation. |
-| Deny-by-default | A newly added field that is not in the registry falls back to PRIVATE, not PUBLIC. |
-| `res.json` is the sole capture point | Only structured JSON responses are inspected. Binary streams and redirects are not captured. |
+| Assumption                           | Rationale                                                                                                                                |
+| ------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| Log sinks are **untrusted** surfaces | Logs may be forwarded to third-party aggregators. No SECRET value must ever reach them.                                                  |
+| Hash prefix only (8 hex chars)       | Full SHA-256 of short values like wallet addresses is brute-forceable. An 8-char prefix is correlation-safe but not reversible.          |
+| No crypto on SECRET tier             | Applying any transformation to a secret value (even hashing) is a risk vector. Replacement with `[REDACTED]` is the only safe operation. |
+| Deny-by-default                      | A newly added field that is not in the registry falls back to PRIVATE, not PUBLIC.                                                       |
+| `res.json` is the sole capture point | Only structured JSON responses are inspected. Binary streams and redirects are not captured.                                             |
 
 ---
 
@@ -368,9 +463,9 @@ Each request produces one JSON line on `stdout`:
 // Example: adding a new private field
 const FIELD_POLICY: Record<string, FieldTier> = {
   // ...
-  ledger_index: FieldTier.PUBLIC,   // safe to log verbatim
-  fee_amount:   FieldTier.PRIVATE,  // hash before logging
-  seed_phrase:  FieldTier.SECRET,   // already exists — never log
+  ledger_index: FieldTier.PUBLIC, // safe to log verbatim
+  fee_amount: FieldTier.PRIVATE, // hash before logging
+  seed_phrase: FieldTier.SECRET, // already exists — never log
 };
 ```
 
@@ -388,10 +483,10 @@ npm test
 
 ### Test coverage (our files)
 
-| File | Stmts | Branch | Funcs | Lines |
-|------|-------|--------|-------|-------|
-| `lib/logging/policy.ts` | 98.5% | 98.3% | 100% | 98.3% |
-| `middleware/request-logger.ts` | 100% | 100% | 100% | 100% |
+| File                           | Stmts | Branch | Funcs | Lines |
+| ------------------------------ | ----- | ------ | ----- | ----- |
+| `lib/logging/policy.ts`        | 98.5% | 98.3%  | 100%  | 98.3% |
+| `middleware/request-logger.ts` | 100%  | 100%   | 100%  | 100%  |
 
 ### Key test categories
 

--- a/backend/src/lib/tracing.ts
+++ b/backend/src/lib/tracing.ts
@@ -1,0 +1,157 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+import { ulid } from "ulid";
+import { getCorrelationId } from "./requestContext";
+
+export type SpanAttributes = Record<string, unknown>;
+
+export interface Span {
+  name: string;
+  traceId: string;
+  spanId: string;
+  parentSpanId: string | null;
+  attrs: SpanAttributes;
+  startedAtMs: number;
+  startedAtNs: bigint;
+  ended: boolean;
+}
+
+interface SpanContext {
+  traceId: string;
+  spanId: string;
+}
+
+interface SpanLogEntry {
+  level: "INFO";
+  type: "TRACE_SPAN";
+  event: "start" | "end";
+  timestamp: string;
+  name: string;
+  trace_id: string;
+  span_id: string;
+  parent_span_id: string | null;
+  duration_ms?: number;
+  error?: boolean;
+  error_message?: string;
+  attrs: SpanAttributes;
+}
+
+const spanContextStorage = new AsyncLocalStorage<SpanContext>();
+
+function isPromise<T>(value: T | Promise<T>): value is Promise<T> {
+  return !!value && typeof (value as Promise<T>).then === "function";
+}
+
+function emitSpanLog(entry: SpanLogEntry): void {
+  process.stdout.write(`${JSON.stringify(entry)}\n`);
+}
+
+function buildTraceId(parent?: SpanContext): string {
+  if (parent?.traceId) {
+    return parent.traceId;
+  }
+
+  const inboundRequestId = getCorrelationId();
+  return inboundRequestId && inboundRequestId.length > 0
+    ? inboundRequestId
+    : ulid();
+}
+
+export function startSpan(name: string, attrs: SpanAttributes = {}): Span {
+  const parent = spanContextStorage.getStore();
+
+  const span: Span = {
+    name,
+    traceId: buildTraceId(parent),
+    spanId: ulid(),
+    parentSpanId: parent?.spanId ?? null,
+    attrs,
+    startedAtMs: Date.now(),
+    startedAtNs: process.hrtime.bigint(),
+    ended: false,
+  };
+
+  emitSpanLog({
+    level: "INFO",
+    type: "TRACE_SPAN",
+    event: "start",
+    timestamp: new Date(span.startedAtMs).toISOString(),
+    name: span.name,
+    trace_id: span.traceId,
+    span_id: span.spanId,
+    parent_span_id: span.parentSpanId,
+    attrs: span.attrs,
+  });
+
+  return span;
+}
+
+export function endSpan(span: Span, err?: unknown): void {
+  if (span.ended) {
+    return;
+  }
+
+  span.ended = true;
+  const endedAtNs = process.hrtime.bigint();
+  const durationMs = Number(endedAtNs - span.startedAtNs) / 1_000_000;
+
+  emitSpanLog({
+    level: "INFO",
+    type: "TRACE_SPAN",
+    event: "end",
+    timestamp: new Date().toISOString(),
+    name: span.name,
+    trace_id: span.traceId,
+    span_id: span.spanId,
+    parent_span_id: span.parentSpanId,
+    duration_ms: durationMs,
+    error: err !== undefined,
+    error_message:
+      err instanceof Error ? err.message : err ? String(err) : undefined,
+    attrs: span.attrs,
+  });
+}
+
+export function withSpan<T>(
+  name: string,
+  attrs: SpanAttributes,
+  fn: () => Promise<T>,
+): Promise<T>;
+export function withSpan<T>(
+  name: string,
+  attrs: SpanAttributes,
+  fn: () => T,
+): T;
+export function withSpan<T>(
+  name: string,
+  attrs: SpanAttributes,
+  fn: () => T | Promise<T>,
+): T | Promise<T> {
+  const span = startSpan(name, attrs);
+
+  return spanContextStorage.run(
+    { traceId: span.traceId, spanId: span.spanId },
+    () => {
+      try {
+        const result = fn();
+
+        if (isPromise(result)) {
+          return result
+            .then((value) => {
+              endSpan(span);
+              return value;
+            })
+            .catch((err) => {
+              endSpan(span, err);
+              throw err;
+            });
+        }
+
+        endSpan(span);
+        return result;
+      } catch (err) {
+        endSpan(span, err);
+        throw err;
+      }
+    },
+  );
+}

--- a/backend/src/lib/tracing.ts
+++ b/backend/src/lib/tracing.ts
@@ -63,7 +63,7 @@ export function startSpan(name: string, attrs: SpanAttributes = {}): Span {
     name,
     traceId: buildTraceId(parent),
     spanId: ulid(),
-    parentSpanId: parent?.spanId ?? null,
+    parentSpanId: parent ? parent.spanId : null,
     attrs,
     startedAtMs: Date.now(),
     startedAtNs: process.hrtime.bigint(),

--- a/backend/src/services/ingestion.ts
+++ b/backend/src/services/ingestion.ts
@@ -9,6 +9,7 @@
  */
 
 // lagMonitor is loaded dynamically to avoid circular deps in test env
+import { withSpan } from "../lib/tracing";
 
 export interface IndexedEvent {
   ledger: number;
@@ -53,36 +54,50 @@ export interface IngestionResult {
 export async function ingestBatch(
   store: IngestionStore,
   events: IndexedEvent[],
-  batchCursor: number
+  batchCursor: number,
 ): Promise<IngestionResult> {
-  const currentCursor = await store.getCursor();
+  return withSpan(
+    "ingestion.ingestBatch",
+    { batch_cursor: batchCursor, events_count: events.length },
+    async () => {
+      const currentCursor = await store.getCursor();
 
-  // Idempotency: if we've already processed up to or past this cursor, skip.
-  if (currentCursor !== null && batchCursor <= currentCursor) {
-    return { committed: false, cursor: currentCursor, eventsProcessed: 0, skipped: true };
-  }
+      // Idempotency: if we've already processed up to or past this cursor, skip.
+      if (currentCursor !== null && batchCursor <= currentCursor) {
+        return {
+          committed: false,
+          cursor: currentCursor,
+          eventsProcessed: 0,
+          skipped: true,
+        };
+      }
 
-  // Validate all events before writing anything — prevents partial state.
-  for (const event of events) {
-    validateEvent(event);
-  }
+      // Validate all events before writing anything — prevents partial state.
+      for (const event of events) {
+        validateEvent(event);
+      }
 
-  // Delegate the atomic commit to the store.
-  await store.commitBatch(events, batchCursor);
+      // Delegate the atomic commit to the store.
+      await store.commitBatch(events, batchCursor);
 
-  // Record metric for monitoring (non-fatal if it fails)
-  try {
-    (await import('./lagMonitor')).lagMonitor.recordIngestion(batchCursor, events.length);
-  } catch {
-    // Metrics failure must not break ingestion
-  }
+      // Record metric for monitoring (non-fatal if it fails)
+      try {
+        (await import("./lagMonitor")).lagMonitor.recordIngestion(
+          batchCursor,
+          events.length,
+        );
+      } catch {
+        // Metrics failure must not break ingestion
+      }
 
-  return {
-    committed: true,
-    cursor: batchCursor,
-    eventsProcessed: events.length,
-    skipped: false,
-  };
+      return {
+        committed: true,
+        cursor: batchCursor,
+        eventsProcessed: events.length,
+        skipped: false,
+      };
+    },
+  );
 }
 
 /**
@@ -99,46 +114,52 @@ export async function ingestBatch(
 export async function rollbackAndReingest(
   store: IngestionStore,
   targetCursor: number,
-  fetchBatch: (cursor: number) => Promise<{ rawEvents: IndexedEvent[] }>
+  fetchBatch: (cursor: number) => Promise<{ rawEvents: IndexedEvent[] }>,
 ): Promise<{ newCursor: number }> {
-  // 1. Rollback to the last known good cursor
-  await store.rollbackTo(targetCursor);
+  return withSpan(
+    "ingestion.rollbackAndReingest",
+    { target_cursor: targetCursor },
+    async () => {
+      // 1. Rollback to the last known good cursor
+      await store.rollbackTo(targetCursor);
 
-  // Emit rollback metric (non-fatal if it fails)
-  try {
-    (await import('./lagMonitor')).lagMonitor.recordRollback(targetCursor);
-  } catch {
-    // Metrics failure must not break recovery
-  }
-
-  // 2. Re-ingest from targetCursor + 1 forward until caught up
-  let currentCursor = targetCursor;
-  const maxIterations = 10_000; // safety valve
-
-  for (let i = 0; i < maxIterations; i++) {
-    const nextCursor = currentCursor + 1;
-    try {
-      const batch = await fetchBatch(nextCursor);
-      if (!batch.rawEvents || batch.rawEvents.length === 0) {
-        // No more batches available — we're caught up
-        break;
+      // Emit rollback metric (non-fatal if it fails)
+      try {
+        (await import("./lagMonitor")).lagMonitor.recordRollback(targetCursor);
+      } catch {
+        // Metrics failure must not break recovery
       }
 
-      const result = await ingestBatch(store, batch.rawEvents, nextCursor);
-      currentCursor = result.cursor;
+      // 2. Re-ingest from targetCursor + 1 forward until caught up
+      let currentCursor = targetCursor;
+      const maxIterations = 10_000; // safety valve
 
-      if (result.skipped) {
-        // Already at or past this cursor, keep going
-        continue;
+      for (let i = 0; i < maxIterations; i++) {
+        const nextCursor = currentCursor + 1;
+        try {
+          const batch = await fetchBatch(nextCursor);
+          if (!batch.rawEvents || batch.rawEvents.length === 0) {
+            // No more batches available — we're caught up
+            break;
+          }
+
+          const result = await ingestBatch(store, batch.rawEvents, nextCursor);
+          currentCursor = result.cursor;
+
+          if (result.skipped) {
+            // Already at or past this cursor, keep going
+            continue;
+          }
+        } catch (err) {
+          throw new Error(
+            `Re-ingestion failed at cursor ${nextCursor}: ${err instanceof Error ? err.message : String(err)}`,
+          );
+        }
       }
-    } catch (err) {
-      throw new Error(
-        `Re-ingestion failed at cursor ${nextCursor}: ${err instanceof Error ? err.message : String(err)}`
-      );
-    }
-  }
 
-  return { newCursor: currentCursor };
+      return { newCursor: currentCursor };
+    },
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -187,7 +208,7 @@ export class InMemoryIngestionStore implements IngestionStore {
     if (cursor < 0) {
       throw new Error("Cannot rollback below genesis: cursor must be >= 0");
     }
-    this.events = this.events.filter(e => e.ledger <= cursor);
+    this.events = this.events.filter((e) => e.ledger <= cursor);
     this.cursor = cursor;
   }
 

--- a/backend/src/services/invariantService.ts
+++ b/backend/src/services/invariantService.ts
@@ -7,6 +7,7 @@ import {
   BidStatus,
   SettlementStatus,
 } from "../types/contract";
+import { withSpan } from "../lib/tracing";
 
 const MAX_SAMPLE_IDS = 5;
 
@@ -145,24 +146,26 @@ function scanMismatchSettlements(
 export async function checkOrphans(
   provider: InvariantDataProvider,
 ): Promise<InvariantReport> {
-  const [invoices, bids, settlements, disputes] = await Promise.all([
-    provider.getInvoices(),
-    provider.getBids(),
-    provider.getSettlements(),
-    provider.getDisputes(),
-  ]);
+  return withSpan("invariant.checkOrphans", {}, async () => {
+    const [invoices, bids, settlements, disputes] = await Promise.all([
+      provider.getInvoices(),
+      provider.getBids(),
+      provider.getSettlements(),
+      provider.getDisputes(),
+    ]);
 
-  const validInvoiceIds = new Set(invoices.map((i) => i.id));
-  return {
-    orphanBids: scanOrphans(bids as HasInvoiceId[], validInvoiceIds),
-    orphanSettlements: scanOrphans(
-      settlements as HasInvoiceId[],
-      validInvoiceIds,
-    ),
-    orphanDisputes: scanOrphans(disputes as HasInvoiceId[], validInvoiceIds),
-    mismatchSettlements: scanMismatchSettlements(bids, settlements),
-    timestamp: new Date().toISOString(),
-  };
+    const validInvoiceIds = new Set(invoices.map((i) => i.id));
+    return {
+      orphanBids: scanOrphans(bids as HasInvoiceId[], validInvoiceIds),
+      orphanSettlements: scanOrphans(
+        settlements as HasInvoiceId[],
+        validInvoiceIds,
+      ),
+      orphanDisputes: scanOrphans(disputes as HasInvoiceId[], validInvoiceIds),
+      mismatchSettlements: scanMismatchSettlements(bids, settlements),
+      timestamp: new Date().toISOString(),
+    };
+  });
 }
 
 // ── Cursor sequence ───────────────────────────────────────────────────────────
@@ -173,25 +176,31 @@ export async function checkOrphans(
  * indicate a regression (duplicate replay or rollback without re-index).
  */
 export function checkCursorSequence(cursors: number[]): CursorRegressionReport {
-  const regressions: Array<{
-    index: number;
-    previous: number;
-    current: number;
-  }> = [];
-  for (let i = 1; i < cursors.length; i++) {
-    if (cursors[i] <= cursors[i - 1]) {
-      regressions.push({
-        index: i,
-        previous: cursors[i - 1],
-        current: cursors[i],
-      });
-    }
-  }
-  return {
-    hasRegression: regressions.length > 0,
-    regressionCount: regressions.length,
-    regressions,
-  };
+  return withSpan(
+    "invariant.checkCursorSequence",
+    { cursor_count: cursors.length },
+    () => {
+      const regressions: Array<{
+        index: number;
+        previous: number;
+        current: number;
+      }> = [];
+      for (let i = 1; i < cursors.length; i++) {
+        if (cursors[i] <= cursors[i - 1]) {
+          regressions.push({
+            index: i,
+            previous: cursors[i - 1],
+            current: cursors[i],
+          });
+        }
+      }
+      return {
+        hasRegression: regressions.length > 0,
+        regressionCount: regressions.length,
+        regressions,
+      };
+    },
+  );
 }
 
 // ── Accounting totals ─────────────────────────────────────────────────────────
@@ -205,37 +214,39 @@ export function checkCursorSequence(cursors: number[]): CursorRegressionReport {
 export async function checkAccountingTotals(
   provider: InvariantDataProvider,
 ): Promise<AccountingReport> {
-  const [bids, settlements] = await Promise.all([
-    provider.getBids(),
-    provider.getSettlements(),
-  ]);
+  return withSpan("invariant.checkAccountingTotals", {}, async () => {
+    const [bids, settlements] = await Promise.all([
+      provider.getBids(),
+      provider.getSettlements(),
+    ]);
 
-  const acceptedBidByInvoice = new Map<string, Bid>();
-  for (const bid of bids) {
-    if (bid.status === BidStatus.Accepted) {
-      acceptedBidByInvoice.set(bid.invoice_id, bid);
+    const acceptedBidByInvoice = new Map<string, Bid>();
+    for (const bid of bids) {
+      if (bid.status === BidStatus.Accepted) {
+        acceptedBidByInvoice.set(bid.invoice_id, bid);
+      }
     }
-  }
 
-  const mismatchIds: string[] = [];
-  for (const settlement of settlements) {
-    if (settlement.status !== SettlementStatus.Paid) continue;
-    const bid = acceptedBidByInvoice.get(settlement.invoice_id);
-    if (!bid) {
-      mismatchIds.push(settlement.invoice_id);
-      continue;
+    const mismatchIds: string[] = [];
+    for (const settlement of settlements) {
+      if (settlement.status !== SettlementStatus.Paid) continue;
+      const bid = acceptedBidByInvoice.get(settlement.invoice_id);
+      if (!bid) {
+        mismatchIds.push(settlement.invoice_id);
+        continue;
+      }
+      if (BigInt(settlement.amount) !== BigInt(bid.bid_amount)) {
+        mismatchIds.push(settlement.invoice_id);
+      }
     }
-    if (BigInt(settlement.amount) !== BigInt(bid.bid_amount)) {
-      mismatchIds.push(settlement.invoice_id);
-    }
-  }
 
-  return {
-    mismatches: {
-      count: mismatchIds.length,
-      sampleIds: mismatchIds.slice(0, MAX_SAMPLE_IDS),
-    },
-  };
+    return {
+      mismatches: {
+        count: mismatchIds.length,
+        sampleIds: mismatchIds.slice(0, MAX_SAMPLE_IDS),
+      },
+    };
+  });
 }
 
 // ── Full suite ────────────────────────────────────────────────────────────────
@@ -249,27 +260,33 @@ export async function runFullInvariantSuite(
   provider: InvariantDataProvider,
   cursorHistory: number[],
 ): Promise<FullInvariantReport> {
-  const [orphans, accounting] = await Promise.all([
-    checkOrphans(provider),
-    checkAccountingTotals(provider),
-  ]);
-  const cursorSequence = checkCursorSequence(cursorHistory);
+  return withSpan(
+    "invariant.runFullInvariantSuite",
+    { cursor_history_count: cursorHistory.length },
+    async () => {
+      const [orphans, accounting] = await Promise.all([
+        checkOrphans(provider),
+        checkAccountingTotals(provider),
+      ]);
+      const cursorSequence = checkCursorSequence(cursorHistory);
 
-  const pass =
-    orphans.orphanBids.count === 0 &&
-    orphans.orphanSettlements.count === 0 &&
-    orphans.orphanDisputes.count === 0 &&
-    orphans.mismatchSettlements.count === 0 &&
-    !cursorSequence.hasRegression &&
-    accounting.mismatches.count === 0;
+      const pass =
+        orphans.orphanBids.count === 0 &&
+        orphans.orphanSettlements.count === 0 &&
+        orphans.orphanDisputes.count === 0 &&
+        orphans.mismatchSettlements.count === 0 &&
+        !cursorSequence.hasRegression &&
+        accounting.mismatches.count === 0;
 
-  return {
-    orphans,
-    cursorSequence,
-    accounting,
-    timestamp: new Date().toISOString(),
-    pass,
-  };
+      return {
+        orphans,
+        cursorSequence,
+        accounting,
+        timestamp: new Date().toISOString(),
+        pass,
+      };
+    },
+  );
 }
 
 // ── Persistence ───────────────────────────────────────────────────────────────
@@ -375,39 +392,43 @@ function recordMetrics(report: FullInvariantReport): void {
 // ── Alerting ────────────────────────────────────────────────────────────────
 
 export function emitInvariantAlert(report: FullInvariantReport): void {
-  if (report.pass) return;
+  withSpan("invariant.emitInvariantAlert", { pass: report.pass }, () => {
+    if (report.pass) return;
 
-  const violations: string[] = [];
-  if (report.orphans.orphanBids.count > 0)
-    violations.push(`orphan_bids: ${report.orphans.orphanBids.count}`);
-  if (report.orphans.orphanSettlements.count > 0)
-    violations.push(
-      `orphan_settlements: ${report.orphans.orphanSettlements.count}`,
-    );
-  if (report.orphans.orphanDisputes.count > 0)
-    violations.push(`orphan_disputes: ${report.orphans.orphanDisputes.count}`);
-  if (report.orphans.mismatchSettlements.count > 0)
-    violations.push(
-      `mismatch_settlements: ${report.orphans.mismatchSettlements.count}`,
-    );
-  if (report.cursorSequence.hasRegression)
-    violations.push(
-      `cursor_regression: ${report.cursorSequence.regressionCount}`,
-    );
-  if (report.accounting.mismatches.count > 0)
-    violations.push(
-      `accounting_mismatches: ${report.accounting.mismatches.count}`,
-    );
+    const violations: string[] = [];
+    if (report.orphans.orphanBids.count > 0)
+      violations.push(`orphan_bids: ${report.orphans.orphanBids.count}`);
+    if (report.orphans.orphanSettlements.count > 0)
+      violations.push(
+        `orphan_settlements: ${report.orphans.orphanSettlements.count}`,
+      );
+    if (report.orphans.orphanDisputes.count > 0)
+      violations.push(
+        `orphan_disputes: ${report.orphans.orphanDisputes.count}`,
+      );
+    if (report.orphans.mismatchSettlements.count > 0)
+      violations.push(
+        `mismatch_settlements: ${report.orphans.mismatchSettlements.count}`,
+      );
+    if (report.cursorSequence.hasRegression)
+      violations.push(
+        `cursor_regression: ${report.cursorSequence.regressionCount}`,
+      );
+    if (report.accounting.mismatches.count > 0)
+      violations.push(
+        `accounting_mismatches: ${report.accounting.mismatches.count}`,
+      );
 
-  console.error(
-    JSON.stringify({
-      level: "ALERT",
-      type: "INVARIANT_VIOLATION",
-      timestamp: report.timestamp,
-      violations,
-      message: `Invariant violation detected: ${violations.join(", ")}`,
-    }),
-  );
+    console.error(
+      JSON.stringify({
+        level: "ALERT",
+        type: "INVARIANT_VIOLATION",
+        timestamp: report.timestamp,
+        violations,
+        message: `Invariant violation detected: ${violations.join(", ")}`,
+      }),
+    );
+  });
 }
 
 // ── Scheduler ───────────────────────────────────────────────────────────────
@@ -454,30 +475,36 @@ export class InvariantScheduler {
   }
 
   private async runCheck(): Promise<void> {
-    if (!this.provider) return;
+    await withSpan(
+      "invariant.scheduler.runCheck",
+      { cursor_history_count: this.cursorHistory.length },
+      async () => {
+        if (!this.provider) return;
 
-    try {
-      const report = await runFullInvariantSuite(
-        this.provider,
-        this.cursorHistory,
-      );
-      recordMetrics(report);
-      reportStore.add({
-        report,
-        cursorHistory: [...this.cursorHistory],
-        runAt: report.timestamp,
-      });
-      emitInvariantAlert(report);
-    } catch (err) {
-      console.error(
-        JSON.stringify({
-          level: "ERROR",
-          type: "INVARIANT_CHECK_FAILED",
-          timestamp: new Date().toISOString(),
-          error: err instanceof Error ? err.message : String(err),
-        }),
-      );
-    }
+        try {
+          const report = await runFullInvariantSuite(
+            this.provider,
+            this.cursorHistory,
+          );
+          recordMetrics(report);
+          reportStore.add({
+            report,
+            cursorHistory: [...this.cursorHistory],
+            runAt: report.timestamp,
+          });
+          emitInvariantAlert(report);
+        } catch (err) {
+          console.error(
+            JSON.stringify({
+              level: "ERROR",
+              type: "INVARIANT_CHECK_FAILED",
+              timestamp: new Date().toISOString(),
+              error: err instanceof Error ? err.message : String(err),
+            }),
+          );
+        }
+      },
+    );
   }
 
   isStarted(): boolean {

--- a/backend/src/services/reconciliationWorker.ts
+++ b/backend/src/services/reconciliationWorker.ts
@@ -1,8 +1,14 @@
-import { DriftReport, DriftItem, BackfillResult } from "../types/reconciliation";
+import {
+  DriftReport,
+  DriftItem,
+  BackfillResult,
+} from "../types/reconciliation";
 import { Invoice } from "../types/contract";
 import { rpcClient } from "./rpcClient";
 import { derivedTableStore } from "./replayService";
 import { MockDataProviders } from "./mockDataProviders";
+import { backfillService } from "./backfillService";
+import { withSpan } from "../lib/tracing";
 
 export class ReconciliationWorker {
   private static reports: DriftReport[] = [];
@@ -10,96 +16,121 @@ export class ReconciliationWorker {
   private static backfillBatchSize: number = 10;
   public static failBackfill: boolean = false;
 
-
   static async runReconciliation(): Promise<DriftReport> {
-    if (this.isRunning) {
-      throw new Error("Reconciliation already in progress");
-    }
-
-    this.isRunning = true;
-    try {
-      // Small pause to reduce contention with other services
-      await new Promise((resolve) => setTimeout(resolve, 50));
-
-      // Read indexed invoices from the derived table store.
-      // In test environment use the mock indexed data to keep tests hermetic.
-      const indexed: Invoice[] =
-        process.env.NODE_ENV === "test"
-          ? MockDataProviders.getIndexedInvoices()
-          : (await derivedTableStore.listInvoices?.()) || [];
-
-      // Fetch canonical on-chain invoices via reliable RPC client
-      let onChain: Invoice[] = [];
-      try {
-        // RPC method name is intentionally generic; tests may mock this call
-        onChain = await rpcClient.call<Invoice[]>("getInvoices", []);
-      } catch (rpcErr) {
-        // In test environment, fall back to mock on-chain data so reconciliation tests work without network
-        if (process.env.NODE_ENV === "test") {
-          onChain = MockDataProviders.getOnChainInvoices();
-        } else {
-          const report: DriftReport = {
-            timestamp: Math.floor(Date.now() / 1000),
-            totalRecordsChecked: 0,
-            driftCount: 0,
-            drifts: [],
-            error: rpcErr instanceof Error ? rpcErr.message : String(rpcErr),
-          } as any;
-
-          this.reports.push(report);
-          return report;
-        }
+    return withSpan("reconciliation.runReconciliation", {}, async () => {
+      if (this.isRunning) {
+        throw new Error("Reconciliation already in progress");
       }
-      const drifts: DriftItem[] = [];
 
-      // Check for missing or mismatched records
-      onChain.forEach((oc) => {
-        const idx = indexed.find((i) => i.id === oc.id);
-        if (!idx) {
-          drifts.push({
-            id: oc.id,
-            type: "Invoice",
-            driftType: "MISSING",
-            onChainValue: oc,
-          });
-        } else if (idx.status !== oc.status) {
-          drifts.push({
-            id: oc.id,
-            type: "Invoice",
-            driftType: "STATUS_MISMATCH",
-            indexedValue: idx.status,
-            onChainValue: oc.status,
-          });
+      this.isRunning = true;
+      try {
+        // Small pause to reduce contention with other services
+        await new Promise((resolve) => setTimeout(resolve, 50));
+
+        // Read indexed invoices from the derived table store.
+        // In test environment use the mock indexed data to keep tests hermetic.
+        const indexed: Invoice[] =
+          process.env.NODE_ENV === "test"
+            ? MockDataProviders.getIndexedInvoices()
+            : (await derivedTableStore.listInvoices?.()) || [];
+
+        // Fetch canonical on-chain invoices via reliable RPC client
+        let onChain: Invoice[] = [];
+        try {
+          // RPC method name is intentionally generic; tests may mock this call
+          onChain = await rpcClient.call<Invoice[]>("getInvoices", []);
+        } catch (rpcErr) {
+          // In test environment, fall back to mock on-chain data so reconciliation tests work without network
+          if (process.env.NODE_ENV === "test") {
+            onChain = MockDataProviders.getOnChainInvoices();
+          } else {
+            const report: DriftReport = {
+              timestamp: Math.floor(Date.now() / 1000),
+              totalRecordsChecked: 0,
+              driftCount: 0,
+              drifts: [],
+              error: rpcErr instanceof Error ? rpcErr.message : String(rpcErr),
+            } as any;
+
+            this.reports.push(report);
+            return report;
+          }
         }
-      });
+        const drifts: DriftItem[] = [];
 
-      const report: DriftReport = {
-        timestamp: Math.floor(Date.now() / 1000),
-        totalRecordsChecked: onChain.length,
-        driftCount: drifts.length,
-        drifts,
-      };
+        // Check for missing or mismatched records
+        onChain.forEach((oc) => {
+          const idx = indexed.find((i) => i.id === oc.id);
+          if (!idx) {
+            drifts.push({
+              id: oc.id,
+              type: "Invoice",
+              driftType: "MISSING",
+              onChainValue: oc,
+            });
+          } else if (idx.status !== oc.status) {
+            drifts.push({
+              id: oc.id,
+              type: "Invoice",
+              driftType: "STATUS_MISMATCH",
+              indexedValue: idx.status,
+              onChainValue: oc.status,
+            });
+          }
+        });
 
-      this.reports.push(report);
-      return report;
-    } finally {
-      this.isRunning = false;
-    }
+        const report: DriftReport = {
+          timestamp: Math.floor(Date.now() / 1000),
+          totalRecordsChecked: onChain.length,
+          driftCount: drifts.length,
+          drifts,
+        };
+
+        this.reports.push(report);
+        return report;
+      } finally {
+        this.isRunning = false;
+      }
+    });
   }
 
-  static async triggerBoundedBackfill(report: DriftReport): Promise<BackfillResult> {
-    return backfillService.triggerDriftBackfill(report, this.backfillBatchSize, ReconciliationWorker.failBackfill);
+  static async triggerBoundedBackfill(
+    report: DriftReport,
+  ): Promise<BackfillResult> {
+    return withSpan(
+      "reconciliation.triggerBoundedBackfill",
+      { drift_count: report.driftCount, batch_size: this.backfillBatchSize },
+      () =>
+        backfillService.triggerDriftBackfill(
+          report,
+          this.backfillBatchSize,
+          ReconciliationWorker.failBackfill,
+        ),
+    );
   }
 
   static getLatestReport(): DriftReport | null {
-    return this.reports.length > 0 ? this.reports[this.reports.length - 1] : null;
+    return withSpan(
+      "reconciliation.getLatestReport",
+      { report_count: this.reports.length },
+      () =>
+        this.reports.length > 0 ? this.reports[this.reports.length - 1] : null,
+    );
   }
 
   static getAllReports(): DriftReport[] {
-    return this.reports;
+    return withSpan(
+      "reconciliation.getAllReports",
+      { report_count: this.reports.length },
+      () => this.reports,
+    );
   }
 
   static isReconciliationRunning(): boolean {
-    return this.isRunning;
+    return withSpan(
+      "reconciliation.isReconciliationRunning",
+      {},
+      () => this.isRunning,
+    );
   }
 }

--- a/backend/src/tests/tracing.test.ts
+++ b/backend/src/tests/tracing.test.ts
@@ -1,0 +1,235 @@
+import { withCorrelationId } from "../lib/requestContext";
+import { endSpan, startSpan, withSpan } from "../lib/tracing";
+
+function collectSpanEntries(
+  writeCalls: Array<[any, ...any[]]>,
+): Array<Record<string, any>> {
+  return writeCalls
+    .map(([chunk]) =>
+      typeof chunk === "string" ? chunk : chunk.toString("utf8"),
+    )
+    .flatMap((line) => line.split("\n"))
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0)
+    .map((line) => JSON.parse(line))
+    .filter((entry) => entry.type === "TRACE_SPAN");
+}
+
+function median(values: number[]): number {
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted[mid];
+}
+
+function expectDefined<T>(value: T | undefined, label: string): T {
+  if (value === undefined) {
+    throw new Error(`${label} must be present`);
+  }
+  return value as T;
+}
+
+describe("tracing spans", () => {
+  let writeSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    writeSpy = jest
+      .spyOn(process.stdout, "write")
+      .mockImplementation(() => true);
+  });
+
+  afterEach(() => {
+    writeSpy.mockRestore();
+  });
+
+  it("preserves parent-child relationship across async boundaries", async () => {
+    await withCorrelationId("req-async-001", async () => {
+      await withSpan("pipeline.parent", { stage: "ingestion" }, async () => {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+        await withSpan("pipeline.child", { stage: "invariant" }, async () => {
+          await Promise.resolve();
+        });
+      });
+    });
+
+    const entries = collectSpanEntries(
+      writeSpy.mock.calls as Array<[any, ...any[]]>,
+    );
+    const parentStart = entries.find(
+      (entry) => entry.event === "start" && entry.name === "pipeline.parent",
+    );
+    const childStart = entries.find(
+      (entry) => entry.event === "start" && entry.name === "pipeline.child",
+    );
+
+    const safeParentStart = expectDefined(parentStart, "parent start span");
+    const safeChildStart = expectDefined(childStart, "child start span");
+    expect(safeChildStart.trace_id).toBe(safeParentStart.trace_id);
+    expect(safeChildStart.parent_span_id).toBe(safeParentStart.span_id);
+  });
+
+  it("ends a span with error=true when the wrapped function throws", async () => {
+    await expect(
+      withSpan("pipeline.failure", { stage: "reconciliation" }, async () => {
+        throw new Error("boom");
+      }),
+    ).rejects.toThrow("boom");
+
+    const entries = collectSpanEntries(
+      writeSpy.mock.calls as Array<[any, ...any[]]>,
+    );
+    const endEntry = entries.find(
+      (entry) => entry.event === "end" && entry.name === "pipeline.failure",
+    );
+
+    const safeEndEntry = expectDefined(endEntry, "failed span end entry");
+    expect(safeEndEntry.error).toBe(true);
+    expect(safeEndEntry.error_message).toBe("boom");
+  });
+
+  it("includes span attributes in both start and end logs", async () => {
+    await withSpan(
+      "pipeline.attributes",
+      { batch_cursor: 42, events_count: 3, service: "ingestion" },
+      async () => {
+        await Promise.resolve();
+      },
+    );
+
+    const entries = collectSpanEntries(
+      writeSpy.mock.calls as Array<[any, ...any[]]>,
+    );
+    const startEntry = entries.find(
+      (entry) =>
+        entry.event === "start" && entry.name === "pipeline.attributes",
+    );
+    const endEntry = entries.find(
+      (entry) => entry.event === "end" && entry.name === "pipeline.attributes",
+    );
+
+    const safeStartEntry = expectDefined(startEntry, "attribute start span");
+    const safeEndEntry = expectDefined(endEntry, "attribute end span");
+
+    expect(safeStartEntry.attrs).toMatchObject({
+      batch_cursor: 42,
+      events_count: 3,
+      service: "ingestion",
+    });
+    expect(safeEndEntry.attrs).toMatchObject({
+      batch_cursor: 42,
+      events_count: 3,
+      service: "ingestion",
+    });
+  });
+
+  it("uses inbound request id as trace_id when present", async () => {
+    await withCorrelationId("client-request-abc-123", async () => {
+      await withSpan("pipeline.root", { service: "ingestion" }, async () => {
+        await Promise.resolve();
+      });
+    });
+
+    const entries = collectSpanEntries(
+      writeSpy.mock.calls as Array<[any, ...any[]]>,
+    );
+    const rootStart = entries.find(
+      (entry) => entry.event === "start" && entry.name === "pipeline.root",
+    );
+
+    const safeRootStart = expectDefined(rootStart, "root start span");
+    expect(safeRootStart.trace_id).toBe("client-request-abc-123");
+  });
+
+  it("generates a ULID trace_id when no inbound request id is present", () => {
+    withSpan("pipeline.generated-trace", {}, () => {
+      return 1;
+    });
+
+    const entries = collectSpanEntries(
+      writeSpy.mock.calls as Array<[any, ...any[]]>,
+    );
+    const startEntry = entries.find(
+      (entry) =>
+        entry.event === "start" && entry.name === "pipeline.generated-trace",
+    );
+    const safeStartEntry = expectDefined(
+      startEntry,
+      "generated trace start span",
+    );
+
+    expect(typeof safeStartEntry.trace_id).toBe("string");
+    expect(safeStartEntry.trace_id.length).toBeGreaterThan(0);
+    expect(safeStartEntry.trace_id).not.toBe("client-request-abc-123");
+  });
+
+  it("keeps hot-loop tracing overhead under 1%", () => {
+    const innerWork = (): number => {
+      let acc = 0;
+      for (let i = 0; i < 500_000; i++) {
+        acc += (i * 7) % 13;
+      }
+      return acc;
+    };
+
+    const measure = (fn: () => void): number => {
+      const start = process.hrtime.bigint();
+      fn();
+      const end = process.hrtime.bigint();
+      return Number(end - start) / 1_000_000;
+    };
+
+    const runHotLoop = () => {
+      for (let i = 0; i < 600; i++) {
+        innerWork();
+      }
+    };
+
+    const runTraced = () => {
+      withSpan("pipeline.hotloop", { mode: "benchmark" }, () => runHotLoop());
+    };
+
+    runHotLoop();
+    runTraced();
+
+    const baselineMs = measure(runHotLoop);
+    const tracedMs = measure(runTraced);
+    const overheadRatio = (tracedMs - baselineMs) / baselineMs;
+
+    expect(overheadRatio).toBeLessThan(0.01);
+  });
+
+  it("does not emit duplicate end logs when endSpan is called twice", () => {
+    const span = startSpan("pipeline.idempotent-end", { service: "invariant" });
+
+    endSpan(span);
+    endSpan(span);
+
+    const entries = collectSpanEntries(
+      writeSpy.mock.calls as Array<[any, ...any[]]>,
+    );
+    const endEntries = entries.filter(
+      (entry) =>
+        entry.event === "end" && entry.name === "pipeline.idempotent-end",
+    );
+
+    expect(endEntries).toHaveLength(1);
+  });
+
+  it("marks sync throw spans as errors", () => {
+    expect(() =>
+      withSpan("pipeline.sync-throw", { stage: "ingestion" }, () => {
+        throw "sync-boom";
+      }),
+    ).toThrow("sync-boom");
+
+    const entries = collectSpanEntries(
+      writeSpy.mock.calls as Array<[any, ...any[]]>,
+    );
+    const endEntry = entries.find(
+      (entry) => entry.event === "end" && entry.name === "pipeline.sync-throw",
+    );
+    const safeEndEntry = expectDefined(endEntry, "sync throw span end");
+
+    expect(safeEndEntry.error).toBe(true);
+    expect(safeEndEntry.error_message).toBe("sync-boom");
+  });
+});

--- a/backend/src/tests/tracing.test.ts
+++ b/backend/src/tests/tracing.test.ts
@@ -214,6 +214,32 @@ describe("tracing spans", () => {
     expect(endEntries).toHaveLength(1);
   });
 
+  it("assigns parent_span_id when creating a child span inside an active span", () => {
+    withSpan("pipeline.explicit-parent", {}, () => {
+      const child = startSpan("pipeline.explicit-child", {
+        service: "invariant",
+      });
+      endSpan(child);
+    });
+
+    const entries = collectSpanEntries(
+      writeSpy.mock.calls as Array<[any, ...any[]]>,
+    );
+    const parentStart = entries.find(
+      (entry) =>
+        entry.event === "start" && entry.name === "pipeline.explicit-parent",
+    );
+    const childStart = entries.find(
+      (entry) =>
+        entry.event === "start" && entry.name === "pipeline.explicit-child",
+    );
+
+    const safeParentStart = expectDefined(parentStart, "explicit parent start");
+    const safeChildStart = expectDefined(childStart, "explicit child start");
+
+    expect(safeChildStart.parent_span_id).toBe(safeParentStart.span_id);
+  });
+
   it("marks sync throw spans as errors", () => {
     expect(() =>
       withSpan("pipeline.sync-throw", { stage: "ingestion" }, () => {

--- a/docs/ux/business-dashboard.md
+++ b/docs/ux/business-dashboard.md
@@ -3,7 +3,7 @@
 **Version**: 1.0  
 **Status**: Active  
 **Last Updated**: 2026-04-28  
-**Document Owner**: Product & Design Team  
+**Document Owner**: Product & Design Team
 
 ---
 
@@ -31,6 +31,7 @@
 ### Purpose
 
 The Business Dashboard is the primary control center for businesses using QuickLendX. It provides a consolidated view of:
+
 - **Invoice Pipeline**: Status of all invoices through the lifecycle
 - **Funding Progress**: Real-time visualization of funding progression
 - **Settlement History**: Records of completed transactions and payouts
@@ -40,6 +41,7 @@ The Business Dashboard is the primary control center for businesses using QuickL
 ### Target User
 
 **Business Owners / Finance Managers** who:
+
 - Upload and manage invoices (1-100+ per month)
 - Need to track funding progress in real-time
 - Require transparency on fees, settlements, and payout schedules
@@ -184,14 +186,14 @@ The Business Dashboard is the primary control center for businesses using QuickL
 
 ### Visual Hierarchy
 
-| Priority | Content | Placement | Rationale |
-|----------|---------|-----------|-----------|
-| 1 | At-a-Glance Metrics | Top, 4-6 KPIs | Users need instant cash position |
-| 2 | Alerts & Actions | Below metrics, max 3 items | Time-sensitive items visible |
-| 3 | Pipeline Status | Central fold | Shows distribution, directs to details |
-| 4 | Funding Progress | Mid-page | User's primary concern (when will I get paid?) |
-| 5 | Settlement History | Lower fold | Reference data, less urgent |
-| 6 | Disputes | Bottom, collapsible | Most users have no disputes; some need quick access |
+| Priority | Content             | Placement                  | Rationale                                           |
+| -------- | ------------------- | -------------------------- | --------------------------------------------------- |
+| 1        | At-a-Glance Metrics | Top, 4-6 KPIs              | Users need instant cash position                    |
+| 2        | Alerts & Actions    | Below metrics, max 3 items | Time-sensitive items visible                        |
+| 3        | Pipeline Status     | Central fold               | Shows distribution, directs to details              |
+| 4        | Funding Progress    | Mid-page                   | User's primary concern (when will I get paid?)      |
+| 5        | Settlement History  | Lower fold                 | Reference data, less urgent                         |
+| 6        | Disputes            | Bottom, collapsible        | Most users have no disputes; some need quick access |
 
 ---
 
@@ -202,6 +204,8 @@ The Business Dashboard is the primary control center for businesses using QuickL
 **Purpose**: Answer the question "What's my cash status right now?" in <2 seconds.
 
 #### Metric Cards (6 Cards, Responsive Grid)
+
+Use the canonical KPI card pattern in [metric-card.md](metric-card.md) for value treatment, trend semantics, estimation labeling, tooltip behavior, and drill-down affordance.
 
 ```
 ┌─────────────────────┐  ┌─────────────────────┐  ┌─────────────────────┐
@@ -221,22 +225,24 @@ The Business Dashboard is the primary control center for businesses using QuickL
 
 #### Metric Details
 
-| Metric | Formula | Updates | Context | 
-|--------|---------|---------|---------|
-| **Total Invoices** | Count of all invoices | Real-time | Trend (↑/↓ vs last week) |
-| **Total Funded** | Sum of `invoice.funded_amount` | Real-time | $ vs % of targets |
-| **Pending Funding** | Sum of unfunded invoices | Real-time | Shows urgency |
-| **Expected Payout** | `sum(funded_amount × (1 - fees))` | Real-time | **Critical**: Shows net cash, not gross |
-| **Avg Time-to-Fund** | Median days from upload to full funding | Daily | Trend line over time |
-| **Active Disputes** | Count of disputed invoices | Real-time | Risk indicator |
+| Metric               | Formula                                 | Updates   | Context                                 |
+| -------------------- | --------------------------------------- | --------- | --------------------------------------- |
+| **Total Invoices**   | Count of all invoices                   | Real-time | Trend (↑/↓ vs last week)                |
+| **Total Funded**     | Sum of `invoice.funded_amount`          | Real-time | $ vs % of targets                       |
+| **Pending Funding**  | Sum of unfunded invoices                | Real-time | Shows urgency                           |
+| **Expected Payout**  | `sum(funded_amount × (1 - fees))`       | Real-time | **Critical**: Shows net cash, not gross |
+| **Avg Time-to-Fund** | Median days from upload to full funding | Daily     | Trend line over time                    |
+| **Active Disputes**  | Count of disputed invoices              | Real-time | Risk indicator                          |
 
 **Security Considerations**:
+
 - ✅ Show "Total Funded" (gross), NOT investor names or exact bid amounts
 - ✅ "Expected Payout" must include fee deductions upfront (transparency)
 - ✅ Do not show investor details unless there's explicit data-sharing agreement
 - ✅ Disputes should never expose reasons that identify invoice contents
 
 **Interactive Elements**:
+
 - Click card → Drill down to detailed view
 - Hover metric → Tooltip with calculation formula
 - Click trend arrow → Show historical chart
@@ -275,20 +281,22 @@ The Business Dashboard is the primary control center for businesses using QuickL
 
 #### Alert Types & Priority
 
-| Type | Color | Trigger | Action | Auto-Resolve |
-|------|-------|---------|--------|--------------|
-| **Dispute** | 🔴 Red | Investor files dispute | Respond to dispute | Manual |
-| **Overdue** | 🟠 Orange | Settlement delayed >24h | Contact support | Auto (when settled) |
-| **Action** | 🟡 Yellow | Invoices in pending state | View & manage | Auto (state change) |
-| **Success** | ✓ Green | Invoice milestone reached | Review & next step | Manual (dismiss) |
+| Type        | Color     | Trigger                   | Action             | Auto-Resolve        |
+| ----------- | --------- | ------------------------- | ------------------ | ------------------- |
+| **Dispute** | 🔴 Red    | Investor files dispute    | Respond to dispute | Manual              |
+| **Overdue** | 🟠 Orange | Settlement delayed >24h   | Contact support    | Auto (when settled) |
+| **Action**  | 🟡 Yellow | Invoices in pending state | View & manage      | Auto (state change) |
+| **Success** | ✓ Green   | Invoice milestone reached | Review & next step | Manual (dismiss)    |
 
 **Behavior Rules**:
+
 - Max 5 alerts visible; older items grouped as "2 more alerts"
 - High-priority (Dispute, Overdue) always shown first
 - Users can dismiss alerts; dismissed alerts reappear if state changes
 - Alerts auto-resolve when underlying condition changes
 
 **Security Considerations**:
+
 - ✅ Never expose dispute details (reason, investor name) in alert preview
 - ✅ Link to full detail page requires authentication
 - ✅ Dismissing alert does NOT change underlying issue; just hides UI
@@ -325,20 +333,22 @@ The Business Dashboard is the primary control center for businesses using QuickL
 
 #### Status Definitions (User-Facing)
 
-| Status | Icon | Business Definition | Typical Timeline | User Action |
-|--------|------|---------------------|------------------|-------------|
-| **Created** | 📄 | Invoice uploaded; waiting for first bid | < 1 hour | Monitor for interest |
-| **Pending** | ⏳ | Bids received; in evaluation phase | 1-3 days | Accept or reject bids |
-| **Funded** | 💰 | Bid accepted; funds in escrow; payment processing | 1-7 days | Wait for settlement |
-| **Settled** | ✓ | Invoice paid in full; funds transferred to business | Instant | Review receipt |
-| **Disputed** | ⚠️ | Investor claimed issue; under review | 3-30 days | Respond with evidence |
+| Status       | Icon | Business Definition                                 | Typical Timeline | User Action           |
+| ------------ | ---- | --------------------------------------------------- | ---------------- | --------------------- |
+| **Created**  | 📄   | Invoice uploaded; waiting for first bid             | < 1 hour         | Monitor for interest  |
+| **Pending**  | ⏳   | Bids received; in evaluation phase                  | 1-3 days         | Accept or reject bids |
+| **Funded**   | 💰   | Bid accepted; funds in escrow; payment processing   | 1-7 days         | Wait for settlement   |
+| **Settled**  | ✓    | Invoice paid in full; funds transferred to business | Instant          | Review receipt        |
+| **Disputed** | ⚠️   | Investor claimed issue; under review                | 3-30 days        | Respond with evidence |
 
 **Interaction Patterns**:
+
 1. Click a status box → Filter dashboard to show only invoices in that status
 2. Click count number → Drill down to list view with sortable columns
 3. Click trend arrow → Show historical pipeline diagram (last 30/60/90 days)
 
 **Data Integrity**:
+
 - ✅ Sum of all statuses ≤ Total Invoices (some invoices may be in default state)
 - ✅ No invoice appears in multiple statuses simultaneously
 - ✅ Pipeline respects immutability (Created → Pending is forward-only; no backward transitions)
@@ -383,18 +393,19 @@ The Business Dashboard is the primary control center for businesses using QuickL
 
 #### Progress Card Data
 
-| Field | Source | Updates | Display Rule |
-|-------|--------|---------|--------------|
-| **Invoice ID** | `invoice.id` | Static | Clickable → detail view |
-| **Amount** | `invoice.amount` | Static | Formatted with currency |
-| **Bid Count** | Count of `bid` records for invoice | Real-time | Shows market interest |
-| **Progress %** | `funded_amount / invoice.amount` | Real-time | Visual bar + text |
-| **Funded $ / Target $** | `funded_amount` / `invoice.amount` | Real-time | Exact numbers below bar |
-| **Remaining $** | `invoice.amount - funded_amount` | Real-time | Highlight if >50% |
-| **Due Date** | `invoice.due_date` | Static | Days remaining (e.g., "7 days") |
-| **Expected Funding** | Based on bid velocity & amounts | Calculated daily | Confidence %ile |
+| Field                   | Source                             | Updates          | Display Rule                    |
+| ----------------------- | ---------------------------------- | ---------------- | ------------------------------- |
+| **Invoice ID**          | `invoice.id`                       | Static           | Clickable → detail view         |
+| **Amount**              | `invoice.amount`                   | Static           | Formatted with currency         |
+| **Bid Count**           | Count of `bid` records for invoice | Real-time        | Shows market interest           |
+| **Progress %**          | `funded_amount / invoice.amount`   | Real-time        | Visual bar + text               |
+| **Funded $ / Target $** | `funded_amount` / `invoice.amount` | Real-time        | Exact numbers below bar         |
+| **Remaining $**         | `invoice.amount - funded_amount`   | Real-time        | Highlight if >50%               |
+| **Due Date**            | `invoice.due_date`                 | Static           | Days remaining (e.g., "7 days") |
+| **Expected Funding**    | Based on bid velocity & amounts    | Calculated daily | Confidence %ile                 |
 
 **Expected Funding Calculation** (Heuristic, not guaranteed):
+
 ```
 confidence = MIN(
   100,
@@ -406,12 +417,14 @@ confidence = MIN(
 ```
 
 **Security Considerations**:
+
 - ✅ Show aggregated bid count, NOT individual investor names or amounts
 - ✅ "Expected funding" is a heuristic, never guaranteed; label clearly as estimate
 - ✅ Do not expose bid evaluation algorithm; users should not game the system
 - ✅ Confidence intervals must be calculated server-side; never trust client math
 
 **Interactive Elements**:
+
 - Hover on progress bar → Tooltip showing exact breakdown (e.g., "$4,000 funded by 2 investors")
 - Click invoice ID → Navigate to invoice detail page
 - "Adjust Terms" → Modal to modify interest rate or due date (triggers new bids)
@@ -487,20 +500,21 @@ confidence = MIN(
 
 #### Settlement Receipt Fields
 
-| Field | Source | Visibility | Notes |
-|-------|--------|------------|-------|
-| **Transaction ID** | `settlement.id` | Public | Unique, audit trail |
-| **Settlement Date** | `settlement.completed_at` | Public | When user received funds |
-| **Invoice ID** | `invoice.id` | Public | Link to invoice |
-| **Amount** | `invoice.amount` | Public | Gross before fees |
-| **Fees** | Calculated | Public | Item-by-item breakdown |
-| **Net Payout** | `invoice.amount - fees` | Public | **Critical**: What user actually gets |
-| **Status** | `settlement.status` | Public | Settled, Pending, Delayed |
-| **Debtor Name** | `invoice.debtor` | Semi-public | Obfuscated for privacy |
-| **Investor Count** | Count of `investment` records | Public | Shows market participation |
-| **Transfer Method** | `settlement.transfer_method` | Private | Bank account obfuscated |
+| Field               | Source                        | Visibility  | Notes                                 |
+| ------------------- | ----------------------------- | ----------- | ------------------------------------- |
+| **Transaction ID**  | `settlement.id`               | Public      | Unique, audit trail                   |
+| **Settlement Date** | `settlement.completed_at`     | Public      | When user received funds              |
+| **Invoice ID**      | `invoice.id`                  | Public      | Link to invoice                       |
+| **Amount**          | `invoice.amount`              | Public      | Gross before fees                     |
+| **Fees**            | Calculated                    | Public      | Item-by-item breakdown                |
+| **Net Payout**      | `invoice.amount - fees`       | Public      | **Critical**: What user actually gets |
+| **Status**          | `settlement.status`           | Public      | Settled, Pending, Delayed             |
+| **Debtor Name**     | `invoice.debtor`              | Semi-public | Obfuscated for privacy                |
+| **Investor Count**  | Count of `investment` records | Public      | Shows market participation            |
+| **Transfer Method** | `settlement.transfer_method`  | Private     | Bank account obfuscated               |
 
 **Security Considerations**:
+
 - ✅ Debtor names shown to business (they know their customers), NOT to investors
 - ✅ Individual investor names hidden; only count/aggregates shown
 - ✅ Bank account numbers: Last 4 digits only
@@ -509,6 +523,7 @@ confidence = MIN(
 - ✅ Ensure PII (debtor name, bank details) marked as sensitive in logs
 
 **Downloadable Formats**:
+
 - **PDF**: Human-readable, printed/archived, branded
 - **JSON**: Machine-readable for accounting software integrations
 - **CSV**: Bulk export for spreadsheets
@@ -645,15 +660,16 @@ confidence = MIN(
 
 #### Dispute States & Visual Indicators
 
-| Status | Icon | Display | Urgency | Business Action |
-|--------|------|---------|---------|-----------------|
-| **Opened** | 🔴 | Red alert, pinned | URGENT | Respond ASAP |
-| **Under Review** | 🟠 | Orange warning | High | Submit evidence |
-| **In Mediation** | 🟡 | Yellow notice | Medium | Await decision |
-| **Resolved** | ✓ | Green success | Low | Archive / review |
-| **Appealed** | 🔴 | Red (escalated) | URGENT | Respond to appeal |
+| Status           | Icon | Display           | Urgency | Business Action   |
+| ---------------- | ---- | ----------------- | ------- | ----------------- |
+| **Opened**       | 🔴   | Red alert, pinned | URGENT  | Respond ASAP      |
+| **Under Review** | 🟠   | Orange warning    | High    | Submit evidence   |
+| **In Mediation** | 🟡   | Yellow notice     | Medium  | Await decision    |
+| **Resolved**     | ✓    | Green success     | Low     | Archive / review  |
+| **Appealed**     | 🔴   | Red (escalated)   | URGENT  | Respond to appeal |
 
 **Security Considerations**:
+
 - ✅ Business sees claim details but NOT investor identity
 - ✅ Investor sees business's response but NOT company name (shown anonymously)
 - ✅ Both parties can only see documents they uploaded or that mediator approves
@@ -667,16 +683,17 @@ confidence = MIN(
 
 ### Button Styles & Interactions
 
-| Button Type | Use Case | Appearance | Action |
-|------------|----------|-----------|--------|
+| Button Type       | Use Case                          | Appearance   | Action                                          |
+| ----------------- | --------------------------------- | ------------ | ----------------------------------------------- |
 | **Primary (CTA)** | Most important action per section | Blue, filled | "Accept Bid", "Submit Response", "Fund Invoice" |
-| **Secondary** | Supporting actions | Gray outline | "View Details", "Download Receipt" |
-| **Danger** | Destructive action | Red outline | "Withdraw Invoice", "Reject All Bids" |
-| **Disabled** | Action unavailable | Gray, faded | When state doesn't allow action |
-| **Loading** | Action in progress | Spinner | Replace button text during async ops |
-| **Icon Button** | Compact, repeated | Icon only | Download, expand, filter, sort |
+| **Secondary**     | Supporting actions                | Gray outline | "View Details", "Download Receipt"              |
+| **Danger**        | Destructive action                | Red outline  | "Withdraw Invoice", "Reject All Bids"           |
+| **Disabled**      | Action unavailable                | Gray, faded  | When state doesn't allow action                 |
+| **Loading**       | Action in progress                | Spinner      | Replace button text during async ops            |
+| **Icon Button**   | Compact, repeated                 | Icon only    | Download, expand, filter, sort                  |
 
 **Interaction Rules**:
+
 - Buttons show loading state with spinner until API response
 - Failed actions show error toast (bottom-right)
 - Successful actions show success toast with undo option (where applicable)
@@ -709,6 +726,7 @@ confidence = MIN(
 ```
 
 **Behavior**:
+
 - Default focus on cancel button (safe default)
 - Danger action button is red with warning icon
 - Optional text field for user feedback/reason
@@ -731,6 +749,7 @@ Table Row (Loading):
 ```
 
 **Principles**:
+
 - Use skeleton loaders for sections that might take >500ms to load
 - Keep existing data visible while refreshing (no flickering)
 - Show spinners for small async operations (<500ms expected)
@@ -752,6 +771,7 @@ Hover on metric card:
 ```
 
 **Rules**:
+
 - Tooltips appear on hover after 300ms delay (avoids flashing)
 - Include formula/calculation method
 - Link to full documentation if needed
@@ -772,6 +792,7 @@ $5,000 - $8,000 (Range format)
 ```
 
 **Rules**:
+
 - Always include currency symbol ($)
 - Use comma thousands separator for amounts ≥ 1,000
 - Show 2 decimal places for exactness (accounting important)
@@ -786,6 +807,7 @@ $5,000 - $8,000 (Range format)
 ```
 
 **Rules**:
+
 - Progress bars show filled (blue) vs. remaining (light gray)
 - Percentages rounded to nearest integer
 - Trends show direction (↑ green, ↓ red) with % change
@@ -802,6 +824,7 @@ May 1, 2026(5 days)       (Due dates with countdown)
 ```
 
 **Rules**:
+
 - Use user's locale for date format (MM/DD/YYYY in US)
 - Include time for event timestamps (dispute filed, settlement completed)
 - Use relative time for events <7 days old; absolute date for older
@@ -826,6 +849,7 @@ May 1, 2026(5 days)       (Due dates with countdown)
 ```
 
 **Empty State Scenarios**:
+
 - No invoices → Encourage upload with CTA
 - No disputes (ideal case) → Positive message
 - No settlement history → Show placeholder
@@ -846,7 +870,7 @@ graph LR
     E["✓ Settled<br/>Funds Transferred"]
     F["⚠️ Disputed<br/>Under Review"]
     G["❌ Withdrawn<br/>Cancelled"]
-    
+
     A -->|Submit| B
     B -->|Accept Bid| C
     C -->|Payment Received| D
@@ -857,7 +881,7 @@ graph LR
     F -->|Resolved Against| G
     A -->|Cancel| G
     B -->|No Interest| G
-    
+
     style A fill:#e8f4f8
     style B fill:#fff3cd
     style C fill:#d4edda
@@ -870,6 +894,7 @@ graph LR
 ### User Action Flows
 
 #### Flow 1: Accept a Bid
+
 ```
 Dashboard
     → Click Invoice (in "Pending" status)
@@ -883,6 +908,7 @@ Dashboard
 ```
 
 #### Flow 2: Respond to Dispute
+
 ```
 Dashboard
     → Alerts section shows "⚠️ Dispute Filed"
@@ -900,6 +926,7 @@ Dashboard
 ```
 
 #### Flow 3: Download Settlement Receipt
+
 ```
 Dashboard
     → Settlement Receipts section
@@ -918,18 +945,19 @@ Dashboard
 
 ### Data Exposure Matrix
 
-| Data Type | Business Sees | Investor Sees | Platform Admin | Notes |
-|-----------|---------------|---------------|----------------|-------|
-| **Invoice Amount** | ✓ (own only) | ✓ (can bid) | ✓ | Core to marketplace |
-| **Invoice Due Date** | ✓ | ✓ | ✓ | Determines interest window |
-| **Debtor Name** | ✓ (own customers) | ✗ | ✓ | Business privacy requirement |
-| **Settlement Amount** | ✓ | ✗ | ✓ | Own transaction only |
-| **Investor Name** | ✗ | N/A | ✓ | Investor privacy requirement |
-| **Bid Amount** | ✗ (only total funded) | ✓ (own only) | ✓ | Prevent information leakage |
-| **Dispute Evidence** | ✓ (own disputes) | ✓ (their disputes) | ✓ | Only related parties see |
-| **Payment Status** | ✓ | ✗ (only settled status) | ✓ | No unnecessary PII exposure |
+| Data Type             | Business Sees         | Investor Sees           | Platform Admin | Notes                        |
+| --------------------- | --------------------- | ----------------------- | -------------- | ---------------------------- |
+| **Invoice Amount**    | ✓ (own only)          | ✓ (can bid)             | ✓              | Core to marketplace          |
+| **Invoice Due Date**  | ✓                     | ✓                       | ✓              | Determines interest window   |
+| **Debtor Name**       | ✓ (own customers)     | ✗                       | ✓              | Business privacy requirement |
+| **Settlement Amount** | ✓                     | ✗                       | ✓              | Own transaction only         |
+| **Investor Name**     | ✗                     | N/A                     | ✓              | Investor privacy requirement |
+| **Bid Amount**        | ✗ (only total funded) | ✓ (own only)            | ✓              | Prevent information leakage  |
+| **Dispute Evidence**  | ✓ (own disputes)      | ✓ (their disputes)      | ✓              | Only related parties see     |
+| **Payment Status**    | ✓                     | ✗ (only settled status) | ✓              | No unnecessary PII exposure  |
 
 **Rules**:
+
 - ✅ Businesses see aggregated bid count, NOT individual investor details
 - ✅ Investors never see business name or customer list
 - ✅ Disputes show evidence but NOT party identities (mediation is anonymous)
@@ -961,6 +989,7 @@ Investor User (Not shown in this dashboard)
 ```
 
 **Implementation**:
+
 - All API endpoints require authentication (JWT token)
 - Business can only access their own data (verified via user ID)
 - Admin endpoints require elevated permissions (role-based)
@@ -978,6 +1007,7 @@ Investor User (Not shown in this dashboard)
 ```
 
 **Rules**:
+
 - Aggregate investor data; never individualize
 - Respect privacy settings (what users agreed to share)
 - Error messages must not reveal system internals
@@ -989,16 +1019,17 @@ Investor User (Not shown in this dashboard)
 
 ### Breakpoints
 
-| Device | Width | Layout | Adjustments |
-|--------|-------|--------|-------------|
-| **Mobile (Portrait)** | 320-599px | Single column | Stack all sections vertically; full-width cards |
-| **Mobile (Landscape)** | 600-767px | Single column | 2-column grid for metrics; single for tables |
-| **Tablet** | 768-1023px | 2-column grid | 2 metrics per row; full-width tables |
-| **Desktop** | 1024px+ | 3+ column grid | 3 metrics per row; scrollable tables |
+| Device                 | Width      | Layout         | Adjustments                                     |
+| ---------------------- | ---------- | -------------- | ----------------------------------------------- |
+| **Mobile (Portrait)**  | 320-599px  | Single column  | Stack all sections vertically; full-width cards |
+| **Mobile (Landscape)** | 600-767px  | Single column  | 2-column grid for metrics; single for tables    |
+| **Tablet**             | 768-1023px | 2-column grid  | 2 metrics per row; full-width tables            |
+| **Desktop**            | 1024px+    | 3+ column grid | 3 metrics per row; scrollable tables            |
 
 ### Responsive Behavior
 
 #### Metrics Section
+
 ```
 Desktop (1024px+):
 ┌────────┐ ┌────────┐ ┌────────┐
@@ -1026,6 +1057,7 @@ Mobile (320px):
 ```
 
 #### Table Display
+
 ```
 Desktop: Full table, all columns visible, horizontal scroll if needed
 
@@ -1062,14 +1094,14 @@ Mobile: Single-column card stack, hide numeric columns:
 
 #### Color Contrast
 
-| Element | Foreground | Background | Ratio | Status |
-|---------|-----------|-----------|-------|--------|
-| Body text | #333333 | #FFFFFF | 12.6:1 | ✓ AAA |
-| Button text | #FFFFFF | #0066CC | 5.5:1 | ✓ AA |
-| Disabled text | #999999 | #F5F5F5 | 4.5:1 | ✓ AA |
-| Success (green) | Text on #D1E7DD | 5.2:1 | ✓ AA |
-| Warning (orange) | Text on #FFF3CD | 3.5:1 | ⚠️ Use white text |
-| Error (red) | Text on #F8D7DA | 7.1:1 | ✓ AAA |
+| Element          | Foreground      | Background | Ratio             | Status |
+| ---------------- | --------------- | ---------- | ----------------- | ------ |
+| Body text        | #333333         | #FFFFFF    | 12.6:1            | ✓ AAA  |
+| Button text      | #FFFFFF         | #0066CC    | 5.5:1             | ✓ AA   |
+| Disabled text    | #999999         | #F5F5F5    | 4.5:1             | ✓ AA   |
+| Success (green)  | Text on #D1E7DD | 5.2:1      | ✓ AA              |
+| Warning (orange) | Text on #FFF3CD | 3.5:1      | ⚠️ Use white text |
+| Error (red)      | Text on #F8D7DA | 7.1:1      | ✓ AAA             |
 
 **Rule**: Do NOT rely on color alone; use icons + color + text.
 
@@ -1086,7 +1118,7 @@ Tab Order: Left-to-right, top-to-bottom
   7. Dispute cards
   8. Footer links
 
-Focus Indicators: 
+Focus Indicators:
   ✓ 3px blue outline around focused element
   ✓ Visible at all zoom levels (>= 100%)
   ✓ No focus hidden via CSS (no outline: none without replacement)
@@ -1179,15 +1211,16 @@ Alternative (Toast, bottom-right):
 
 **Error Types & Display**:
 
-| Error | User Message | Severity | Action | Auto-Dismiss |
-|-------|--------------|----------|--------|--------------|
-| **Validation** | "Invoice amount must be > $100" | Low | Highlight field | No |
-| **Network** | "Connection lost. Retrying..." | Medium | Auto-retry | After retry |
-| **Server** | "Server error. Contact support." | High | Show support link | No |
-| **Auth** | "Session expired. Please log in." | High | Redirect to login | No |
-| **Permission** | "You don't have access to this." | Medium | Show help text | No |
+| Error          | User Message                      | Severity | Action            | Auto-Dismiss |
+| -------------- | --------------------------------- | -------- | ----------------- | ------------ |
+| **Validation** | "Invoice amount must be > $100"   | Low      | Highlight field   | No           |
+| **Network**    | "Connection lost. Retrying..."    | Medium   | Auto-retry        | After retry  |
+| **Server**     | "Server error. Contact support."  | High     | Show support link | No           |
+| **Auth**       | "Session expired. Please log in." | High     | Redirect to login | No           |
+| **Permission** | "You don't have access to this."  | Medium   | Show help text    | No           |
 
 **Rules**:
+
 - Be specific (not "Error"; explain what went wrong)
 - Suggest recovery (not just "Failed")
 - Use "Error:" prefix for accessibility
@@ -1219,12 +1252,12 @@ User clicks "Accept Bid" button
 
 ### Load Time Targets
 
-| Page | Metric | Target | Strategy |
-|------|--------|--------|----------|
-| **Dashboard Load** | First Contentful Paint (FCP) | <1.5s | Skeleton loaders, lazy loading |
-| **Metric Cards** | Time to Interactive (TTI) | <2s | No render-blocking scripts |
-| **Invoice List** | Large Contentful Paint (LCP) | <2.5s | Optimize images, load only visible items |
-| **Settlement Table** | Interactive to next action | <200ms | Pagination, not infinite scroll |
+| Page                 | Metric                       | Target | Strategy                                 |
+| -------------------- | ---------------------------- | ------ | ---------------------------------------- |
+| **Dashboard Load**   | First Contentful Paint (FCP) | <1.5s  | Skeleton loaders, lazy loading           |
+| **Metric Cards**     | Time to Interactive (TTI)    | <2s    | No render-blocking scripts               |
+| **Invoice List**     | Large Contentful Paint (LCP) | <2.5s  | Optimize images, load only visible items |
+| **Settlement Table** | Interactive to next action   | <200ms | Pagination, not infinite scroll          |
 
 ### Data Fetching Strategy
 
@@ -1241,7 +1274,7 @@ Dashboard Load Sequence:
    ├─ Settlement receipts (paginated, first 10)
    └─ Disputes (if any)
 
-3. (User-triggered) 
+3. (User-triggered)
    ├─ Detailed invoice pages (on click)
    └─ Dispute detail pages (on click)
 ```
@@ -1287,7 +1320,8 @@ User deletes invoice / changes status:
 
 #### Decision 1: Aggregated Investor Data (Not Individualized)
 
-**Rationale**: 
+**Rationale**:
+
 - **Privacy**: Businesses don't need to know which investors funded which portions
 - **Simplicity**: One number (3 investors) is clearer than three rows
 - **Prevent Gaming**: If users know investor preferences, they might adjust terms to attract specific investors
@@ -1298,6 +1332,7 @@ User deletes invoice / changes status:
 #### Decision 2: Dispute Status Shows Investor Claim (Not Business Response)
 
 **Rationale**:
+
 - **Clarity**: Business needs to understand what they're responding to
 - **Privacy**: Investor's response not shown to business until they submit their own (prevents coordinated responses)
 - **Fairness**: Both parties see full evidence; mediation is neutral
@@ -1308,6 +1343,7 @@ User deletes invoice / changes status:
 #### Decision 3: Settlement Receipts Include Debtor Name
 
 **Rationale**:
+
 - **Practicality**: Business needs to match receipts to their own records (debtor name is identifying)
 - **Accounting**: Receipts must be reconcilable with A/R records
 - **Security**: Debtor name is NOT shared with investors (one-way transparency)
@@ -1318,6 +1354,7 @@ User deletes invoice / changes status:
 #### Decision 4: Expected Funding is Estimate, Not Guarantee
 
 **Rationale**:
+
 - **Honesty**: Bid velocity is unpredictable; avoid false confidence
 - **Prevent Gaming**: If users rely on estimate, they might make poor decisions
 - **Data Freshness**: Confidence updates daily, not real-time (stale data is dangerous)
@@ -1327,6 +1364,7 @@ User deletes invoice / changes status:
 #### Decision 5: Dashboard Focuses on Business (Not Investor) View
 
 **Rationale**:
+
 - **Distinct Use Cases**: Business needs cash-flow visibility; investor needs return tracking
 - **Data Separation**: Business data not mixed with investor data (prevents leakage)
 - **UX Clarity**: Focused on one audience; simpler, clearer interface
@@ -1385,6 +1423,6 @@ User deletes invoice / changes status:
 
 **Document Version**: 1.0  
 **Approved By**: [Product Lead]  
-**Last Updated**: 2026-04-28  
+**Last Updated**: 2026-04-28
 
 For questions or feedback, contact: product-team@quicklendx.io

--- a/docs/ux/metric-card.md
+++ b/docs/ux/metric-card.md
@@ -1,0 +1,307 @@
+# Metric Card Component Spec
+
+**Version**: 1.0  
+**Status**: Active  
+**Last Updated**: 2026-06-01  
+**Document Owner**: Product & Design Team
+
+---
+
+## Purpose
+
+Define the canonical KPI card used across Business, Investor, and Admin dashboards. This spec covers the shared anatomy, value treatment, trend semantics, estimate labeling, hover/focus tooltip behavior, drill-down affordance, and accessibility requirements.
+
+This document complements [business-dashboard.md](business-dashboard.md) Section 1 and provides the reusable pattern for future implementation in `app/components/MetricCard.tsx`.
+
+---
+
+## Core Principles
+
+1. **Scanability**: Users should identify the metric, value, and trend in a single glance.
+2. **Consistency**: The same structure, semantics, and motion apply across all dashboard surfaces.
+3. **Clarity**: Numeric values use mono-number treatment; labels stay sentence case and plain language.
+4. **Transparency**: Formulas and data freshness are discoverable on hover or keyboard focus.
+5. **Actionability**: The full card is a drill-down target, not just the CTA text.
+
+---
+
+## Anatomy
+
+Recommended vertical stack:
+
+1. **Eyebrow / Label**
+2. **Primary Value**
+3. **Secondary Context Line**
+4. **Trend Indicator**
+5. **Tooltip Trigger**
+6. **Drill-down affordance**
+
+### Layout sketch
+
+```text
+┌─────────────────────────────────────┐
+│ Total funded              ⓘ         │
+│ $87,500                              │
+│ 8.2% vs last week  ↑                 │
+│ 12 invoices included                │
+│ [View breakdown]                     │
+└─────────────────────────────────────┘
+```
+
+### Anatomy notes
+
+- The **entire card** is focusable and clickable.
+- The tooltip trigger may be an info icon beside the label or metric name.
+- The drill-down affordance should be visually secondary to the value, but clearly discoverable.
+
+---
+
+## Value Treatment
+
+### Primary value
+
+- Use the mono-number token style for all KPI values.
+- Apply tabular numerals where available to stabilize digit width.
+- Preserve currency symbols, percentage signs, and units inline with the value.
+- Keep the number as the strongest visual weight on the card.
+
+### Formatting rules
+
+- Use compact notation only when the dashboard spec permits it. Otherwise show exact values.
+- Keep labels sentence case.
+- Do not force the value into all caps or use decorative numerals.
+- If the metric is a ratio or percentage, keep the percent sign attached to the value.
+
+### Example values
+
+- `$87,500`
+- `42%`
+- `4.2 days`
+- `1,284`
+
+---
+
+## Trend Semantics
+
+Trend is shown as a compact secondary signal next to or below the value.
+
+### Direction rules
+
+- **Up arrow + green** means the metric increased relative to the comparison period.
+- **Down arrow + red** means the metric decreased relative to the comparison period.
+- **Neutral / flat** is allowed when the metric changed by less than the defined threshold or has no meaningful direction.
+
+### Comparison text
+
+- Prefer explicit comparison text such as `vs last week`, `vs last month`, or `since yesterday`.
+- Keep the delta concise and factual.
+- When the trend is paired with an operational metric, the comparison period must be visible in the tooltip.
+
+### Interpretation guidance
+
+- For favorable growth metrics, upward trend is positive.
+- For risk or latency metrics, upward trend may be negative. In those cases, the semantic color still follows the meaning of the metric, not the arrow itself.
+- The visual direction should never imply certainty or a guarantee; it only describes movement in the data.
+
+### Example trend strings
+
+- `↑ 12% vs last week`
+- `↓ 5.2% vs last month`
+- `→ Flat vs yesterday`
+
+---
+
+## Estimate Labeling
+
+Metrics derived from forecasted, inferred, or incomplete data must be explicitly labeled with `(est.)`.
+
+### Rules
+
+- Place `(est.)` directly in the metric label or adjacent to the value when the entire metric is estimated.
+- Do not hide estimation status in a tooltip only; it must be visible in the card.
+- Use the same label treatment across dashboards so users can compare cards consistently.
+- If a metric has mixed precision, the tooltip must explain which part is estimated.
+
+### Examples
+
+- `Expected payout (est.)`
+- `$82,950 (est.)`
+- `Pending funding (est.)`
+
+### Tooltip requirement for estimates
+
+- Explain the inputs, assumptions, and the freshness of the latest data.
+- If the estimate is based on partial settlement or incomplete funding data, say so plainly.
+
+---
+
+## Secondary Context Line
+
+The secondary context line gives the user one extra fact that helps interpret the value.
+
+### Preferred content
+
+- Count of included records
+- Comparison period
+- Due window or settlement horizon
+- Short status qualifier
+
+### Examples
+
+- `12 invoices included`
+- `Due in next 14 days`
+- `Updated 3 minutes ago`
+- `Fees deducted`
+
+### Rules
+
+- Keep the line to one short phrase.
+- Do not repeat the primary label verbatim.
+- Use plain language first.
+- If the metric is estimated, the secondary line should reinforce the estimate or freshness state.
+
+---
+
+## Tooltip Layout
+
+Metric tooltips should follow the shared tooltip spec in [tooltips.md](tooltips.md) and include the following order:
+
+1. **Definition**: one short sentence describing what the metric represents.
+2. **Formula**: a compact formula or calculation statement.
+3. **Last updated**: the most recent data ingestion or sync time.
+4. **Learn more**: optional link to the relevant dashboard or data definition.
+
+### Tooltip content example
+
+```text
+Definition: Expected payout is the projected net amount after fees.
+Formula: sum(funded_amount × (1 - fees))
+Last updated: 2026-06-01 10:15 UTC
+Learn more: business-dashboard.md
+```
+
+### Tooltip behavior
+
+- Hover: show after the shared 300ms delay.
+- Keyboard focus: show immediately.
+- Touch: tap to open and tap outside to dismiss.
+- Keep the tooltip concise and non-interactive.
+
+---
+
+## Drill-down Behavior
+
+The whole card is a navigation target.
+
+### Interaction rules
+
+- Clicking or pressing `Enter` / `Space` on the card opens the relevant detail view.
+- The drill-down target should be announced clearly in the accessible name.
+- If the card contains a separate CTA, the CTA must not be the only way to navigate.
+
+### Drill-down destinations
+
+- Business: invoice pipeline, settlement history, dispute detail, or payout schedule.
+- Investor: expected yield, bid queue, portfolio status, or repayment view.
+- Admin: risk review, monitoring queue, reconciliation detail, or system metrics.
+
+---
+
+## States
+
+### Default
+
+- Clean surface, strong value, secondary context, and optional trend.
+
+### Hover
+
+- Slight elevation or border emphasis.
+- Tooltip trigger and click target remain obvious.
+
+### Focus
+
+- Visible keyboard focus ring using the primary focus token.
+- Tooltip may open on focus when the info trigger is focused.
+
+### Active / pressed
+
+- Brief press feedback on the entire card.
+
+### Loading
+
+- Skeleton or muted placeholder for label, value, and context.
+
+### Empty / unavailable
+
+- Use `—` or a short unavailable state when data has not loaded yet.
+- Avoid inventing placeholder numbers.
+
+### Error
+
+- Show a neutral error state with a retry action when the metric cannot load.
+
+---
+
+## Responsive Grid
+
+The KPI card is designed to sit inside a responsive card grid.
+
+### Grid behavior
+
+- **375px**: single-column stack or two-up grid only if content remains readable.
+- **768px**: two to three columns depending on label length.
+- **1280px**: six-card dashboard row is acceptable when the labels remain scannable.
+
+### Density rule
+
+- The label must never wrap so aggressively that the value loses prominence.
+- If a label is too long, shorten the label rather than shrinking the value below readability.
+
+---
+
+## Accessibility
+
+- The whole card must be keyboard focusable.
+- The accessible name should describe both the metric and its current value.
+- Include a descriptive `aria-label` such as `Total funded, $87,500, up 12 percent from last week, view breakdown`.
+- Tooltip trigger must be reachable by keyboard and use `aria-describedby`.
+- Use `role="button"` only when the card behaves as a button; otherwise use a semantic link for navigation.
+- Focus order should let the user reach the card, then the tooltip trigger, then the drill-down action if separate.
+
+### Screen reader guidance
+
+- Read the primary label and value first.
+- Include trend direction in the accessible name.
+- Include `(est.)` in the accessible label when present visually.
+
+---
+
+## Visual QA Checklist
+
+- Verify the card grid at **375px** and **1280px**.
+- Confirm the value uses mono-number treatment and remains visually dominant.
+- Confirm trend arrows use the correct semantic color.
+- Confirm `(est.)` is visible whenever the metric is estimated.
+- Confirm the tooltip is reachable by pointer and keyboard.
+- Confirm the whole card is focusable and has a descriptive `aria-label`.
+
+---
+
+## Future Implementation Note
+
+Suggested component entry point:
+
+- `app/components/MetricCard.tsx`
+
+Suggested props shape:
+
+- `label`
+- `value`
+- `trend`
+- `secondaryLine`
+- `tooltip`
+- `href` or `onClick`
+- `ariaLabel`
+- `estimate`
+
+The implementation should reuse the shared tooltip component spec and the design tokens in [design-tokens.md](design-tokens.md).


### PR DESCRIPTION
closes #1028

Added a canonical KPI card spec in docs/ux/metric-card.md and linked it from Section 1 of docs/ux/business-dashboard.md. The spec covers card anatomy, mono-number value treatment, trend arrow/color semantics, (est.) labeling, tooltip content/layout with freshness, full-card drill-down behavior, keyboard/focus accessibility, and the future app/components/MetricCard.tsx entry point