### PR TITLE
docs(uiux): add first-class explorer link component spec

### DIFF
--- a/docs/ux/explorer-link.md
+++ b/docs/ux/explorer-link.md
@@ -1,0 +1,45 @@
+# Explorer Link Component Specification
+
+This document defines the UI/UX pattern for block explorer links (Stellar Expert / Horizon). Following the principles outlined in `docs/ux/review-notes.md` and `docs/ux/visual-direction.md`, visual links to block explorers are "First Class" components and must not be hidden in sub-menus. This transparent, accessible pattern directly reinforces the "Immutable Proof" trust pillar.
+
+*Note: This design specification will be implemented in the future as a reusable React component at `app/components/ExplorerLink.tsx`.*
+
+**Figma source:** [Design — Explorer Link Component](https://www.figma.com/design/B4vJUfYOinfSPFTub9yVaA/Design-explorer-link-component?node-id=0-1&t=UJ8kANcf3LFHgybv-1)
+
+## Anatomy & Affordance
+
+The explorer link must be a distinct, self-contained component providing a consistent "view on explorer" affordance for transaction hashes, addresses, and settlement events.
+
+- **Typography:** The hash or address must use the standard **Data Mono** typography token. This ensures design consistency with existing mono-address tokens.
+- **External Link Semantics:**
+  - Must open in a new tab.
+  - Must include `rel="noopener noreferrer"` for security.
+  - Must append an external-link icon directly following the text to indicate off-site navigation.
+- **Accessibility:**
+  - Use descriptive link text (e.g., "View transaction [hash] on Stellar Expert"). Never use non-descriptive phrases like "click here".
+  - The element must have clear focus visibility states for keyboard navigation.
+
+## Truncation & Copy-to-Clipboard Rules
+
+To accommodate varying screen sizes while maintaining the Immutable Proof principle:
+
+- **Hash Truncation:** Long transaction hashes and addresses must be truncated in the middle (e.g., first 5-6 characters, an ellipsis, and the last 4-5 characters) to fit the UI gracefully.
+- **Copy Action:** 
+  - The component must include a mechanism to copy the full, un-truncated hash or address to the clipboard.
+  - This is typically handled by a "copy" icon button adjacent to the link.
+  - Visual feedback (like a "Copied!" tooltip or toast) should be triggered upon a successful copy action.
+
+## Placement Matrix
+
+The explorer link must be placed consistently across the following surfaces:
+
+| Surface | Placement |
+| --- | --- |
+| **Bid** | Displayed near the bid details or transaction summary, allowing users to easily verify the bid's on-chain record. |
+| **Settlement Receipt** | Placed prominently as a foundational element of the receipt view to prove settlement finality. |
+| **Dispute Timeline** | Embedded within individual timeline event entries so users can independently audit each recorded action. |
+
+## QA Guidelines
+
+- **Visual QA:** Component layout, truncation, and copy icon alignment must be verified at both **375px** (mobile) and **1280px** (desktop) viewports.
+- Ensure all states (hover, focus, active) meet accessibility contrast and focus ring guidelines.


### PR DESCRIPTION
Closes #1024 

## docs(uiux): add first-class explorer link component spec

### Summary

Adds `docs/ux/explorer-link.md` — the UI/UX specification for a consistent "view on explorer" affordance for transaction hashes, addresses, and settlement events across QuickLendX surfaces. This reinforces the **Immutable Proof** trust pillar as required by `docs/ux/review-notes.md` and `docs/ux/visual-direction.md`.

### Changes

- **[NEW]** `docs/ux/explorer-link.md`
  - Component anatomy: Data Mono token, external-link icon, `rel="noopener noreferrer"`, new-tab behaviour
  - Hash/address truncation rules (middle-truncation with ellipsis)
  - Copy-to-clipboard behaviour and visual feedback pattern
  - Placement matrix for bid, settlement receipt, and dispute timeline surfaces
  - Accessibility requirements: descriptive link text, focus visibility
  - Visual QA guidelines at 375px (mobile) and 1280px (desktop)
  - Figma design source linked
  - Forward reference to future `app/components/ExplorerLink.tsx`

### Figma

[Design — Explorer Link Component](https://www.figma.com/design/B4vJUfYOinfSPFTub9yVaA/Design-explorer-link-component?node-id=0-1&t=UJ8kANcf3LFHgybv-1)

### Testing

- `npm run build` — ✅ Compiled successfully (Next.js 15.5.12, 5 static pages generated)
- Lint: pre-existing project ESLint v9 config issue (no `eslint.config.js` found) — unrelated to this docs-only change
- Visual QA breakpoints (375px / 1280px) documented in spec

### Checklist

- [x] Follows Conventional Commit prefix (`docs`)
- [x] Branch: `uiux/explorer-link-pattern-spec`
- [x] No source code modified — docs-only change
- [x] Accessible link text and focus visibility specified
- [x] `rel="noopener noreferrer"` and new-tab behaviour specified
- [x] Placement defined on bid, settlement receipt, and dispute timeline
