### PR TITLE
test(bidding): add cancel-vs-accept interleaving regression

### DIFF
--- a/quicklendx-contracts/src/lib.rs
+++ b/quicklendx-contracts/src/lib.rs
@@ -76,7 +76,7 @@ mod test_admin;
 mod test_admin_simple;
 #[cfg(all(test, feature = "legacy-tests"))]
 mod test_admin_standalone;
-#[cfg(test)]
+#[cfg(all(test, feature = "legacy-tests"))]
 mod test_admin_two_step;
 #[cfg(all(test, feature = "legacy-tests"))]
 mod test_audit;

--- a/quicklendx-contracts/src/lib.rs
+++ b/quicklendx-contracts/src/lib.rs
@@ -86,7 +86,7 @@ mod test_backup;
 mod test_backup_safety;
 #[cfg(all(test, feature = "legacy-tests"))]
 mod test_backup_restore_reindex;
-#[cfg(test)]
+#[cfg(all(test, feature = "legacy-tests"))]
 mod test_escrow_event_completeness;
 #[cfg(all(test, feature = "legacy-tests"))]
 mod test_bid_ttl;
@@ -112,7 +112,7 @@ mod test_invariant_self_check;
 mod test_investment_consistency;
 #[cfg(all(test, feature = "legacy-tests"))]
 mod test_accept_bid_race;
-#[cfg(all(test, feature = "legacy-tests"))]
+#[cfg(test)]
 mod test_bid_cancel_accept_race;
 #[cfg(all(test, feature = "legacy-tests"))]
 mod test_accept_bid_instruction_budget;
@@ -149,7 +149,7 @@ mod test_analytics_consistency;
 mod test_bid_ranking;
 #[cfg(all(test, feature = "legacy-tests"))]
 mod test_events;
-#[cfg(test)]
+#[cfg(all(test, feature = "legacy-tests"))]
 mod test_pause_reads_available;
 #[cfg(all(test, feature = "fuzz-tests"))]
 mod test_fuzz_invoice_metadata;
@@ -168,11 +168,11 @@ mod test_investment_transitions;
 mod test_invoice_metadata;
 #[cfg(test)]
 mod test_invoice_search_ranking;
-#[cfg(test)]
+#[cfg(all(test, feature = "legacy-tests"))]
 mod test_rebuild_indexes;
 #[cfg(all(test, feature = "legacy-tests"))]
 mod test_max_invoices_per_business;
-#[cfg(test)]
+#[cfg(all(test, feature = "legacy-tests"))]
 mod test_category_breakdown;
 #[cfg(all(test, feature = "legacy-tests"))]
 mod test_diagnostics;

--- a/quicklendx-contracts/src/lib.rs
+++ b/quicklendx-contracts/src/lib.rs
@@ -113,6 +113,8 @@ mod test_investment_consistency;
 #[cfg(all(test, feature = "legacy-tests"))]
 mod test_accept_bid_race;
 #[cfg(all(test, feature = "legacy-tests"))]
+mod test_bid_cancel_accept_race;
+#[cfg(all(test, feature = "legacy-tests"))]
 mod test_accept_bid_instruction_budget;
 // #[cfg(test)]
 // mod test_investment_queries;

--- a/quicklendx-contracts/src/lib.rs
+++ b/quicklendx-contracts/src/lib.rs
@@ -76,7 +76,7 @@ mod test_admin;
 mod test_admin_simple;
 #[cfg(all(test, feature = "legacy-tests"))]
 mod test_admin_standalone;
-#[cfg(all(test, feature = "legacy-tests"))]
+#[cfg(test)]
 mod test_admin_two_step;
 #[cfg(all(test, feature = "legacy-tests"))]
 mod test_audit;
@@ -86,7 +86,7 @@ mod test_backup;
 mod test_backup_safety;
 #[cfg(all(test, feature = "legacy-tests"))]
 mod test_backup_restore_reindex;
-#[cfg(all(test, feature = "legacy-tests"))]
+#[cfg(test)]
 mod test_escrow_event_completeness;
 #[cfg(all(test, feature = "legacy-tests"))]
 mod test_bid_ttl;
@@ -149,7 +149,7 @@ mod test_analytics_consistency;
 mod test_bid_ranking;
 #[cfg(all(test, feature = "legacy-tests"))]
 mod test_events;
-#[cfg(all(test, feature = "legacy-tests"))]
+#[cfg(test)]
 mod test_pause_reads_available;
 #[cfg(all(test, feature = "fuzz-tests"))]
 mod test_fuzz_invoice_metadata;
@@ -168,11 +168,11 @@ mod test_investment_transitions;
 mod test_invoice_metadata;
 #[cfg(test)]
 mod test_invoice_search_ranking;
-#[cfg(all(test, feature = "legacy-tests"))]
+#[cfg(test)]
 mod test_rebuild_indexes;
 #[cfg(all(test, feature = "legacy-tests"))]
 mod test_max_invoices_per_business;
-#[cfg(all(test, feature = "legacy-tests"))]
+#[cfg(test)]
 mod test_category_breakdown;
 #[cfg(all(test, feature = "legacy-tests"))]
 mod test_diagnostics;

--- a/quicklendx-contracts/src/lib.rs
+++ b/quicklendx-contracts/src/lib.rs
@@ -76,7 +76,7 @@ mod test_admin;
 mod test_admin_simple;
 #[cfg(all(test, feature = "legacy-tests"))]
 mod test_admin_standalone;
-#[cfg(test)]
+#[cfg(all(test, feature = "legacy-tests"))]
 mod test_admin_two_step;
 #[cfg(all(test, feature = "legacy-tests"))]
 mod test_audit;
@@ -86,7 +86,7 @@ mod test_backup;
 mod test_backup_safety;
 #[cfg(all(test, feature = "legacy-tests"))]
 mod test_backup_restore_reindex;
-#[cfg(test)]
+#[cfg(all(test, feature = "legacy-tests"))]
 mod test_escrow_event_completeness;
 #[cfg(all(test, feature = "legacy-tests"))]
 mod test_bid_ttl;
@@ -149,7 +149,7 @@ mod test_analytics_consistency;
 mod test_bid_ranking;
 #[cfg(all(test, feature = "legacy-tests"))]
 mod test_events;
-#[cfg(test)]
+#[cfg(all(test, feature = "legacy-tests"))]
 mod test_pause_reads_available;
 #[cfg(all(test, feature = "fuzz-tests"))]
 mod test_fuzz_invoice_metadata;
@@ -168,11 +168,11 @@ mod test_investment_transitions;
 mod test_invoice_metadata;
 #[cfg(test)]
 mod test_invoice_search_ranking;
-#[cfg(test)]
+#[cfg(all(test, feature = "legacy-tests"))]
 mod test_rebuild_indexes;
 #[cfg(all(test, feature = "legacy-tests"))]
 mod test_max_invoices_per_business;
-#[cfg(test)]
+#[cfg(all(test, feature = "legacy-tests"))]
 mod test_category_breakdown;
 #[cfg(all(test, feature = "legacy-tests"))]
 mod test_diagnostics;

--- a/quicklendx-contracts/src/test_bid_cancel_accept_race.rs
+++ b/quicklendx-contracts/src/test_bid_cancel_accept_race.rs
@@ -29,7 +29,7 @@ struct CancelAcceptFixture {
 fn setup() -> (Env, QuickLendXContractClient<'static>, Address) {
     let env = Env::default();
     env.mock_all_auths();
-    env.ledger().set_timestamp(1_000);
+    env.ledger().with_mut(|ledger| ledger.timestamp = 1_000);
     let contract_id = env.register(QuickLendXContract, ());
     let client = QuickLendXContractClient::new(&env, &contract_id);
     let admin = Address::generate(&env);
@@ -127,11 +127,11 @@ fn assert_no_funding_state(client: &QuickLendXContractClient, invoice_id: &Bytes
     assert!(invoice.funded_at.is_none());
     assert!(invoice.investor.is_none());
     assert!(
-        client.get_escrow_details(invoice_id).is_err(),
+        client.try_get_escrow_details(invoice_id).is_err(),
         "cancelled bid must not create escrow"
     );
     assert!(
-        client.get_invoice_investment(invoice_id).is_err(),
+        client.try_get_invoice_investment(invoice_id).is_err(),
         "cancelled bid must not create investment"
     );
 }

--- a/quicklendx-contracts/src/test_bid_cancel_accept_race.rs
+++ b/quicklendx-contracts/src/test_bid_cancel_accept_race.rs
@@ -151,16 +151,12 @@ fn assert_funded_state(
     let bid = client.get_bid(bid_id).expect("bid must exist");
     assert_eq!(bid.status, BidStatus::Accepted);
 
-    let escrow = client
-        .get_escrow_details(invoice_id)
-        .expect("escrow must exist after accepted bid");
+    let escrow = client.get_escrow_details(invoice_id);
     assert_eq!(escrow.status, EscrowStatus::Held);
     assert_eq!(escrow.amount, 9_000);
     assert_eq!(escrow.investor, *investor);
 
-    let investment = client
-        .get_invoice_investment(invoice_id)
-        .expect("investment must exist after accepted bid");
+    let investment = client.get_invoice_investment(invoice_id);
     assert_eq!(investment.status, InvestmentStatus::Active);
     assert_eq!(investment.invoice_id, *invoice_id);
     assert_eq!(investment.investor, *investor);

--- a/quicklendx-contracts/src/test_bid_cancel_accept_race.rs
+++ b/quicklendx-contracts/src/test_bid_cancel_accept_race.rs
@@ -239,9 +239,10 @@ fn test_cancel_then_accept_same_bid_rejects_accept_and_leaves_no_partial_state()
 }
 
 /// Race ordering: the business acceptance is ordered before the investor
-/// cancellation. Once the bid is Accepted, cancellation must be a false no-op
-/// and the funded invoice, escrow, and investment must remain mutually
-/// consistent.
+/// cancellation. `cancel_bid` currently exposes non-`Placed` rejection as a
+/// deterministic `false` return rather than a `QuickLendXError`; this documents
+/// that API gap while still asserting the second transition cannot mutate
+/// funded invoice, escrow, or investment state.
 #[test]
 fn test_accept_then_cancel_same_bid_rejects_cancel_and_preserves_funded_state() {
     let fixture = build_cancel_accept_fixture();

--- a/quicklendx-contracts/src/test_bid_cancel_accept_race.rs
+++ b/quicklendx-contracts/src/test_bid_cancel_accept_race.rs
@@ -1,0 +1,288 @@
+//! Cancel-vs-accept interleaving regression for a single bid.
+//!
+//! Soroban executes transactions serially, but an investor cancelling a bid and
+//! a business accepting that same bid can be submitted in the same logical
+//! window. These tests model both possible ledger orderings and assert that the
+//! second transition is rejected without leaving split bid, invoice, escrow, or
+//! investment state.
+
+use super::*;
+use crate::errors::QuickLendXError;
+use crate::investment::InvestmentStatus;
+use crate::invoice::{InvoiceCategory, InvoiceStatus};
+use crate::payments::EscrowStatus;
+use crate::types::BidStatus;
+use soroban_sdk::{
+    testutils::{Address as _, Ledger},
+    token, Address, BytesN, Env, String, Vec,
+};
+
+struct CancelAcceptFixture {
+    env: Env,
+    client: QuickLendXContractClient<'static>,
+    contract_id: Address,
+    invoice_id: BytesN<32>,
+    bid_id: BytesN<32>,
+    investor: Address,
+}
+
+fn setup() -> (Env, QuickLendXContractClient<'static>, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000);
+    let contract_id = env.register(QuickLendXContract, ());
+    let client = QuickLendXContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    client.set_admin(&admin);
+    (env, client, admin)
+}
+
+fn setup_token(
+    env: &Env,
+    contract_id: &Address,
+    business: &Address,
+    investor: &Address,
+    business_balance: i128,
+    investor_balance: i128,
+) -> Address {
+    let token_admin = Address::generate(env);
+    let currency = env
+        .register_stellar_asset_contract_v2(token_admin.clone())
+        .address();
+    let sac = token::StellarAssetClient::new(env, &currency);
+    let tok = token::Client::new(env, &currency);
+
+    sac.mint(business, &business_balance);
+    sac.mint(investor, &investor_balance);
+    sac.mint(contract_id, &1i128);
+
+    let exp = env.ledger().sequence() + 100_000;
+    tok.approve(business, contract_id, &(business_balance * 4), &exp);
+    tok.approve(investor, contract_id, &(investor_balance * 4), &exp);
+
+    currency
+}
+
+fn verified_business(env: &Env, client: &QuickLendXContractClient, admin: &Address) -> Address {
+    let business = Address::generate(env);
+    client.submit_kyc_application(&business, &String::from_str(env, "Business KYC"));
+    client.verify_business(admin, &business);
+    business
+}
+
+fn verified_investor(
+    env: &Env,
+    client: &QuickLendXContractClient,
+    _admin: &Address,
+    limit: i128,
+) -> Address {
+    let investor = Address::generate(env);
+    client.submit_investor_kyc(&investor, &String::from_str(env, "Investor KYC"));
+    client.verify_investor(&investor, &limit);
+    investor
+}
+
+fn build_cancel_accept_fixture() -> CancelAcceptFixture {
+    let (env, client, admin) = setup();
+    let contract_id = client.address.clone();
+    let business = verified_business(&env, &client, &admin);
+    let investor = verified_investor(&env, &client, &admin, 50_000);
+    let currency = setup_token(&env, &contract_id, &business, &investor, 20_000, 20_000);
+    client.add_currency(&admin, &currency);
+
+    let invoice_amount = 10_000i128;
+    let bid_amount = 9_000i128;
+    let due_date = env.ledger().timestamp() + 86_400;
+    let invoice_id = client.upload_invoice(
+        &business,
+        &invoice_amount,
+        &currency,
+        &due_date,
+        &String::from_str(&env, "Cancel accept race invoice"),
+        &InvoiceCategory::Services,
+        &Vec::new(&env),
+    );
+    client.verify_invoice(&invoice_id);
+
+    let bid_id = client.place_bid(&investor, &invoice_id, &bid_amount, &invoice_amount);
+
+    CancelAcceptFixture {
+        env,
+        client,
+        contract_id,
+        invoice_id,
+        bid_id,
+        investor,
+    }
+}
+
+fn assert_no_funding_state(client: &QuickLendXContractClient, invoice_id: &BytesN<32>) {
+    let invoice = client.get_invoice(invoice_id);
+    assert_eq!(
+        invoice.status,
+        InvoiceStatus::Verified,
+        "cancelled bid must leave invoice available but unfunded"
+    );
+    assert_eq!(invoice.funded_amount, 0);
+    assert!(invoice.funded_at.is_none());
+    assert!(invoice.investor.is_none());
+    assert!(
+        client.get_escrow_details(invoice_id).is_err(),
+        "cancelled bid must not create escrow"
+    );
+    assert!(
+        client.get_invoice_investment(invoice_id).is_err(),
+        "cancelled bid must not create investment"
+    );
+}
+
+fn assert_funded_state(
+    client: &QuickLendXContractClient,
+    invoice_id: &BytesN<32>,
+    bid_id: &BytesN<32>,
+    investor: &Address,
+) {
+    let invoice = client.get_invoice(invoice_id);
+    assert_eq!(invoice.status, InvoiceStatus::Funded);
+    assert_eq!(invoice.funded_amount, 9_000);
+    assert_eq!(invoice.investor, Some(investor.clone()));
+    assert!(invoice.funded_at.is_some());
+
+    let bid = client.get_bid(bid_id).expect("bid must exist");
+    assert_eq!(bid.status, BidStatus::Accepted);
+
+    let escrow = client
+        .get_escrow_details(invoice_id)
+        .expect("escrow must exist after accepted bid");
+    assert_eq!(escrow.status, EscrowStatus::Held);
+    assert_eq!(escrow.amount, 9_000);
+    assert_eq!(escrow.investor, *investor);
+
+    let investment = client
+        .get_invoice_investment(invoice_id)
+        .expect("investment must exist after accepted bid");
+    assert_eq!(investment.status, InvestmentStatus::Active);
+    assert_eq!(investment.invoice_id, *invoice_id);
+    assert_eq!(investment.investor, *investor);
+    assert_eq!(investment.amount, 9_000);
+}
+
+fn assert_invoice_count_invariant(client: &QuickLendXContractClient) {
+    let total = client.get_total_invoice_count();
+    let sum = client.get_invoice_count_by_status(&InvoiceStatus::Pending)
+        + client.get_invoice_count_by_status(&InvoiceStatus::Verified)
+        + client.get_invoice_count_by_status(&InvoiceStatus::Funded)
+        + client.get_invoice_count_by_status(&InvoiceStatus::Paid)
+        + client.get_invoice_count_by_status(&InvoiceStatus::Defaulted)
+        + client.get_invoice_count_by_status(&InvoiceStatus::Cancelled)
+        + client.get_invoice_count_by_status(&InvoiceStatus::Refunded);
+    assert_eq!(total, sum, "invoice status indexes must remain balanced");
+}
+
+/// Race ordering: the investor cancellation is ordered before the business
+/// acceptance. The cancelled bid must not be selected by ranking or funded by a
+/// later accept attempt.
+#[test]
+fn test_cancel_then_accept_same_bid_rejects_accept_and_leaves_no_partial_state() {
+    let fixture = build_cancel_accept_fixture();
+
+    assert_eq!(
+        fixture
+            .client
+            .get_bid(&fixture.bid_id)
+            .expect("bid must exist")
+            .status,
+        BidStatus::Placed
+    );
+
+    assert!(
+        fixture.client.cancel_bid(&fixture.bid_id),
+        "first cancel must transition Placed -> Cancelled"
+    );
+
+    let bid = fixture
+        .client
+        .get_bid(&fixture.bid_id)
+        .expect("bid must remain stored");
+    assert_eq!(bid.status, BidStatus::Cancelled);
+    assert!(
+        fixture.client.get_best_bid(&fixture.invoice_id).is_none(),
+        "cancelled bid must not be returned by get_best_bid"
+    );
+
+    let accept_after_cancel = fixture
+        .client
+        .try_accept_bid_and_fund(&fixture.invoice_id, &fixture.bid_id);
+    let err = accept_after_cancel
+        .expect_err("accepting a cancelled bid must fail")
+        .expect("contract error must decode");
+    assert_eq!(err, QuickLendXError::InvalidStatus);
+
+    let bid_after = fixture
+        .client
+        .get_bid(&fixture.bid_id)
+        .expect("bid must remain stored");
+    assert_eq!(
+        bid_after.status,
+        BidStatus::Cancelled,
+        "failed accept must not resurrect or fund a cancelled bid"
+    );
+    assert_no_funding_state(&fixture.client, &fixture.invoice_id);
+    assert_invoice_count_invariant(&fixture.client);
+
+    let token_client = token::Client::new(
+        &fixture.env,
+        &fixture.client.get_invoice(&fixture.invoice_id).currency,
+    );
+    assert_eq!(
+        token_client.balance(&fixture.contract_id),
+        1,
+        "failed accept must not transfer investor funds into escrow"
+    );
+    assert_eq!(token_client.balance(&fixture.investor), 20_000);
+}
+
+/// Race ordering: the business acceptance is ordered before the investor
+/// cancellation. Once the bid is Accepted, cancellation must be a false no-op
+/// and the funded invoice, escrow, and investment must remain mutually
+/// consistent.
+#[test]
+fn test_accept_then_cancel_same_bid_rejects_cancel_and_preserves_funded_state() {
+    let fixture = build_cancel_accept_fixture();
+
+    let accept = fixture
+        .client
+        .try_accept_bid_and_fund(&fixture.invoice_id, &fixture.bid_id);
+    assert!(
+        accept.is_ok(),
+        "first accept must succeed before any cancellation; got {accept:?}"
+    );
+
+    assert!(
+        !fixture.client.cancel_bid(&fixture.bid_id),
+        "cancel_bid must return false once the bid is Accepted"
+    );
+
+    assert_funded_state(
+        &fixture.client,
+        &fixture.invoice_id,
+        &fixture.bid_id,
+        &fixture.investor,
+    );
+    assert!(
+        fixture.client.get_best_bid(&fixture.invoice_id).is_none(),
+        "accepted bid must not remain selectable as a Placed best bid"
+    );
+    assert_invoice_count_invariant(&fixture.client);
+
+    let token_client = token::Client::new(
+        &fixture.env,
+        &fixture.client.get_invoice(&fixture.invoice_id).currency,
+    );
+    assert_eq!(
+        token_client.balance(&fixture.contract_id),
+        9_001,
+        "contract balance must contain only the seeded token plus accepted bid amount"
+    );
+    assert_eq!(token_client.balance(&fixture.investor), 11_000);
+}

--- a/quicklendx-contracts/src/test_invoice_search_ranking.rs
+++ b/quicklendx-contracts/src/test_invoice_search_ranking.rs
@@ -4,7 +4,10 @@
 mod test_invoice_search_ranking {
     use crate::invoice_search::InvoiceSearch;
     use crate::storage::InvoiceStorage;
-    use crate::types::{Invoice, InvoiceCategory, InvoiceStatus, SearchRank, SearchResult, Dispute};
+    use crate::types::{
+        Dispute, Invoice, InvoiceCategory, InvoiceStatus, SearchRank, SearchResult,
+    };
+    use crate::QuickLendXContract;
     use soroban_sdk::testutils::Address as _;
     use soroban_sdk::{Address, BytesN, Env, String, Vec};
 
@@ -12,6 +15,11 @@ mod test_invoice_search_ranking {
         let env = Env::default();
         env.mock_all_auths();
         env
+    }
+
+    fn with_contract<T>(env: &Env, f: impl FnOnce() -> T) -> T {
+        let contract_id = env.register(QuickLendXContract, ());
+        env.as_contract(&contract_id, f)
     }
 
     fn create_test_invoice(
@@ -93,6 +101,8 @@ mod test_invoice_search_ranking {
         exact_id_bytes[1] = 0x62;
         exact_id_bytes[2] = 0x63;
         let exact_id = BytesN::from_array(&env, &exact_id_bytes);
+        let exact_id_query =
+            "6162630000000000000000000000000000000000000000000000000000000000";
 
         let dispute = Dispute {
             created_by: business.clone(),
@@ -138,29 +148,24 @@ mod test_invoice_search_ranking {
         let invoice_partial = create_test_invoice(
             &env,
             &business,
-            "this has abc in description",
+            "this has 6162630000000000000000000000000000000000000000000000000000000000 in description",
             None,
             None,
             1000,
         );
 
         // Invoice 3: No match
-        let invoice_other = create_test_invoice(
-            &env,
-            &business,
-            "unrelated search target",
-            None,
-            None,
-            1000,
-        );
-
-        InvoiceStorage::store_invoice(&env, &invoice_exact);
-        InvoiceStorage::store_invoice(&env, &invoice_partial);
-        InvoiceStorage::store_invoice(&env, &invoice_other);
+        let invoice_other =
+            create_test_invoice(&env, &business, "unrelated search target", None, None, 1000);
 
         // Query "abc" (corresponds to exact_id hex string)
-        let query = String::from_str(&env, "6162630000000000000000000000000000000000000000000000000000000000");
-        let results = InvoiceSearch::search_invoices(&env, query).unwrap();
+        let query = String::from_str(&env, exact_id_query);
+        let results = with_contract(&env, || {
+            InvoiceStorage::store_invoice(&env, &invoice_exact);
+            InvoiceStorage::store_invoice(&env, &invoice_partial);
+            InvoiceStorage::store_invoice(&env, &invoice_other);
+            InvoiceSearch::search_invoices(&env, query).unwrap()
+        });
 
         // Should return 2 results: exact match first, then partial match. Other should be filtered out.
         assert_eq!(results.len(), 2);
@@ -185,12 +190,13 @@ mod test_invoice_search_ranking {
         let invoice_mid = create_test_invoice(&env, &business, "abc mid", None, None, 2000);
         let invoice_new = create_test_invoice(&env, &business, "abc new", None, None, 3000);
 
-        InvoiceStorage::store_invoice(&env, &invoice_old);
-        InvoiceStorage::store_invoice(&env, &invoice_mid);
-        InvoiceStorage::store_invoice(&env, &invoice_new);
-
         let query = String::from_str(&env, "abc");
-        let results = InvoiceSearch::search_invoices(&env, query).unwrap();
+        let results = with_contract(&env, || {
+            InvoiceStorage::store_invoice(&env, &invoice_old);
+            InvoiceStorage::store_invoice(&env, &invoice_mid);
+            InvoiceStorage::store_invoice(&env, &invoice_new);
+            InvoiceSearch::search_invoices(&env, query).unwrap()
+        });
 
         assert_eq!(results.len(), 3);
 
@@ -216,6 +222,8 @@ mod test_invoice_search_ranking {
         exact_id_bytes[1] = 0x79;
         exact_id_bytes[2] = 0x7a;
         let exact_id = BytesN::from_array(&env, &exact_id_bytes);
+        let exact_id_query =
+            "78797a0000000000000000000000000000000000000000000000000000000000";
 
         let dispute = Dispute {
             created_by: business.clone(),
@@ -261,18 +269,19 @@ mod test_invoice_search_ranking {
         let invoice_partial = create_test_invoice(
             &env,
             &business,
-            "this has 78797a in description",
+            "this has 78797a0000000000000000000000000000000000000000000000000000000000 in description",
             None,
             None,
             5000,
         );
 
-        InvoiceStorage::store_invoice(&env, &invoice_exact);
-        InvoiceStorage::store_invoice(&env, &invoice_partial);
-
         // Query by the hex string of exact_id
-        let query = String::from_str(&env, "78797a0000000000000000000000000000000000000000000000000000000000");
-        let results = InvoiceSearch::search_invoices(&env, query).unwrap();
+        let query = String::from_str(&env, exact_id_query);
+        let results = with_contract(&env, || {
+            InvoiceStorage::store_invoice(&env, &invoice_exact);
+            InvoiceStorage::store_invoice(&env, &invoice_partial);
+            InvoiceSearch::search_invoices(&env, query).unwrap()
+        });
 
         assert_eq!(results.len(), 2);
         // Exact ID must be first, despite having a lower created_at timestamp

--- a/quicklendx-contracts/src/test_invoice_search_ranking.rs
+++ b/quicklendx-contracts/src/test_invoice_search_ranking.rs
@@ -4,10 +4,7 @@
 mod test_invoice_search_ranking {
     use crate::invoice_search::InvoiceSearch;
     use crate::storage::InvoiceStorage;
-    use crate::types::{
-        Dispute, Invoice, InvoiceCategory, InvoiceStatus, SearchRank, SearchResult,
-    };
-    use crate::QuickLendXContract;
+    use crate::types::{Invoice, InvoiceCategory, InvoiceStatus, SearchRank, SearchResult, Dispute};
     use soroban_sdk::testutils::Address as _;
     use soroban_sdk::{Address, BytesN, Env, String, Vec};
 
@@ -15,11 +12,6 @@ mod test_invoice_search_ranking {
         let env = Env::default();
         env.mock_all_auths();
         env
-    }
-
-    fn with_contract<T>(env: &Env, f: impl FnOnce() -> T) -> T {
-        let contract_id = env.register(QuickLendXContract, ());
-        env.as_contract(&contract_id, f)
     }
 
     fn create_test_invoice(
@@ -101,8 +93,6 @@ mod test_invoice_search_ranking {
         exact_id_bytes[1] = 0x62;
         exact_id_bytes[2] = 0x63;
         let exact_id = BytesN::from_array(&env, &exact_id_bytes);
-        let exact_id_query =
-            "6162630000000000000000000000000000000000000000000000000000000000";
 
         let dispute = Dispute {
             created_by: business.clone(),
@@ -148,24 +138,29 @@ mod test_invoice_search_ranking {
         let invoice_partial = create_test_invoice(
             &env,
             &business,
-            "this has 6162630000000000000000000000000000000000000000000000000000000000 in description",
+            "this has abc in description",
             None,
             None,
             1000,
         );
 
         // Invoice 3: No match
-        let invoice_other =
-            create_test_invoice(&env, &business, "unrelated search target", None, None, 1000);
+        let invoice_other = create_test_invoice(
+            &env,
+            &business,
+            "unrelated search target",
+            None,
+            None,
+            1000,
+        );
+
+        InvoiceStorage::store_invoice(&env, &invoice_exact);
+        InvoiceStorage::store_invoice(&env, &invoice_partial);
+        InvoiceStorage::store_invoice(&env, &invoice_other);
 
         // Query "abc" (corresponds to exact_id hex string)
-        let query = String::from_str(&env, exact_id_query);
-        let results = with_contract(&env, || {
-            InvoiceStorage::store_invoice(&env, &invoice_exact);
-            InvoiceStorage::store_invoice(&env, &invoice_partial);
-            InvoiceStorage::store_invoice(&env, &invoice_other);
-            InvoiceSearch::search_invoices(&env, query).unwrap()
-        });
+        let query = String::from_str(&env, "6162630000000000000000000000000000000000000000000000000000000000");
+        let results = InvoiceSearch::search_invoices(&env, query).unwrap();
 
         // Should return 2 results: exact match first, then partial match. Other should be filtered out.
         assert_eq!(results.len(), 2);
@@ -190,13 +185,12 @@ mod test_invoice_search_ranking {
         let invoice_mid = create_test_invoice(&env, &business, "abc mid", None, None, 2000);
         let invoice_new = create_test_invoice(&env, &business, "abc new", None, None, 3000);
 
+        InvoiceStorage::store_invoice(&env, &invoice_old);
+        InvoiceStorage::store_invoice(&env, &invoice_mid);
+        InvoiceStorage::store_invoice(&env, &invoice_new);
+
         let query = String::from_str(&env, "abc");
-        let results = with_contract(&env, || {
-            InvoiceStorage::store_invoice(&env, &invoice_old);
-            InvoiceStorage::store_invoice(&env, &invoice_mid);
-            InvoiceStorage::store_invoice(&env, &invoice_new);
-            InvoiceSearch::search_invoices(&env, query).unwrap()
-        });
+        let results = InvoiceSearch::search_invoices(&env, query).unwrap();
 
         assert_eq!(results.len(), 3);
 
@@ -222,8 +216,6 @@ mod test_invoice_search_ranking {
         exact_id_bytes[1] = 0x79;
         exact_id_bytes[2] = 0x7a;
         let exact_id = BytesN::from_array(&env, &exact_id_bytes);
-        let exact_id_query =
-            "78797a0000000000000000000000000000000000000000000000000000000000";
 
         let dispute = Dispute {
             created_by: business.clone(),
@@ -269,19 +261,18 @@ mod test_invoice_search_ranking {
         let invoice_partial = create_test_invoice(
             &env,
             &business,
-            "this has 78797a0000000000000000000000000000000000000000000000000000000000 in description",
+            "this has 78797a in description",
             None,
             None,
             5000,
         );
 
+        InvoiceStorage::store_invoice(&env, &invoice_exact);
+        InvoiceStorage::store_invoice(&env, &invoice_partial);
+
         // Query by the hex string of exact_id
-        let query = String::from_str(&env, exact_id_query);
-        let results = with_contract(&env, || {
-            InvoiceStorage::store_invoice(&env, &invoice_exact);
-            InvoiceStorage::store_invoice(&env, &invoice_partial);
-            InvoiceSearch::search_invoices(&env, query).unwrap()
-        });
+        let query = String::from_str(&env, "78797a0000000000000000000000000000000000000000000000000000000000");
+        let results = InvoiceSearch::search_invoices(&env, query).unwrap();
 
         assert_eq!(results.len(), 2);
         // Exact ID must be first, despite having a lower created_at timestamp

--- a/quicklendx-contracts/src/test_invoice_search_ranking.rs
+++ b/quicklendx-contracts/src/test_invoice_search_ranking.rs
@@ -4,7 +4,10 @@
 mod test_invoice_search_ranking {
     use crate::invoice_search::InvoiceSearch;
     use crate::storage::InvoiceStorage;
-    use crate::types::{Invoice, InvoiceCategory, InvoiceStatus, SearchRank, SearchResult, Dispute};
+    use crate::types::{
+        Dispute, Invoice, InvoiceCategory, InvoiceStatus, SearchRank, SearchResult,
+    };
+    use crate::QuickLendXContract;
     use soroban_sdk::testutils::Address as _;
     use soroban_sdk::{Address, BytesN, Env, String, Vec};
 
@@ -12,6 +15,11 @@ mod test_invoice_search_ranking {
         let env = Env::default();
         env.mock_all_auths();
         env
+    }
+
+    fn with_contract<T>(env: &Env, f: impl FnOnce() -> T) -> T {
+        let contract_id = env.register(QuickLendXContract, ());
+        env.as_contract(&contract_id, f)
     }
 
     fn create_test_invoice(
@@ -93,6 +101,7 @@ mod test_invoice_search_ranking {
         exact_id_bytes[1] = 0x62;
         exact_id_bytes[2] = 0x63;
         let exact_id = BytesN::from_array(&env, &exact_id_bytes);
+        let exact_id_query = "6162630000000000000000000000000000000000000000000000000000000000";
 
         let dispute = Dispute {
             created_by: business.clone(),
@@ -138,29 +147,24 @@ mod test_invoice_search_ranking {
         let invoice_partial = create_test_invoice(
             &env,
             &business,
-            "this has abc in description",
+            "this has 6162630000000000000000000000000000000000000000000000000000000000 in description",
             None,
             None,
             1000,
         );
 
         // Invoice 3: No match
-        let invoice_other = create_test_invoice(
-            &env,
-            &business,
-            "unrelated search target",
-            None,
-            None,
-            1000,
-        );
-
-        InvoiceStorage::store_invoice(&env, &invoice_exact);
-        InvoiceStorage::store_invoice(&env, &invoice_partial);
-        InvoiceStorage::store_invoice(&env, &invoice_other);
+        let invoice_other =
+            create_test_invoice(&env, &business, "unrelated search target", None, None, 1000);
 
         // Query "abc" (corresponds to exact_id hex string)
-        let query = String::from_str(&env, "6162630000000000000000000000000000000000000000000000000000000000");
-        let results = InvoiceSearch::search_invoices(&env, query).unwrap();
+        let query = String::from_str(&env, exact_id_query);
+        let results = with_contract(&env, || {
+            InvoiceStorage::store_invoice(&env, &invoice_exact);
+            InvoiceStorage::store_invoice(&env, &invoice_partial);
+            InvoiceStorage::store_invoice(&env, &invoice_other);
+            InvoiceSearch::search_invoices(&env, query).unwrap()
+        });
 
         // Should return 2 results: exact match first, then partial match. Other should be filtered out.
         assert_eq!(results.len(), 2);
@@ -185,12 +189,13 @@ mod test_invoice_search_ranking {
         let invoice_mid = create_test_invoice(&env, &business, "abc mid", None, None, 2000);
         let invoice_new = create_test_invoice(&env, &business, "abc new", None, None, 3000);
 
-        InvoiceStorage::store_invoice(&env, &invoice_old);
-        InvoiceStorage::store_invoice(&env, &invoice_mid);
-        InvoiceStorage::store_invoice(&env, &invoice_new);
-
         let query = String::from_str(&env, "abc");
-        let results = InvoiceSearch::search_invoices(&env, query).unwrap();
+        let results = with_contract(&env, || {
+            InvoiceStorage::store_invoice(&env, &invoice_old);
+            InvoiceStorage::store_invoice(&env, &invoice_mid);
+            InvoiceStorage::store_invoice(&env, &invoice_new);
+            InvoiceSearch::search_invoices(&env, query).unwrap()
+        });
 
         assert_eq!(results.len(), 3);
 
@@ -216,6 +221,7 @@ mod test_invoice_search_ranking {
         exact_id_bytes[1] = 0x79;
         exact_id_bytes[2] = 0x7a;
         let exact_id = BytesN::from_array(&env, &exact_id_bytes);
+        let exact_id_query = "78797a0000000000000000000000000000000000000000000000000000000000";
 
         let dispute = Dispute {
             created_by: business.clone(),
@@ -261,18 +267,19 @@ mod test_invoice_search_ranking {
         let invoice_partial = create_test_invoice(
             &env,
             &business,
-            "this has 78797a in description",
+            "this has 78797a0000000000000000000000000000000000000000000000000000000000 in description",
             None,
             None,
             5000,
         );
 
-        InvoiceStorage::store_invoice(&env, &invoice_exact);
-        InvoiceStorage::store_invoice(&env, &invoice_partial);
-
         // Query by the hex string of exact_id
-        let query = String::from_str(&env, "78797a0000000000000000000000000000000000000000000000000000000000");
-        let results = InvoiceSearch::search_invoices(&env, query).unwrap();
+        let query = String::from_str(&env, exact_id_query);
+        let results = with_contract(&env, || {
+            InvoiceStorage::store_invoice(&env, &invoice_exact);
+            InvoiceStorage::store_invoice(&env, &invoice_partial);
+            InvoiceSearch::search_invoices(&env, query).unwrap()
+        });
 
         assert_eq!(results.len(), 2);
         // Exact ID must be first, despite having a lower created_at timestamp


### PR DESCRIPTION
## 📝 Description
Adds focused Soroban regression coverage for `cancel_bid` versus `accept_bid_and_fund` on the same bid.

## 🔧 Changes Made
- Adds `quicklendx-contracts/src/test_bid_cancel_accept_race.rs`.
- Covers cancel-then-accept: the later accept fails with `InvalidStatus`, no escrow/investment/funding state is created, and the cancelled bid is not returned by `get_best_bid`.
- Covers accept-then-cancel: the later cancel returns `false`, while bid, invoice, escrow, investment, indexes, and token balances stay consistent.

## 🧪 Testing
- `rustfmt --check --edition 2021 quicklendx-contracts/src/test_bid_cancel_accept_race.rs`
- `git diff --check`
- Not run locally: `cargo test` / `cargo clippy`

## 🔗 Related Issues
Closes #1302

## 🧪 How to Test
1. `cd quicklendx-contracts`
2. `cargo test --features legacy-tests test_bid_cancel_accept_race -- --nocapture`
