### PR TITLE
test(delegation): proof-style proptest for invalidate_nonce_range cov…

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,6 @@
+[workspace]
+members = ["contracts/credence_delegation"]
+
 [package]
 name = "quicklendx-contracts"
 version = "0.1.0"

--- a/contracts/credence_delegation/Cargo.toml
+++ b/contracts/credence_delegation/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "credence_delegation"
+version = "0.1.0"
+edition = "2021"
+
+[dev-dependencies]
+proptest = "1.4"
+
+[lints.rust]
+warnings = "deny"

--- a/contracts/credence_delegation/src/lib.rs
+++ b/contracts/credence_delegation/src/lib.rs
@@ -1,0 +1,6 @@
+/// Credence Delegation Contract
+///
+/// Provides a monotonic nonce system for pre-signed delegation payloads,
+/// preventing replay attacks on the QuickLendX protocol's off-chain
+/// delegation flow.
+pub mod nonce;

--- a/contracts/credence_delegation/src/nonce.rs
+++ b/contracts/credence_delegation/src/nonce.rs
@@ -1,0 +1,222 @@
+/// Maximum number of nonces that a single `invalidate_nonce_range` call may
+/// skip forward.
+///
+/// # Bound and rationale
+///
+/// `invalidate_nonce_range` advances `current` from its present value to
+/// `new_nonce` in a single atomic step.  Without a cap an attacker who
+/// controls `new_nonce` (or a buggy delegator) could push `current` to
+/// `u64::MAX` in one call, permanently locking the delegation channel.
+/// Capping the span to 10 000 per call:
+///
+/// 1. **Prevents accidental lockout** — a typo in `new_nonce` can discard at
+///    most 10 000 pre-signed payloads, not all of them.
+/// 2. **Bounds gas / iteration cost** — on-chain implementations that must
+///    iterate over the range have a predictable worst-case of 10 000 steps.
+/// 3. **Preserves forward progress** — large invalidations can always be
+///    achieved by chaining multiple calls, each within the limit.
+///
+/// The value 10 000 was chosen to match the protocol's BPS denominator
+/// (basis-point scale), making it easy to reason about in the context of
+/// percentage-based limits elsewhere in QuickLendX.
+pub const MAX_NONCE_INVALIDATION_SPAN: u64 = 10_000;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Error types
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Errors returned by nonce operations.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum NonceError {
+    /// The payload nonce does not equal the current stored nonce.
+    ///
+    /// This covers three cases uniformly:
+    /// - Replay: `payload.nonce < current` — nonce has already been consumed
+    ///   or invalidated.
+    /// - Skipped: `payload.nonce > current` — out-of-order execution is not
+    ///   permitted; nonces must be used strictly in sequence.
+    InvalidNonce,
+
+    /// The requested invalidation span exceeds [`MAX_NONCE_INVALIDATION_SPAN`].
+    ///
+    /// `span = new_nonce - current` was larger than the allowed maximum.
+    SpanTooLarge {
+        /// The span that was requested.
+        span: u64,
+    },
+
+    /// `new_nonce` must be strictly greater than the current nonce.
+    NonceMustIncrease,
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// NonceStore
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Per-delegator monotonic nonce counter.
+///
+/// # Monotonicity invariant
+///
+/// `current` only ever increases.  Execution of a delegated payload requires
+/// `payload.nonce == current`; on success `current` becomes `current + 1`.
+/// Because `current` never decreases, every nonce that has been passed or
+/// skipped is **permanently unspendable**.
+///
+/// Formally: after any sequence of `consume` and `invalidate_nonce_range`
+/// calls that leave `current == N`, no payload with `nonce < N` can ever
+/// satisfy the equality check again.
+///
+/// # Replay-window coverage
+///
+/// `invalidate_nonce_range(new_nonce)` covers the half-open range
+/// `[old_current, new_nonce)`.  Every nonce `k` in that range satisfies
+/// `k < new_nonce == current`, so `consume(k)` will return
+/// [`NonceError::InvalidNonce`] for all time.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NonceStore {
+    current: u64,
+}
+
+impl NonceStore {
+    /// Creates a `NonceStore` whose first valid nonce is `initial`.
+    pub fn new(initial: u64) -> Self {
+        Self { current: initial }
+    }
+
+    /// Returns the current (next-expected) nonce value.
+    pub fn current(&self) -> u64 {
+        self.current
+    }
+
+    /// Invalidates all pre-signed payloads whose nonce falls in the
+    /// half-open range `[current, new_nonce)` by advancing `current` to
+    /// `new_nonce`.
+    ///
+    /// # Proof of unspendability
+    ///
+    /// Let `N_before = current` before the call and `N_after = new_nonce`
+    /// after.  For any nonce `k` where `N_before ≤ k < N_after`:
+    ///
+    /// ```text
+    /// 1. After the call: current = N_after.
+    /// 2. Execution requires payload.nonce == current  (exact equality).
+    /// 3. k < N_after = current  →  k ≠ current  →  consume(k) = Err(InvalidNonce).
+    /// 4. current is monotonically non-decreasing, so current ≥ N_after forever.
+    /// 5. Therefore consume(k) = Err(InvalidNonce) for all future states too.
+    /// ```
+    ///
+    /// Nonces below `N_before` were already unspendable by the same argument.
+    /// The union of the two ranges gives the full set `[0, N_after)`.
+    ///
+    /// # Errors
+    ///
+    /// * [`NonceError::NonceMustIncrease`] — `new_nonce ≤ current`.
+    /// * [`NonceError::SpanTooLarge`]      — `new_nonce - current > MAX_NONCE_INVALIDATION_SPAN`.
+    ///
+    /// On error the store is **not modified**.
+    pub fn invalidate_nonce_range(&mut self, new_nonce: u64) -> Result<(), NonceError> {
+        if new_nonce <= self.current {
+            return Err(NonceError::NonceMustIncrease);
+        }
+        let span = new_nonce - self.current;
+        if span > MAX_NONCE_INVALIDATION_SPAN {
+            return Err(NonceError::SpanTooLarge { span });
+        }
+        self.current = new_nonce;
+        Ok(())
+    }
+
+    /// Attempts to execute a delegated payload identified by `nonce`.
+    ///
+    /// Succeeds only when `nonce == current`.  On success `current` is
+    /// incremented by 1, preventing re-use of the same nonce.
+    ///
+    /// # Errors
+    ///
+    /// [`NonceError::InvalidNonce`] when `nonce ≠ current` (replay or skip).
+    pub fn consume(&mut self, nonce: u64) -> Result<(), NonceError> {
+        if nonce != self.current {
+            return Err(NonceError::InvalidNonce);
+        }
+        // Monotonic increment — current can never decrease after this point.
+        self.current += 1;
+        Ok(())
+    }
+
+    /// Verifies that `nonce` matches `current` without consuming it.
+    ///
+    /// Useful for pre-flight signature checks before committing side effects.
+    ///
+    /// # Errors
+    ///
+    /// [`NonceError::InvalidNonce`] when `nonce ≠ current`.
+    pub fn verify(&self, nonce: u64) -> Result<(), NonceError> {
+        if nonce != self.current {
+            return Err(NonceError::InvalidNonce);
+        }
+        Ok(())
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Unit tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fresh_store_accepts_zero() {
+        let mut s = NonceStore::new(0);
+        assert!(s.consume(0).is_ok());
+        assert_eq!(s.current(), 1);
+    }
+
+    #[test]
+    fn consume_wrong_nonce_is_invalid() {
+        let mut s = NonceStore::new(5);
+        assert_eq!(s.consume(4), Err(NonceError::InvalidNonce));
+        assert_eq!(s.consume(6), Err(NonceError::InvalidNonce));
+        assert_eq!(s.current(), 5); // store unchanged on error
+    }
+
+    #[test]
+    fn invalidate_advances_current() {
+        let mut s = NonceStore::new(0);
+        s.invalidate_nonce_range(100).unwrap();
+        assert_eq!(s.current(), 100);
+    }
+
+    #[test]
+    fn invalidate_rejects_non_increase() {
+        let mut s = NonceStore::new(50);
+        assert_eq!(s.invalidate_nonce_range(50), Err(NonceError::NonceMustIncrease));
+        assert_eq!(s.invalidate_nonce_range(10), Err(NonceError::NonceMustIncrease));
+        assert_eq!(s.current(), 50);
+    }
+
+    #[test]
+    fn invalidate_at_max_span_succeeds() {
+        let mut s = NonceStore::new(0);
+        assert!(s.invalidate_nonce_range(MAX_NONCE_INVALIDATION_SPAN).is_ok());
+        assert_eq!(s.current(), MAX_NONCE_INVALIDATION_SPAN);
+    }
+
+    #[test]
+    fn invalidate_over_max_span_rejected() {
+        let mut s = NonceStore::new(0);
+        let result = s.invalidate_nonce_range(MAX_NONCE_INVALIDATION_SPAN + 1);
+        assert!(matches!(result, Err(NonceError::SpanTooLarge { span: 10_001 })));
+        assert_eq!(s.current(), 0); // store unchanged
+    }
+
+    #[test]
+    fn verify_does_not_advance_current() {
+        let s = NonceStore::new(7);
+        assert!(s.verify(7).is_ok());
+        assert_eq!(s.current(), 7);
+        assert_eq!(s.verify(6), Err(NonceError::InvalidNonce));
+        assert_eq!(s.verify(8), Err(NonceError::InvalidNonce));
+    }
+}

--- a/contracts/credence_delegation/tests/nonce_replay.rs
+++ b/contracts/credence_delegation/tests/nonce_replay.rs
@@ -1,0 +1,292 @@
+//! # Nonce Replay-Window Property Tests
+//!
+//! Verifies that `invalidate_nonce_range(new_nonce)` permanently renders
+//! every nonce in `[0, new_nonce)` unspendable — regardless of the initial
+//! counter value, the invalidation span, or which specific nonce the attacker
+//! attempts to replay.
+//!
+//! ## Security claim under test
+//!
+//! For any delegator whose `NonceStore` has been advanced to `N` (by any
+//! combination of `consume` and `invalidate_nonce_range` calls), an attacker
+//! holding a pre-signed payload with `nonce < N` cannot execute that payload:
+//! `consume(nonce)` will always return `Err(NonceError::InvalidNonce)`.
+//!
+//! ## Running
+//!
+//! ```bash
+//! cargo test -p credence_delegation nonce_replay
+//! ```
+//!
+//! Property tests run 10 000 randomly generated cases each.
+//! Deterministic edge-case tests always run unconditionally.
+
+use credence_delegation::nonce::{NonceError, NonceStore, MAX_NONCE_INVALIDATION_SPAN};
+use proptest::prelude::*;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Property tests — 10 000 cases each
+// ─────────────────────────────────────────────────────────────────────────────
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(10_000))]
+
+    /// **Core replay invariant**: after `invalidate_nonce_range(new_nonce)`,
+    /// every nonce `n` in `[0, new_nonce)` is rejected by `consume`.
+    ///
+    /// Generates:
+    /// - `start`  — initial counter value (avoids overflow in `start + span`)
+    /// - `span`   — invalidation size in `[1, MAX_NONCE_INVALIDATION_SPAN]`
+    /// - `replay` — attacker-chosen nonce, pinned to `[0, new_nonce)` via modulo
+    #[test]
+    fn prop_invalidated_nonces_are_unspendable(
+        start  in 0u64..u64::MAX - MAX_NONCE_INVALIDATION_SPAN,
+        span   in 1u64..=MAX_NONCE_INVALIDATION_SPAN,
+        replay in any::<u64>(),
+    ) {
+        let new_nonce = start + span;
+        // Pin replay to [0, new_nonce) — the full invalidated prefix.
+        let replay = replay % new_nonce; // new_nonce >= 1, so no division by zero
+
+        let mut store = NonceStore::new(start);
+        store.invalidate_nonce_range(new_nonce).unwrap();
+
+        prop_assert_eq!(
+            store.consume(replay),
+            Err(NonceError::InvalidNonce),
+            "Replay of nonce {replay} must be rejected after invalidation \
+             to {new_nonce} (start={start} span={span})"
+        );
+    }
+
+    /// **Minimal-span invariant**: span = 1 invalidates exactly one nonce.
+    ///
+    /// After invalidation by 1, nonce `start` is rejected and `start + 1`
+    /// (the new `current`) is accepted.
+    #[test]
+    fn prop_minimal_span_invalidates_exactly_one_nonce(
+        start in 0u64..u64::MAX - 1,
+    ) {
+        let mut store = NonceStore::new(start);
+        store.invalidate_nonce_range(start + 1).unwrap();
+
+        // The invalidated nonce must be rejected.
+        prop_assert_eq!(
+            store.consume(start),
+            Err(NonceError::InvalidNonce),
+            "Nonce {start} must be invalid after minimal invalidation"
+        );
+        // The next nonce (new current) must be accepted.
+        prop_assert!(
+            store.consume(start + 1).is_ok(),
+            "Nonce {} must be valid after minimal invalidation", start + 1
+        );
+    }
+
+    /// **Max-span boundary**: span = MAX succeeds; the boundary nonce
+    /// `new_nonce - 1` (last of the invalidated range) is rejected, while
+    /// `new_nonce` itself is accepted.
+    #[test]
+    fn prop_max_span_boundary_nonce_rejected(
+        start in 0u64..u64::MAX - MAX_NONCE_INVALIDATION_SPAN,
+    ) {
+        let new_nonce = start + MAX_NONCE_INVALIDATION_SPAN;
+        let mut store = NonceStore::new(start);
+
+        prop_assert!(
+            store.invalidate_nonce_range(new_nonce).is_ok(),
+            "Max-span invalidation must succeed (start={start})"
+        );
+
+        // Boundary: new_nonce - 1 is inside [start, new_nonce) — must fail.
+        prop_assert_eq!(
+            store.consume(new_nonce - 1),
+            Err(NonceError::InvalidNonce),
+            "Boundary nonce {} must be rejected", new_nonce - 1
+        );
+
+        // new_nonce is now the live counter — must succeed.
+        prop_assert!(
+            store.consume(new_nonce).is_ok(),
+            "new_nonce {new_nonce} must be accepted"
+        );
+    }
+
+    /// **Over-limit rejection**: any span > MAX is always rejected.
+    #[test]
+    fn prop_over_max_span_always_rejected(
+        start     in 0u64..u64::MAX - MAX_NONCE_INVALIDATION_SPAN - 1,
+        extra_span in 1u64..1_000u64,
+    ) {
+        let over_span = MAX_NONCE_INVALIDATION_SPAN + extra_span;
+        let mut store = NonceStore::new(start);
+        let result = store.invalidate_nonce_range(start + over_span);
+
+        prop_assert!(
+            matches!(result, Err(NonceError::SpanTooLarge { .. })),
+            "Span {over_span} > MAX must be rejected, got {result:?}"
+        );
+        // Store must be unchanged on error.
+        prop_assert_eq!(store.current(), start);
+    }
+
+    /// **First valid nonce accepted**: `new_nonce` (the value assigned to
+    /// `current` after invalidation) is always accepted immediately.
+    #[test]
+    fn prop_first_valid_nonce_accepted(
+        start in 0u64..u64::MAX - MAX_NONCE_INVALIDATION_SPAN,
+        span  in 1u64..=MAX_NONCE_INVALIDATION_SPAN,
+    ) {
+        let new_nonce = start + span;
+        let mut store = NonceStore::new(start);
+        store.invalidate_nonce_range(new_nonce).unwrap();
+
+        prop_assert!(
+            store.consume(new_nonce).is_ok(),
+            "new_nonce {new_nonce} must be the first accepted nonce"
+        );
+    }
+
+    /// **Future nonces rejected**: nonces strictly greater than `new_nonce`
+    /// are also invalid — they do not match `current` and cannot be used
+    /// out of order.
+    #[test]
+    fn prop_future_nonces_rejected(
+        start  in 0u64..u64::MAX - MAX_NONCE_INVALIDATION_SPAN - 1_000,
+        span   in 1u64..=MAX_NONCE_INVALIDATION_SPAN,
+        offset in 1u64..1_000u64,
+    ) {
+        let new_nonce = start + span;
+        let mut store = NonceStore::new(start);
+        store.invalidate_nonce_range(new_nonce).unwrap();
+
+        let future = new_nonce + offset;
+        prop_assert_eq!(
+            store.consume(future),
+            Err(NonceError::InvalidNonce),
+            "Future nonce {future} must be rejected (current is {new_nonce})"
+        );
+    }
+
+    /// **Monotonicity**: `current` never decreases after any sequence of
+    /// valid `invalidate_nonce_range` calls.
+    #[test]
+    fn prop_current_is_non_decreasing(
+        start in 0u64..u64::MAX - 2 * MAX_NONCE_INVALIDATION_SPAN,
+        s1    in 1u64..=MAX_NONCE_INVALIDATION_SPAN,
+        s2    in 1u64..=MAX_NONCE_INVALIDATION_SPAN,
+    ) {
+        let mut store = NonceStore::new(start);
+        let after_first = start + s1;
+        let after_second = after_first + s2;
+
+        store.invalidate_nonce_range(after_first).unwrap();
+        prop_assert_eq!(store.current(), after_first);
+
+        store.invalidate_nonce_range(after_second).unwrap();
+        prop_assert_eq!(store.current(), after_second);
+
+        // Attempting to go back must always fail.
+        prop_assert_eq!(
+            store.invalidate_nonce_range(after_first),
+            Err(NonceError::NonceMustIncrease)
+        );
+        // Current is unchanged after the failed attempt.
+        prop_assert_eq!(store.current(), after_second);
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Deterministic edge-case tests (always run, no feature flag required)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Invalidation by exactly 1: the single skipped nonce is immediately invalid.
+#[test]
+fn nonce_replay_invalidation_by_one() {
+    let mut store = NonceStore::new(0);
+    assert!(store.invalidate_nonce_range(1).is_ok());
+    assert_eq!(store.consume(0), Err(NonceError::InvalidNonce));
+    assert!(store.consume(1).is_ok());
+}
+
+/// Invalidation by MAX: all 10 000 nonces [0, MAX) are invalid.
+#[test]
+fn nonce_replay_invalidation_by_max() {
+    let mut store = NonceStore::new(0);
+    assert!(store.invalidate_nonce_range(MAX_NONCE_INVALIDATION_SPAN).is_ok());
+
+    for n in 0..MAX_NONCE_INVALIDATION_SPAN {
+        assert_eq!(
+            store.consume(n),
+            Err(NonceError::InvalidNonce),
+            "nonce {n} should be invalid after max-span invalidation"
+        );
+    }
+    // Only MAX itself is the live nonce.
+    assert!(store.consume(MAX_NONCE_INVALIDATION_SPAN).is_ok());
+}
+
+/// Invalidation by MAX + 1 must be rejected; store must not change.
+#[test]
+fn nonce_replay_invalidation_by_max_plus_one_rejected() {
+    let mut store = NonceStore::new(0);
+    let result = store.invalidate_nonce_range(MAX_NONCE_INVALIDATION_SPAN + 1);
+    assert!(
+        matches!(result, Err(NonceError::SpanTooLarge { span: 10_001 })),
+        "Expected SpanTooLarge(10_001), got {result:?}"
+    );
+    assert_eq!(store.current(), 0, "Store must be unchanged on over-span error");
+}
+
+/// Boundary case: `new_nonce - 1` (last invalidated) fails; `new_nonce` succeeds.
+///
+/// This test validates the half-open range semantics at a non-zero start,
+/// confirming the boundary nonce cannot be replayed even after bumping by
+/// `MAX - 1` positions.
+#[test]
+fn nonce_replay_boundary_last_invalidated() {
+    const START: u64 = 500;
+    // Bump by MAX - 1 = 9_999 (within the allowed span).
+    const SPAN: u64 = MAX_NONCE_INVALIDATION_SPAN - 1;
+    const NEW: u64 = START + SPAN;
+
+    let mut store = NonceStore::new(START);
+    store.invalidate_nonce_range(NEW).unwrap();
+
+    // NEW - 1 is the last nonce in [START, NEW) — must be rejected.
+    assert_eq!(
+        store.consume(NEW - 1),
+        Err(NonceError::InvalidNonce),
+        "Boundary nonce {} must be invalid", NEW - 1
+    );
+    // NEW is the new current — must succeed.
+    assert!(store.consume(NEW).is_ok());
+}
+
+/// Once invalidated, a nonce remains invalid through subsequent invalidations.
+#[test]
+fn nonce_replay_persists_across_further_invalidations() {
+    let mut store = NonceStore::new(0);
+    store.invalidate_nonce_range(5).unwrap();
+    store.invalidate_nonce_range(10).unwrap();
+
+    // Nonces 0–9 were invalidated in two separate calls — all must fail.
+    for n in 0..10 {
+        assert_eq!(
+            store.consume(n),
+            Err(NonceError::InvalidNonce),
+            "nonce {n} should remain invalid after chained invalidations"
+        );
+    }
+    assert!(store.consume(10).is_ok());
+}
+
+/// `invalidate_nonce_range` must not accept a non-increasing value.
+#[test]
+fn nonce_replay_no_decrease() {
+    let mut store = NonceStore::new(100);
+    assert!(store.invalidate_nonce_range(101).is_ok());
+    assert_eq!(store.invalidate_nonce_range(100), Err(NonceError::NonceMustIncrease));
+    assert_eq!(store.invalidate_nonce_range(101), Err(NonceError::NonceMustIncrease));
+    assert_eq!(store.current(), 101);
+}

--- a/docs/contracts/nonce-replay-proof.md
+++ b/docs/contracts/nonce-replay-proof.md
@@ -1,0 +1,184 @@
+# Nonce Replay-Window Proof — `credence_delegation`
+
+> **Module**: `contracts/credence_delegation/src/nonce.rs`  
+> **Constant**: `MAX_NONCE_INVALIDATION_SPAN = 10_000`  
+> **Test harness**: `contracts/credence_delegation/tests/nonce_replay.rs`
+
+---
+
+## 1. Definitions
+
+| Symbol | Meaning |
+|--------|---------|
+| `current` | The stored nonce value for a specific delegator. Initialised to some `N₀ ≥ 0`. |
+| `payload.nonce` | The nonce embedded in a pre-signed delegation payload. |
+| `consume(n)` | Attempt to execute a payload with nonce `n`. Succeeds iff `n == current`; advances `current` to `current + 1` on success. |
+| `invalidate_nonce_range(m)` | Advance `current` to `m` atomically, provided `m > current` and `m - current ≤ MAX_NONCE_INVALIDATION_SPAN`. |
+| `MAX_NONCE_INVALIDATION_SPAN` | 10 000 — the maximum single-call advance. |
+
+---
+
+## 2. Core Invariant
+
+**Monotonicity**: `current` is strictly non-decreasing across the lifetime of a `NonceStore`.
+
+*Proof.*  
+`current` is modified in exactly two places:
+1. `consume` — sets `current ← current + 1` (increase by 1).
+2. `invalidate_nonce_range` — sets `current ← new_nonce` where `new_nonce > current` (strict increase).
+
+No code path decreases `current`.  
+Both paths are guarded by precondition checks that return an error (leaving `current` unchanged) before any mutation occurs. ∎
+
+---
+
+## 3. Replay-Window Theorem
+
+**Theorem**: Let `S` be a `NonceStore`. After any finite sequence of `consume` and `invalidate_nonce_range` calls that leaves `current = N`, the call `consume(k)` returns `Err(NonceError::InvalidNonce)` for every `k < N` — and will continue to do so for all future states of `S`.
+
+**Proof.**
+
+*Step 1 — Immediate rejection after the call.*  
+After the sequence, `current = N`.  
+`consume(k)` checks `k == current`.  
+For any `k < N`: `k < N = current`, so `k ≠ current`, so the check fails and `Err(InvalidNonce)` is returned.
+
+*Step 2 — Rejection in all future states.*  
+By the Monotonicity Invariant, every future state has `current ≥ N`.  
+For any `k < N` and any future `current' ≥ N > k`: `k ≠ current'`, so `consume(k)` returns `Err(InvalidNonce)`.
+
+*Step 3 — Coverage of the invalidated range.*  
+`invalidate_nonce_range(new_nonce)` advances `current` from `N_before` to `new_nonce`.  
+The set of nonces made newly unspendable by this call is `{N_before, N_before+1, …, new_nonce−1}`, i.e. the half-open interval `[N_before, new_nonce)`.  
+Combined with the previously-unspendable set `[0, N_before)`, the full unspendable set after the call is `[0, new_nonce)`. ∎
+
+---
+
+## 4. Half-Open Range Semantics
+
+```
+Before invalidate_nonce_range(new_nonce):
+
+   0 ─── … ─── N_before ─── … ─── new_nonce ─── … ─── ∞
+   ├──── already invalid ───┤       └── future nonces
+                             └── current = N_before
+
+After invalidate_nonce_range(new_nonce):
+
+   0 ─── … ─── N_before ─── … ─── new_nonce ─── … ─── ∞
+   ├────────── all invalid ────────┤
+                                   └── current = new_nonce (first valid)
+```
+
+- `n < new_nonce` → invalid (Err(InvalidNonce)).
+- `n == new_nonce` → valid (the next spendable nonce).
+- `n > new_nonce` → invalid (out-of-order; nonces must be used strictly in sequence).
+
+---
+
+## 5. The `MAX_NONCE_INVALIDATION_SPAN` Bound
+
+`invalidate_nonce_range` rejects any call where `new_nonce - current > MAX_NONCE_INVALIDATION_SPAN`.
+
+### Why the bound is necessary
+
+| Risk without bound | Mitigation |
+|--------------------|-----------|
+| **Accidental lockout**: a single buggy call to `invalidate_nonce_range(u64::MAX)` would push `current` to `u64::MAX`, making the delegation channel permanently unusable. | Cap limits a single mistake to at most 10 000 skipped nonces. |
+| **On-chain gas abuse**: a smart-contract implementation that must iterate over the invalidated range (e.g. to emit events) would consume unbounded gas. | O(10 000) worst case is predictable and auditable. |
+| **Replay-window DoS**: an attacker with brief write access could lock out a legitimate delegator by advancing `current` far into the future. | Caps how far each call can advance. |
+
+### Why 10 000
+
+- Matches the BPS denominator (`10_000 = 100%`) used throughout QuickLendX, making it easy to reason about in context.
+- Large enough to cover any realistic operational batch (e.g. revoking all pre-signed payloads from a compromised signing key in a single transaction).
+- Small enough that the worst-case gas cost is bounded and the unit test `nonce_replay_invalidation_by_max` completes in microseconds.
+
+---
+
+## 6. Threat Model
+
+### 6.1 Attacker capabilities assumed
+
+- The attacker holds one or more pre-signed delegation payloads (`payload.nonce = k`) that were valid at the time of signing.
+- The attacker can submit those payloads to the protocol at any time.
+- The attacker cannot forge new signatures (standard cryptographic assumption).
+- The attacker cannot directly write to the `NonceStore` storage.
+
+### 6.2 Attack vector: replay after key rotation / revocation
+
+**Scenario**: The delegator signs a batch of payloads for nonces 0–999, then decides to revoke all of them (e.g. after a key compromise) and calls `invalidate_nonce_range(1_000)`.
+
+**Outcome**: `current` advances to 1 000. Every payload with `nonce ∈ [0, 1 000)` will now return `Err(InvalidNonce)`. The attacker's payloads are permanently unspendable. ✓
+
+### 6.3 Attack vector: span overflow / lockout
+
+**Scenario**: An attacker (or buggy client) calls `invalidate_nonce_range(current + 10_001)`.
+
+**Outcome**: `SpanTooLarge` is returned; `current` is unchanged. The delegation channel is unaffected. ✓
+
+### 6.4 Attack vector: replay at the boundary nonce
+
+**Scenario**: The delegator invalidates to `new_nonce`. The attacker attempts to use the payload with `nonce = new_nonce - 1` (the last nonce in the invalidated range).
+
+**Outcome**: `new_nonce - 1 < new_nonce = current` → `Err(InvalidNonce)`. The boundary is correctly enforced as a strict less-than. ✓
+
+### 6.5 Non-threat: sequential replay by the delegator
+
+A delegator may still use nonces `≥ current` in strict order (one per `consume` call). This is the intended usage. Each consumed nonce advances `current` by exactly 1, so prior nonces can never be reused. ✓
+
+### 6.6 Non-threat: concurrent invalidation calls
+
+Multiple calls to `invalidate_nonce_range` are additive: each advances `current` forward. Because `current` is monotonically non-decreasing, no combination of valid calls can reduce `current` or make a previously-invalidated nonce reachable again. ✓
+
+---
+
+## 7. Property Tests — Summary
+
+All tests live in `contracts/credence_delegation/tests/nonce_replay.rs`.
+
+Run with:
+
+```bash
+cargo test -p credence_delegation nonce_replay
+```
+
+### 7.1 Property tests (10 000 random cases each)
+
+| Test name | What it covers |
+|-----------|----------------|
+| `prop_invalidated_nonces_are_unspendable` | Core claim: ∀ `k < new_nonce`, `consume(k)` = `InvalidNonce` after invalidation. |
+| `prop_minimal_span_invalidates_exactly_one_nonce` | Span = 1: the single skipped nonce is invalid; `start + 1` is valid. |
+| `prop_max_span_boundary_nonce_rejected` | Span = MAX: boundary nonce `new_nonce - 1` is invalid; `new_nonce` is valid. |
+| `prop_over_max_span_always_rejected` | Span > MAX: always `SpanTooLarge`; store unchanged. |
+| `prop_first_valid_nonce_accepted` | `new_nonce` is the first accepted nonce after invalidation. |
+| `prop_future_nonces_rejected` | Nonces > `new_nonce` are also invalid (out-of-order). |
+| `prop_current_is_non_decreasing` | Chained invalidations never decrease `current`. |
+
+### 7.2 Deterministic edge-case tests (always run)
+
+| Test name | Specific case |
+|-----------|---------------|
+| `nonce_replay_invalidation_by_one` | Span = 1, start = 0 |
+| `nonce_replay_invalidation_by_max` | Span = 10 000, iterates all 10 000 invalid nonces |
+| `nonce_replay_invalidation_by_max_plus_one_rejected` | Span = 10 001, must be `SpanTooLarge(10_001)` |
+| `nonce_replay_boundary_last_invalidated` | start = 500, span = MAX−1; checks `new_nonce − 1` fails and `new_nonce` succeeds |
+| `nonce_replay_persists_across_further_invalidations` | Two chained invalidations; all prior nonces remain invalid |
+| `nonce_replay_no_decrease` | Confirms `NonceMustIncrease` when attempting to lower `current` |
+
+---
+
+## 8. Formal Summary
+
+Given a `NonceStore` with `current = N` (reached by any sequence of valid operations):
+
+```
+∀ k ∈ ℕ₀ where k < N:  consume(k) = Err(InvalidNonce)
+```
+
+This holds because:
+1. `consume` requires exact equality `k == current`.
+2. `current` is monotonically non-decreasing (`current' ≥ current` after every operation).
+3. `k < N ≤ current'` ⟹ `k ≠ current'` ⟹ `Err(InvalidNonce)`.
+
+No additional mechanism (timeout, expiry, external oracle) is needed. The monotonicity of a `u64` counter under the two defined operations provides the replay protection unconditionally.


### PR DESCRIPTION
## Summary

- Adds `contracts/credence_delegation/src/nonce.rs` — `NonceStore`, `MAX_NONCE_INVALIDATION_SPAN = 10_000`, `invalidate_nonce_range`, `consume`, and `verify` with full inline proof commentary
- Adds `contracts/credence_delegation/tests/nonce_replay.rs` — 7 proptest properties (10 000 cases each) + 6 deterministic edge-case tests covering the full replay-window surface
- Adds `docs/contracts/nonce-replay-proof.md` — formal monotonicity proof, half-open range semantics, threat model, and test inventory
- Converts the root `Cargo.toml` into a workspace root and wires `credence_delegation` as a member so `cargo test -p credence_delegation nonce_replay` works from the repo root

## How it works

`invalidate_nonce_range(new_nonce)` advances `current` from its present value to `new_nonce` in one atomic step, invalidating the half-open range `[current, new_nonce)`. The replay-proof rests on a single invariant: **`current` only ever increases**. Because `consume` requires `payload.nonce == current` (exact equality), any nonce `k < current` can never satisfy the check again — today or in any future state.

## Bound rationale

`MAX_NONCE_INVALIDATION_SPAN = 10_000` caps each call to prevent:
- Accidental lockout (a typo pushing `current` to `u64::MAX`)
- Unbounded on-chain iteration cost
- A brief-write-access DoS that advances the counter far into the future

Large invalidations can always be achieved by chaining multiple calls within the limit.

## Test coverage

| Category | Count | Run command |
|---|---|---|
| Property tests (10 000 cases each) | 7 | `cargo test -p credence_delegation nonce_replay` |
| Deterministic edge-case tests | 6 | same |
| **Total random cases** | **70 000** | |

Edge cases explicitly covered:
- Invalidation by exactly 1 (minimal span)
- Invalidation by `MAX` — iterates all 10 000 invalid nonces
- Invalidation by `MAX + 1` — must return `SpanTooLarge { span: 10_001 }`; store unchanged
- Boundary nonce `new_nonce − 1` rejected at non-zero start (bumped by `MAX − 1 = 9_999`)
- Future nonces (`> new_nonce`) rejected — out-of-order execution is not permitted
- Chained invalidations — previously-invalidated nonces remain invalid across further calls
- Monotonicity — `current` never decreases after any sequence of valid operations

## Files changed

- `Cargo.toml` — added `[workspace]` section
- `contracts/credence_delegation/Cargo.toml` *(new)*
- `contracts/credence_delegation/src/lib.rs` *(new)*
- `contracts/credence_delegation/src/nonce.rs` *(new)*
- `contracts/credence_delegation/tests/nonce_replay.rs` *(new)*
- `docs/contracts/nonce-replay-proof.md` *(new)*

Closes #415
