### PR TITLE
test(governance): add two-step admin transfer e2e suite and developer docs

### DIFF
--- a/quicklendx-contracts/docs/admin-transfer.md
+++ b/quicklendx-contracts/docs/admin-transfer.md
@@ -1,0 +1,76 @@
+# Hardened Admin Role Transfer
+
+Admin key handoff is the single most critical and sensitive governance operation in the QuickLendX protocol. The smart contracts support two modes of admin role transfers: **Direct (One-step)** and **Two-step Handoff**. 
+
+---
+
+## Direct vs. Two-Step Handoff
+
+### 1. Direct Transfer (One-Step)
+In a direct transfer, the current admin immediately appoints a new address as the administrator.
+- **API Call**: `transfer_admin(new_admin)`
+- **Execution**: Instantaneous. The `admin` storage slot is immediately updated to the `new_admin` address.
+- **Risk**: High. If the current admin makes a typo or provides an incorrect, inaccessible, or blackhole address, ownership of the protocol is lost forever with no recovery path.
+
+### 2. Two-Step Handoff (Recommended for Production)
+The two-step flow mitigates the risk of single-point errors by forcing the proposed new admin to explicitly claim/accept the role before ownership is transferred.
+- **API Flow**:
+  1. Current admin calls `initiate_admin_transfer(pending_admin)`.
+  2. The contract records `pending_admin` and engages a **transfer lock**.
+  3. The proposed `pending_admin` must authorize and call `accept_admin_transfer()`.
+- **Safety**: 
+  - Prevents accidental transfers to incorrect or uncontrolled addresses (since the recipient must prove they can sign on behalf of the new key).
+  - The current admin retains full authority and can cancel the pending transfer at any time prior to acceptance using `cancel_admin_transfer()`.
+
+---
+
+## The Transfer Lock Interaction
+
+When a two-step transfer is initiated, the contract sets a internal flag `ADMIN_TRANSFER_LOCK_KEY` to `true`.
+While this lock is active:
+- Direct transfers via `transfer_admin` are blocked.
+- Any attempt to overwrite or re-initiate a pending transfer is blocked.
+- The lock is cleared under only two conditions:
+  - The pending admin successfully accepts the transfer, completing the transition.
+  - The current admin explicitly cancels the transfer, returning the contract to its normal state.
+
+---
+
+## Recommended Production Procedure
+
+For production deployments, operators should exclusively use the **Two-Step Handoff**:
+
+```mermaid
+sequenceDiagram
+    actor CurrentAdmin as Current Admin
+    actor NewAdmin as Proposed Admin
+    participant Contract as QuickLendX Contract
+
+    CurrentAdmin->>Contract: set_two_step_enabled(true)
+    CurrentAdmin->>Contract: initiate_admin_transfer(NewAdmin)
+    Note over Contract: Transfer Locked<br/>Pending Admin Set
+    NewAdmin->>Contract: accept_admin_transfer()
+    Note over Contract: Transfer Unlocked<br/>Admin Updated
+```
+
+### Step-by-Step Operator Guide
+
+1. **Verify State & Mode**:
+   Ensure two-step mode is enabled on the contract:
+   - Call `is_two_step_enabled()`.
+   - If not enabled, the current admin must call `set_two_step_enabled(true)`.
+
+2. **Initiate Transfer**:
+   The current admin initiates the transfer:
+   - Call `initiate_admin_transfer(pending_admin)`.
+   - Verify that `is_transfer_locked()` returns `true` and `get_pending_admin()` returns the expected address.
+
+3. **Acceptance by the New Admin**:
+   The proposed new admin signs and submits the acceptance:
+   - Call `accept_admin_transfer()`.
+   - Verify that `get_current_admin()` now returns the new admin address, `is_transfer_locked()` is `false`, and `get_pending_admin()` is `None`.
+
+4. **Emergency Cancellation**:
+   If an incorrect address was proposed or the transfer needs to be aborted:
+   - The current admin calls `cancel_admin_transfer()`.
+   - The pending state is cleared, the lock is released, and full authority remains with the original admin.

--- a/quicklendx-contracts/src/lib.rs
+++ b/quicklendx-contracts/src/lib.rs
@@ -74,6 +74,8 @@ mod test_admin;
 mod test_admin_simple;
 #[cfg(all(test, feature = "legacy-tests"))]
 mod test_admin_standalone;
+#[cfg(test)]
+mod test_admin_two_step;
 #[cfg(all(test, feature = "legacy-tests"))]
 mod test_audit;
 #[cfg(test)]

--- a/quicklendx-contracts/src/test_admin_two_step.rs
+++ b/quicklendx-contracts/src/test_admin_two_step.rs
@@ -1,0 +1,248 @@
+//! Two-step admin transfer and transfer lock end-to-end tests.
+
+#[cfg(test)]
+mod test_admin_two_step {
+    use crate::admin::{AdminStorage, ADMIN_INITIALIZED_KEY};
+    use crate::errors::QuickLendXError;
+    use crate::QuickLendXContract;
+    use soroban_sdk::{
+        symbol_short,
+        testutils::{Address as _, Events},
+        xdr, Address, Env, Symbol, TryFromVal,
+    };
+
+    fn setup() -> (Env, Address) {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(QuickLendXContract, ());
+        (env, contract_id)
+    }
+
+    fn setup_with_admin() -> (Env, Address, Address) {
+        let (env, contract_id) = setup();
+        let admin = Address::generate(&env);
+        initialize_admin(&env, &contract_id, &admin).unwrap();
+        (env, contract_id, admin)
+    }
+
+    fn initialize_admin(
+        env: &Env,
+        contract_id: &Address,
+        admin: &Address,
+    ) -> Result<(), QuickLendXError> {
+        env.as_contract(contract_id, || AdminStorage::initialize(env, admin))
+    }
+
+    fn transfer_admin(
+        env: &Env,
+        contract_id: &Address,
+        current_admin: &Address,
+        new_admin: &Address,
+    ) -> Result<(), QuickLendXError> {
+        env.as_contract(contract_id, || AdminStorage::transfer_admin(env, current_admin, new_admin))
+    }
+
+    fn initiate_admin_transfer(
+        env: &Env,
+        contract_id: &Address,
+        current_admin: &Address,
+        pending_admin: &Address,
+    ) -> Result<(), QuickLendXError> {
+        env.as_contract(contract_id, || {
+            AdminStorage::initiate_admin_transfer(env, current_admin, pending_admin)
+        })
+    }
+
+    fn accept_admin_transfer(
+        env: &Env,
+        contract_id: &Address,
+        pending_admin: &Address,
+    ) -> Result<(), QuickLendXError> {
+        env.as_contract(contract_id, || AdminStorage::accept_admin_transfer(env, pending_admin))
+    }
+
+    fn cancel_admin_transfer(
+        env: &Env,
+        contract_id: &Address,
+        current_admin: &Address,
+    ) -> Result<(), QuickLendXError> {
+        env.as_contract(contract_id, || AdminStorage::cancel_admin_transfer(env, current_admin))
+    }
+
+    fn set_two_step_enabled(
+        env: &Env,
+        contract_id: &Address,
+        admin: &Address,
+        enabled: bool,
+    ) -> Result<(), QuickLendXError> {
+        env.as_contract(contract_id, || AdminStorage::set_two_step_enabled(env, admin, enabled))
+    }
+
+    fn get_admin(env: &Env, contract_id: &Address) -> Option<Address> {
+        env.as_contract(contract_id, || AdminStorage::get_admin(env))
+    }
+
+    fn get_pending_admin(env: &Env, contract_id: &Address) -> Option<Address> {
+        env.as_contract(contract_id, || AdminStorage::get_pending_admin(env))
+    }
+
+    fn is_admin(env: &Env, contract_id: &Address, address: &Address) -> bool {
+        env.as_contract(contract_id, || AdminStorage::is_admin(env, address))
+    }
+
+    fn is_transfer_locked(env: &Env, contract_id: &Address) -> bool {
+        env.as_contract(contract_id, || AdminStorage::is_transfer_locked(env))
+    }
+
+    fn is_two_step_enabled(env: &Env, contract_id: &Address) -> bool {
+        env.as_contract(contract_id, || AdminStorage::is_two_step_enabled(env))
+    }
+
+    fn latest_topic_symbol(env: &Env) -> Symbol {
+        let events = env.events().all();
+        let last = events
+            .events()
+            .last()
+            .expect("expected at least one emitted event");
+
+        match &last.body {
+            xdr::ContractEventBody::V0(body) => Symbol::try_from_val(
+                env,
+                body.topics
+                    .first()
+                    .expect("contract event should have at least one topic"),
+            )
+            .expect("first topic should be a Symbol"),
+        }
+    }
+
+    /// Tests the complete happy path: initiate -> accept -> verify transfer.
+    #[test]
+    fn test_two_step_transfer_happy_path() {
+        let (env, contract_id, admin_1) = setup_with_admin();
+        let admin_2 = Address::generate(&env);
+
+        // Enable two-step mode
+        set_two_step_enabled(&env, &contract_id, &admin_1, true).unwrap();
+        assert!(is_two_step_enabled(&env, &contract_id));
+        assert_eq!(latest_topic_symbol(&env), symbol_short!("adm_2st"));
+
+        // Initiate transfer
+        initiate_admin_transfer(&env, &contract_id, &admin_1, &admin_2).unwrap();
+        assert_eq!(get_pending_admin(&env, &contract_id), Some(admin_2.clone()));
+        assert!(is_transfer_locked(&env, &contract_id));
+        assert_eq!(latest_topic_symbol(&env), symbol_short!("adm_req"));
+
+        // Accept transfer
+        accept_admin_transfer(&env, &contract_id, &admin_2).unwrap();
+
+        // Verify state changes
+        assert_eq!(get_admin(&env, &contract_id), Some(admin_2.clone()));
+        assert!(is_admin(&env, &contract_id, &admin_2));
+        assert!(!is_admin(&env, &contract_id, &admin_1));
+        assert_eq!(get_pending_admin(&env, &contract_id), None);
+        assert!(!is_transfer_locked(&env, &contract_id));
+        assert_eq!(latest_topic_symbol(&env), symbol_short!("adm_trf"));
+    }
+
+    /// Tests the cancel path: initiate -> cancel -> verify state reverted.
+    #[test]
+    fn test_two_step_transfer_cancel_path() {
+        let (env, contract_id, admin_1) = setup_with_admin();
+        let admin_2 = Address::generate(&env);
+
+        set_two_step_enabled(&env, &contract_id, &admin_1, true).unwrap();
+        initiate_admin_transfer(&env, &contract_id, &admin_1, &admin_2).unwrap();
+
+        // Cancel the pending transfer
+        cancel_admin_transfer(&env, &contract_id, &admin_1).unwrap();
+
+        // Verify state is reverted
+        assert_eq!(get_admin(&env, &contract_id), Some(admin_1.clone()));
+        assert_eq!(get_pending_admin(&env, &contract_id), None);
+        assert!(!is_transfer_locked(&env, &contract_id));
+        assert_eq!(latest_topic_symbol(&env), symbol_short!("adm_cnl"));
+    }
+
+    /// Tests negative path: a third party cannot accept the pending transfer.
+    #[test]
+    fn test_unauthorized_acceptance_rejected() {
+        let (env, contract_id, admin_1) = setup_with_admin();
+        let admin_2 = Address::generate(&env);
+        let third_party = Address::generate(&env);
+
+        set_two_step_enabled(&env, &contract_id, &admin_1, true).unwrap();
+        initiate_admin_transfer(&env, &contract_id, &admin_1, &admin_2).unwrap();
+
+        // Third party accepts
+        assert_eq!(
+            accept_admin_transfer(&env, &contract_id, &third_party),
+            Err(QuickLendXError::Unauthorized)
+        );
+        assert_eq!(get_admin(&env, &contract_id), Some(admin_1));
+        assert_eq!(get_pending_admin(&env, &contract_id), Some(admin_2));
+    }
+
+    /// Tests negative path: accepting when there is no pending transfer fails.
+    #[test]
+    fn test_accept_without_pending_fails() {
+        let (env, contract_id, admin_1) = setup_with_admin();
+        let admin_2 = Address::generate(&env);
+
+        set_two_step_enabled(&env, &contract_id, &admin_1, true).unwrap();
+
+        // Accept with no pending transfer
+        assert_eq!(
+            accept_admin_transfer(&env, &contract_id, &admin_2),
+            Err(QuickLendXError::OperationNotAllowed)
+        );
+    }
+
+    /// Tests negative path: initiating while transfer lock is active or pending transfer exists fails.
+    #[test]
+    fn test_initiate_while_locked_or_pending_fails() {
+        let (env, contract_id, admin_1) = setup_with_admin();
+        let admin_2 = Address::generate(&env);
+        let admin_3 = Address::generate(&env);
+
+        set_two_step_enabled(&env, &contract_id, &admin_1, true).unwrap();
+        initiate_admin_transfer(&env, &contract_id, &admin_1, &admin_2).unwrap();
+
+        // Attempt to initiate a second transfer
+        assert_eq!(
+            initiate_admin_transfer(&env, &contract_id, &admin_1, &admin_3),
+            Err(QuickLendXError::OperationNotAllowed)
+        );
+        assert_eq!(get_pending_admin(&env, &contract_id), Some(admin_2));
+    }
+
+    /// Tests negative path: initiating self-transfer (pending admin == current admin) fails.
+    #[test]
+    fn test_initiate_self_transfer_fails() {
+        let (env, contract_id, admin_1) = setup_with_admin();
+
+        set_two_step_enabled(&env, &contract_id, &admin_1, true).unwrap();
+
+        assert_eq!(
+            initiate_admin_transfer(&env, &contract_id, &admin_1, &admin_1),
+            Err(QuickLendXError::OperationNotAllowed)
+        );
+    }
+
+    /// Tests direct transfer is blocked when a two-step transfer is pending/locked.
+    #[test]
+    fn test_direct_transfer_blocked_during_pending_flow() {
+        let (env, contract_id, admin_1) = setup_with_admin();
+        let admin_2 = Address::generate(&env);
+        let admin_3 = Address::generate(&env);
+
+        set_two_step_enabled(&env, &contract_id, &admin_1, true).unwrap();
+        initiate_admin_transfer(&env, &contract_id, &admin_1, &admin_2).unwrap();
+
+        // Attempt direct transfer
+        assert_eq!(
+            transfer_admin(&env, &contract_id, &admin_1, &admin_3),
+            Err(QuickLendXError::OperationNotAllowed)
+        );
+    }
+}


### PR DESCRIPTION

# Description
This PR addresses #1322 by adding a dedicated end-to-end and negative test suite for the two-step admin transfer flow (`initiate_admin_transfer`, `accept_admin_transfer` and `cancel_admin_transfer`) as well as comprehensive developer and operator documentation

Admin key handoff is a high-risk operation. The added tests and documentation ensure the safe two-step path is fully proven, verified and clear for operators

Closes #1322

## Proposed Changes

### Contracts & Tests
- **[NEW]** `quicklendx-contracts/src/test_admin_two_step.rs`:
  - **Happy Path**: Verifies that enabling two-step mode, initiating the transfer, and accepting it successfully updates the admin, clears the pending state, and releases the lock.
  - **Cancel Path**: Verifies that the current admin can abort an ongoing transfer, clearing pending state and releasing the transfer lock.
  - **Negative Matrix**: Ensures unauthorized third-parties cannot accept transfers, accepting fails when no transfer is pending, and initiating a transfer fails if the transfer lock is active or a self-transfer is requested.
  - **Event Verification**: Confirms `adm_2st`, `adm_req`, `adm_trf`, and `adm_cnl` events emit with proper topics.
- **[MODIFY]** `quicklendx-contracts/src/lib.rs`: Registered the new test module under test configurations (`#[cfg(test)]`).

### Documentation
- **[NEW]** `quicklendx-contracts/docs/admin-transfer.md`:
  - Explains the architectural differences between direct (one-step) and two-step transfers.
  - Details the transfer lock behavior.
  - Outlines the recommended production handoff sequence with step-by-step instructions and a Mermaid sequence diagram.

## Impact
- **Security**: The transfer lock and two-step handoff are fully tested, ensuring that operators cannot accidentally lock themselves out or transfer control to incorrect addresses.
- **Developer/Operator Experience**: Clear guidance is established for contract administrators to safely update the admin role on-chain.
