### PR TITLE
test: add backup restoration integrity tests and fix index management

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,9 +37,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "backtrace"
@@ -121,9 +121,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.63"
+version = "1.2.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
+checksum = "dad887fd958be91b5098c0248def011f4523ab786cd411be668777e55063501f"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -137,9 +137,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chrono"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
  "num-traits",
@@ -608,13 +608,12 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.99"
+version = "0.3.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
+checksum = "03d04c30968dffe80775bd4d7fb676131cd04a1fb46d2686dbffbaec2d9dfd31"
 dependencies = [
  "cfg-if",
  "futures-util",
- "once_cell",
  "wasm-bindgen",
 ]
 
@@ -655,15 +654,15 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "log"
-version = "0.4.30"
+version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
+checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
 
 [[package]]
 name = "memchr"
-version = "2.8.1"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "miniz_oxide"
@@ -719,53 +718,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c"
 dependencies = [
  "autocfg",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "num-conv"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
-
-[[package]]
-name = "num-derive"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfb77679af88f8b125209d354a202862602672222e7f2313fdd6dc349bad4712"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "num-integer"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
-dependencies = [
- "autocfg",
- "num-traits",
-]
-
-[[package]]
-name = "num-traits"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
-name = "object"
-version = "0.32.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441"
-dependencies = [
- "memchr",
 ]
 
 [[package]]
@@ -807,9 +759,9 @@ dependencies = [
 
 [[package]]
 name = "platforms"
-version = "3.10.0"
+version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6001d2ac55b4eb1ca634c65fc06555068b8dd89c9f20fd92064e5341a436e63"
+checksum = "366f9622ebb8981452cd68eba56dd73eccc76fa093dc1d7dd5f5495da05cc977"
 
 [[package]]
 name = "powerfmt"
@@ -1054,9 +1006,9 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "soroban-builtin-sdk-macros"
@@ -1384,9 +1336,9 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.122"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
+checksum = "8ddb3f79143bced6de84270411622a2699cee572fc0875aeaf1e7867cf9fca1a"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1397,9 +1349,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.122"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
+checksum = "4e21a184b13fb19e157296e2c46056aec9092264fab83e4ba59e68c61b323c3d"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1407,9 +1359,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.122"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
+checksum = "fecefd9c35bd935a20fc3fc344b5f29138961e4f47fb03297d88f2587afb5ebd"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -1420,9 +1372,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.122"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
+checksum = "23939e44bb9a5d7576fa2b563dc2e136628f1224e88a8deed09e04858b77871f"
 dependencies = [
  "unicode-ident",
 ]
@@ -1545,6 +1497,6 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.8.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"

--- a/quicklendx-contracts/src/bid.rs
+++ b/quicklendx-contracts/src/bid.rs
@@ -4,7 +4,7 @@ use soroban_sdk::{contracttype, symbol_short, Address, BytesN, Env, Symbol, Vec}
 use crate::admin::AdminStorage;
 use crate::errors::QuickLendXError;
 use crate::events::{emit_bid_expired, emit_bid_ttl_updated};
-use crate::storage::extend_persistent_ttl;
+use crate::storage::{extend_persistent_ttl, bump_persistent};
 pub use crate::types::{Bid, BidStatus};
 
 /// Storage keys for the per-invoice bid index.

--- a/quicklendx-contracts/src/events.rs
+++ b/quicklendx-contracts/src/events.rs
@@ -580,14 +580,6 @@ pub fn emit_ttl_extended(env: &Env, kind: &String, count: u32) {
     .publish(env);
 }
 
-#[contractevent]
-pub struct BidTtlUpdated {
-    pub old_days: u64,
-    pub new_days: u64,
-    pub admin: Address,
-    pub timestamp: u64,
-}
-// ... (after TtlExtended)
 
 
 
@@ -629,13 +621,7 @@ pub struct AdminTransferred {
     pub timestamp: u64,
 }
 
-#[contractevent]
-pub struct BidTtlUpdated {
-    pub old_days: u64,
-    pub new_days: u64,
-    pub admin: Address,
-    pub timestamp: u64,
-}
+
 
 #[contractevent]
 pub struct RevenueDistributed {

--- a/quicklendx-contracts/src/lib.rs
+++ b/quicklendx-contracts/src/lib.rs
@@ -80,6 +80,8 @@ mod test_audit;
 mod test_backup;
 #[cfg(all(test, feature = "legacy-tests"))]
 mod test_backup_safety;
+#[cfg(test)]
+mod test_backup_restore_reindex;
 #[cfg(all(test, feature = "legacy-tests"))]
 mod test_bid_ttl;
 #[cfg(all(test, feature = "legacy-tests"))]

--- a/quicklendx-contracts/src/lib.rs
+++ b/quicklendx-contracts/src/lib.rs
@@ -3288,7 +3288,7 @@ impl QuickLendXContract {
             meta.last_updated_at,
         );
         result.set(String::from_str(&env, "cursor"), meta.cursor);
-        result;
+        result
     }
 }
 

--- a/quicklendx-contracts/src/maintenance.rs
+++ b/quicklendx-contracts/src/maintenance.rs
@@ -12,9 +12,8 @@ use crate::currency::CurrencyWhitelist;
 use crate::errors::QuickLendXError;
 use crate::investment::InvestmentStorage;
 use crate::payments::EscrowStorage;
-use crate::currency::CurrencyWhitelist;
+use crate::storage::{extend_persistent_ttl, DataKey, InvoiceStorage};
 use soroban_sdk::{contracttype, symbol_short, Address, Env, String, Symbol};
-use soroban_sdk::{symbol_short, Address, Env, String, Symbol, contracttype};
 
 /// Storage key for the maintenance mode boolean flag.
 pub const MAINTENANCE_MODE_KEY: Symbol = symbol_short!("maint");
@@ -45,8 +44,6 @@ pub const MAX_REASON_LEN: u32 = 256;
 /// will be identical.
 #[contracttype]
 #[derive(Clone, Debug, PartialEq)]
-#[contracttype]
-#[derive(Clone)]
 pub struct ExtendReport {
     /// Number of invoice records whose TTL was extended.
     pub invoices_refreshed: u32,
@@ -133,7 +130,6 @@ impl MaintenanceControl {
     ///
     /// # Errors
     /// * `NotAdmin` - caller is not the admin.
-    pub fn extend_protocol_ttl(env: &Env, admin: &Address) -> Result<ExtendReport, QuickLendXError> {
     pub fn extend_protocol_ttl(
         env: &Env,
         admin: &Address,
@@ -198,14 +194,5 @@ impl MaintenanceControl {
         }
 
         Ok(report)
-    }
-}
-        Self::emit_ttl_extended(env, "invoice", report.invoices_refreshed);
-        Self::emit_ttl_extended(env, "bid", report.bids_refreshed);
-        Self::emit_ttl_extended(env, "investment", report.investments_refreshed);
-        Self::emit_ttl_extended(env, "escrow", report.escrows_refreshed);
-        Self::emit_ttl_extended(env, "currency", report.currencies_refreshed);
-
-Ok(report)
     }
 }

--- a/quicklendx-contracts/src/storage.rs
+++ b/quicklendx-contracts/src/storage.rs
@@ -179,6 +179,10 @@ impl InvoiceStorage {
         if let Some(ref tax_id) = invoice.metadata_tax_id {
             Self::add_to_tax_id_index(env, tax_id, &invoice.id);
         }
+        Self::add_category_index(env, &invoice.category, &invoice.id);
+        for tag in invoice.tags.iter() {
+            Self::add_tag_index(env, &tag, &invoice.id);
+        }
     }
 
     pub fn store_invoice(env: &Env, invoice: &Invoice) {
@@ -258,6 +262,18 @@ impl InvoiceStorage {
                     Self::add_to_tax_id_index(env, tax_id, &invoice.id);
                 }
             }
+            if old.category != invoice.category {
+                Self::remove_category_index(env, &old.category, &invoice.id);
+                Self::add_category_index(env, &invoice.category, &invoice.id);
+            }
+            if old.tags != invoice.tags {
+                for tag in old.tags.iter() {
+                    Self::remove_tag_index(env, &tag, &invoice.id);
+                }
+                for tag in invoice.tags.iter() {
+                    Self::add_tag_index(env, &tag, &invoice.id);
+                }
+            }
         }
         let key = DataKey::Invoice(invoice.id.clone());
         env.storage()
@@ -299,6 +315,10 @@ impl InvoiceStorage {
             }
             if let Some(ref tax_id) = invoice.metadata_tax_id {
                 Self::remove_from_tax_id_index(env, tax_id, invoice_id);
+            }
+            Self::remove_category_index(env, &invoice.category, invoice_id);
+            for tag in invoice.tags.iter() {
+                Self::remove_tag_index(env, &tag, invoice_id);
             }
         }
         env.storage()

--- a/quicklendx-contracts/src/storage.rs
+++ b/quicklendx-contracts/src/storage.rs
@@ -30,12 +30,7 @@ where
     env.storage().persistent().extend_ttl(key, ttl_u32, ttl_u32);
 }
 
-pub fn bump_persistent<T>(env: &Env, key: &T)
-where
-    T: soroban_sdk::IntoVal<soroban_sdk::Env, soroban_sdk::Val>,
-{
-    extend_persistent_ttl(env, key);
-}
+
 
 /// Storage keys for the contract
 pub struct StorageKeys;

--- a/quicklendx-contracts/src/test_backup_restore_reindex.rs
+++ b/quicklendx-contracts/src/test_backup_restore_reindex.rs
@@ -1,0 +1,263 @@
+#![cfg(test)]
+
+use crate::{
+    backup::{Backup, BackupStatus, BackupStorage},
+    storage::{InvoiceStorage, StorageIntegrityAudit},
+    types::{DisputeStatus, Invoice, InvoiceCategory, InvoiceStatus},
+    errors::QuickLendXError,
+};
+use soroban_sdk::{
+    testutils::{Address as _, Ledger},
+    Address, BytesN, Env, String, Vec,
+};
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+fn setup_env() -> Env {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().with_mut(|li| li.timestamp = 1_000_000);
+    env
+}
+
+fn make_complex_invoice(
+    env: &Env,
+    idx: u32,
+    business: &Address,
+    status: InvoiceStatus,
+    category: InvoiceCategory,
+    tags: Vec<String>,
+    customer_name: &str,
+    tax_id: &str,
+) -> Invoice {
+    use crate::types::Dispute;
+
+    let mut id_bytes = [0u8; 32];
+    id_bytes[28..32].copy_from_slice(&idx.to_be_bytes());
+    let id = BytesN::from_array(env, &id_bytes);
+
+    Invoice {
+        id,
+        business: business.clone(),
+        amount: 1_000,
+        currency: Address::generate(env),
+        due_date: 9_999_999_999,
+        status,
+        description: String::from_str(env, "complex invoice"),
+        metadata_customer_name: Some(String::from_str(env, customer_name)),
+        metadata_customer_address: Some(String::from_str(env, "123 Test St")),
+        metadata_tax_id: Some(String::from_str(env, tax_id)),
+        metadata_notes: Some(String::from_str(env, "Notes")),
+        metadata_line_items: Vec::new(env),
+        category,
+        tags,
+        funded_amount: 0,
+        funded_at: None,
+        investor: None,
+        settled_at: None,
+        average_rating: None,
+        total_ratings: 0,
+        ratings: Vec::new(env),
+        dispute_status: DisputeStatus::None,
+        dispute: Dispute {
+            created_by: Address::generate(env),
+            created_at: 0,
+            reason: String::from_str(env, ""),
+            evidence: String::from_str(env, ""),
+            resolution: String::from_str(env, ""),
+            resolved_by: Address::generate(env),
+            resolved_at: 0,
+        },
+        total_paid: 0,
+        payment_history: Vec::new(env),
+        created_at: env.ledger().timestamp(),
+    }
+}
+
+fn create_valid_backup(env: &Env, invoices: Vec<Invoice>) -> BytesN<32> {
+    let backup_id = BackupStorage::generate_backup_id(env);
+    let count = invoices.len();
+
+    let backup = Backup {
+        backup_id: backup_id.clone(),
+        timestamp: env.ledger().timestamp(),
+        description: String::from_str(env, "complex backup"),
+        invoice_count: count,
+        status: BackupStatus::Active,
+        format_version: 2,
+    };
+
+    BackupStorage::store_backup(env, &backup, Some(&invoices)).unwrap();
+    BackupStorage::store_backup_data(env, &backup_id, &invoices);
+    BackupStorage::add_to_backup_list(env, &backup_id);
+
+    backup_id
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[test]
+fn test_restore_rebuilds_all_indexes() {
+    let env = setup_env();
+
+    let business_a = Address::generate(&env);
+    let business_b = Address::generate(&env);
+
+    let mut tags_1 = Vec::new(&env);
+    tags_1.push_back(String::from_str(&env, "urgent"));
+    tags_1.push_back(String::from_str(&env, "tech"));
+
+    let mut tags_2 = Vec::new(&env);
+    tags_2.push_back(String::from_str(&env, "tech"));
+
+    let inv_1 = make_complex_invoice(&env, 1, &business_a, InvoiceStatus::Pending, InvoiceCategory::Technology, tags_1, "Acme Corp", "TAX123");
+    let inv_2 = make_complex_invoice(&env, 2, &business_a, InvoiceStatus::Funded, InvoiceCategory::Services, tags_2, "Acme Corp", "TAX123");
+    let inv_3 = make_complex_invoice(&env, 3, &business_b, InvoiceStatus::Pending, InvoiceCategory::Manufacturing, Vec::new(&env), "Beta LLC", "TAX999");
+
+    let mut invoices_to_backup = Vec::new(&env);
+    invoices_to_backup.push_back(inv_1.clone());
+    invoices_to_backup.push_back(inv_2.clone());
+    invoices_to_backup.push_back(inv_3.clone());
+
+    let backup_id = create_valid_backup(&env, invoices_to_backup);
+
+    // Pre-populate state with some completely different data to ensure it's cleared
+    let stale_inv = make_complex_invoice(&env, 99, &Address::generate(&env), InvoiceStatus::Verified, InvoiceCategory::Other, Vec::new(&env), "Stale", "TAX000");
+    InvoiceStorage::store_invoice(&env, &stale_inv);
+
+    // Perform restore
+    let restored_count = BackupStorage::restore_from_backup(&env, &backup_id).unwrap();
+    assert_eq!(restored_count, 3);
+
+    // Assert get_by_business
+    let bus_a_invoices = InvoiceStorage::get_by_business(&env, &business_a);
+    assert_eq!(bus_a_invoices.len(), 2);
+    assert!(bus_a_invoices.contains(&inv_1.id));
+    assert!(bus_a_invoices.contains(&inv_2.id));
+
+    let bus_b_invoices = InvoiceStorage::get_by_business(&env, &business_b);
+    assert_eq!(bus_b_invoices.len(), 1);
+    assert!(bus_b_invoices.contains(&inv_3.id));
+
+    // Assert get_by_status
+    let pending_invoices = InvoiceStorage::get_by_status(&env, InvoiceStatus::Pending);
+    assert_eq!(pending_invoices.len(), 2);
+    assert!(pending_invoices.contains(&inv_1.id));
+    assert!(pending_invoices.contains(&inv_3.id));
+
+    let funded_invoices = InvoiceStorage::get_by_status(&env, InvoiceStatus::Funded);
+    assert_eq!(funded_invoices.len(), 1);
+    assert!(funded_invoices.contains(&inv_2.id));
+
+    let verified_invoices = InvoiceStorage::get_by_status(&env, InvoiceStatus::Verified);
+    assert_eq!(verified_invoices.len(), 0); // Stale should be gone
+
+    // Assert get_by_customer
+    let acme_invoices = InvoiceStorage::get_by_customer(&env, &String::from_str(&env, "Acme Corp"));
+    assert_eq!(acme_invoices.len(), 2);
+    assert!(acme_invoices.contains(&inv_1.id));
+    assert!(acme_invoices.contains(&inv_2.id));
+
+    // Assert get_by_tax_id
+    let tax_invoices = InvoiceStorage::get_by_tax_id(&env, &String::from_str(&env, "TAX123"));
+    assert_eq!(tax_invoices.len(), 2);
+    assert!(tax_invoices.contains(&inv_1.id));
+
+    // Assert category
+    let tech_cat = InvoiceStorage::get_by_category(&env, InvoiceCategory::Technology);
+    assert_eq!(tech_cat.len(), 1);
+    assert!(tech_cat.contains(&inv_1.id));
+
+    let mfg_cat = InvoiceStorage::get_by_category(&env, InvoiceCategory::Manufacturing);
+    assert_eq!(mfg_cat.len(), 1);
+    assert!(mfg_cat.contains(&inv_3.id));
+
+    // Assert tag
+    let urgent_tags = InvoiceStorage::get_by_tag(&env, &String::from_str(&env, "urgent"));
+    assert_eq!(urgent_tags.len(), 1);
+    assert!(urgent_tags.contains(&inv_1.id));
+
+    let tech_tags = InvoiceStorage::get_by_tag(&env, &String::from_str(&env, "tech"));
+    assert_eq!(tech_tags.len(), 2);
+    assert!(tech_tags.contains(&inv_1.id));
+    assert!(tech_tags.contains(&inv_2.id));
+
+    // Check no orphans
+    let audit_result = StorageIntegrityAudit::audit_invoice_integrity(&env);
+    assert!(audit_result.is_ok(), "Audit failed: {:?}", audit_result.err().unwrap());
+}
+
+#[test]
+fn test_restore_idempotent_and_orphan_free() {
+    let env = setup_env();
+
+    let business_a = Address::generate(&env);
+    let inv_1 = make_complex_invoice(&env, 1, &business_a, InvoiceStatus::Pending, InvoiceCategory::Technology, Vec::new(&env), "Acme Corp", "TAX123");
+
+    let mut invoices_to_backup = Vec::new(&env);
+    invoices_to_backup.push_back(inv_1.clone());
+
+    let backup_id_1 = create_valid_backup(&env, invoices_to_backup.clone());
+
+    // Restore first time
+    BackupStorage::restore_from_backup(&env, &backup_id_1).unwrap();
+
+    // Verify
+    let bus_a_invoices = InvoiceStorage::get_by_business(&env, &business_a);
+    assert_eq!(bus_a_invoices.len(), 1);
+
+    // Attempting to restore the same backup fails because it's archived
+    let result = BackupStorage::restore_from_backup(&env, &backup_id_1);
+    assert_eq!(result, Err(QuickLendXError::OperationNotAllowed));
+
+    // Let's create a NEW backup with the SAME data to prove idempotency of clearing/rebuilding
+    let backup_id_2 = create_valid_backup(&env, invoices_to_backup);
+
+    // Restore second time
+    BackupStorage::restore_from_backup(&env, &backup_id_2).unwrap();
+
+    // Still exactly 1 invoice
+    let bus_a_invoices_after = InvoiceStorage::get_by_business(&env, &business_a);
+    assert_eq!(bus_a_invoices_after.len(), 1);
+
+    // No orphans
+    let audit_result = StorageIntegrityAudit::audit_invoice_integrity(&env);
+    assert!(audit_result.is_ok());
+}
+
+#[test]
+fn test_unsupported_version_rejected() {
+    let env = setup_env();
+
+    let business_a = Address::generate(&env);
+    let inv_1 = make_complex_invoice(&env, 1, &business_a, InvoiceStatus::Pending, InvoiceCategory::Technology, Vec::new(&env), "Acme Corp", "TAX123");
+
+    // Populate valid state
+    InvoiceStorage::store_invoice(&env, &inv_1);
+
+    let backup_id = BackupStorage::generate_backup_id(&env);
+
+    // Store V3
+    use soroban_sdk::IntoVal;
+    let mut map = soroban_sdk::Map::<soroban_sdk::Symbol, soroban_sdk::Val>::new(&env);
+    map.set(soroban_sdk::Symbol::new(&env, "backup_id"), backup_id.clone().into_val(&env));
+    map.set(soroban_sdk::Symbol::new(&env, "timestamp"), env.ledger().timestamp().into_val(&env));
+    map.set(soroban_sdk::Symbol::new(&env, "description"), String::from_str(&env, "v3 backup").into_val(&env));
+    map.set(soroban_sdk::Symbol::new(&env, "invoice_count"), 1u32.into_val(&env));
+    map.set(soroban_sdk::Symbol::new(&env, "status"), BackupStatus::Active.into_val(&env));
+    map.set(soroban_sdk::Symbol::new(&env, "format_version"), 3u32.into_val(&env));
+
+    env.storage().instance().set(&backup_id, &map);
+
+    let rest_result = BackupStorage::restore_from_backup(&env, &backup_id);
+    assert_eq!(rest_result, Err(QuickLendXError::BackupVersionUnsupported));
+
+    // State is untouched
+    let bus_a_invoices = InvoiceStorage::get_by_business(&env, &business_a);
+    assert_eq!(bus_a_invoices.len(), 1);
+    assert!(bus_a_invoices.contains(&inv_1.id));
+}


### PR DESCRIPTION
- Fix `InvoiceStorage` to correctly manage `category` and `tags` indexes during invoice creation, updates, and removal.
- Add comprehensive tests (`test_backup_restore_reindex.rs`) to verify that all secondary indexes are accurately rebuilt when restoring from a backup.
- Validate that the restore process is idempotent, orphan-free, and rejects unsupported backup format versions.


closes #1319 