### PR TITLE
feat: implement protocol invariant checks and document the diagnostic report framework

### DIFF
--- a/quicklendx-contracts/docs/invariant-report.md
+++ b/quicklendx-contracts/docs/invariant-report.md
@@ -1,0 +1,34 @@
+# Invariant Self-Check Report Developer Guide
+
+This document covers the admin-callable invariant self-check entrypoint (`invariant_self_check`) that provides a structured diagnostic report detailing cross-module invariant health.
+
+## Overview
+
+The `invariant_self_check` entrypoint aggregates cross-module and data-layer invariants into a single, read-only "heartbeat" list of `(check_name, passed, evidence)` rows. It is admin-gated and read-only, ensuring no state mutation can occur.
+
+## Composed Invariant Checks
+
+The diagnostic report executes the following 7 checks:
+
+1. **`no_orphan_investments`**: Every entry in the active-investment index must carry `InvestmentStatus::Active`.
+2. **`audit_chain_integrity`**: Every invoice's audit trail must hash-chain validate without missing or tampered entries.
+3. **`solvency`**: Active principals must be positive, and funded amounts must not exceed face values.
+4. **`storage_index_coherence`**: Every invoice must belong to exactly one status index corresponding to its actual record status.
+5. **`sum_investments_le_sum_invoices`**: The sum of all active investments must be less than or equal to the sum of all invoice face values.
+6. **`escrow_uniqueness`**: Every invoice ID has at most one associated escrow mapping, and any present escrow correctly references its invoice ID.
+7. **`settlement_accounting_identity`**: For every settled (`Paid`) invoice, the recalculated platform fee and investor return must sum exactly to `total_paid` (`investor_return + platform_fee == total_paid`).
+
+## Computational Complexity and Scan Cost
+
+Because these invariants inspect global contract state, running them incurs a linear scan cost:
+
+- **`no_orphan_investments`**: $O(N_{active})$ persistent storage reads.
+- **`audit_chain_integrity`**: $O(N_{all} \times L_{audit})$ persistent storage reads, where $L_{audit}$ is the length of the audit chain per invoice.
+- **`solvency`**: $O(N_{active} + N_{funded})$ persistent storage reads.
+- **`storage_index_coherence`**: $O(N_{all})$ persistent storage reads.
+- **`sum_investments_le_sum_invoices`**: $O(N_{active} + N_{all})$ persistent storage reads.
+- **`escrow_uniqueness`**: $O(N_{all})$ persistent storage reads.
+- **`settlement_accounting_identity`**: $O(N_{paid})$ persistent storage reads.
+
+> [!WARNING]
+> Due to the $O(N)$ scanning cost, this endpoint should only be called sparingly by admins or monitoring agents (e.g. during audits or incident triage) and not inside hot paths.

--- a/quicklendx-contracts/src/invariants.rs
+++ b/quicklendx-contracts/src/invariants.rs
@@ -20,12 +20,13 @@
 //!   mode. The report is a diagnostic, not a remediation - it never repairs the
 //!   inconsistency it detects.
 
-use soroban_sdk::{contracttype, Address, Env, String, Vec};
+use soroban_sdk::{contracttype, Address, BytesN, Env, String, Vec};
 
 use crate::admin::AdminStorage;
 use crate::audit::AuditStorage;
 use crate::errors::QuickLendXError;
 use crate::investment::InvestmentStorage;
+use crate::payments::{EscrowStorage, EscrowStatus};
 use crate::storage::InvoiceStorage;
 use crate::types::InvoiceStatus;
 
@@ -179,6 +180,132 @@ fn check_storage_index_coherence(env: &Env) -> InvariantCheck {
     row(env, "storage_index_coherence", passed, evidence)
 }
 
+/// Sum of all active investments must be less than or equal to the sum of all invoice amounts.
+///
+/// **Cost:** O(N_active + N_all) persistent reads to iterate active investments and invoices.
+fn check_sum_investments_le_sum_invoices(env: &Env) -> InvariantCheck {
+    let mut sum_investments: i128 = 0;
+    let mut sum_invoices: i128 = 0;
+    let mut passed = true;
+
+    for id in InvestmentStorage::get_active_investment_ids(env).iter() {
+        if let Some(inv) = InvestmentStorage::get_investment(env, &id) {
+            sum_investments = match sum_investments.checked_add(inv.amount) {
+                Some(val) => val,
+                None => {
+                    passed = false;
+                    break;
+                }
+            };
+        }
+    }
+
+    if passed {
+        for id in InvoiceStorage::get_all_invoice_ids(env).iter() {
+            if let Some(invoice) = InvoiceStorage::get_invoice(env, &id) {
+                sum_invoices = match sum_invoices.checked_add(invoice.amount) {
+                    Some(val) => val,
+                    None => {
+                        passed = false;
+                        break;
+                    }
+                };
+            }
+        }
+    }
+
+    if passed && sum_investments > sum_invoices {
+        passed = false;
+    }
+
+    let evidence = if passed {
+        "Sum of active investments is less than or equal to sum of invoice amounts."
+    } else {
+        "Accounting discrepancy: sum of active investments exceeds sum of invoice amounts."
+    };
+    row(env, "sum_investments_le_sum_invoices", passed, evidence)
+}
+
+/// Escrow mapping uniqueness check: verifies that each invoice has at most one escrow mapping
+/// and that any present escrow correctly points back to that invoice ID.
+///
+/// **Cost:** O(N_all) persistent reads to scan all invoice escrow mappings.
+fn check_escrow_uniqueness(env: &Env) -> InvariantCheck {
+    let mut passed = true;
+    for id in InvoiceStorage::get_all_invoice_ids(env).iter() {
+        let invoice_key = (soroban_sdk::symbol_short!("escrow"), &id);
+        if let Some(escrow_id) = env.storage().persistent().get::<_, BytesN<32>>(&invoice_key) {
+            if let Some(escrow) = EscrowStorage::get_escrow(env, &escrow_id) {
+                if escrow.invoice_id != id {
+                    passed = false;
+                    break;
+                }
+            } else {
+                passed = false;
+                break;
+            }
+        }
+    }
+
+    let evidence = if passed {
+        "Every present escrow mapping is unique and correctly references its invoice ID."
+    } else {
+        "Escrow uniqueness violation: mismatch or orphan escrow pointer detected."
+    };
+    row(env, "escrow_uniqueness", passed, evidence)
+}
+
+/// Settlement accounting identity: recalculate fees and returns for settled/Paid invoices
+/// and verify that `investor_return + platform_fee == total_paid`.
+///
+/// **Cost:** O(N_paid) persistent reads to inspect all Paid invoices and their corresponding investments.
+fn check_settlement_accounting_identity(env: &Env) -> InvariantCheck {
+    let mut passed = true;
+    for id in InvoiceStorage::get_by_status(env, InvoiceStatus::Paid).iter() {
+        if let Some(invoice) = InvoiceStorage::get_invoice(env, &id) {
+            if let Some(investment) = InvestmentStorage::get_investment_by_invoice(env, &id) {
+                let (investor_return, platform_fee) = match crate::fees::FeeManager::calculate_platform_fee(
+                    env,
+                    investment.amount,
+                    invoice.total_paid,
+                ) {
+                    Ok(result) => result,
+                    Err(crate::errors::QuickLendXError::StorageKeyNotFound) => {
+                        crate::profits::calculate_profit(env, investment.amount, invoice.total_paid)
+                    }
+                    Err(_) => {
+                        passed = false;
+                        break;
+                    }
+                };
+
+                let disbursement_total = match investor_return.checked_add(platform_fee) {
+                    Some(val) => val,
+                    None => {
+                        passed = false;
+                        break;
+                    }
+                };
+
+                if disbursement_total != invoice.total_paid {
+                    passed = false;
+                    break;
+                }
+            } else {
+                passed = false;
+                break;
+            }
+        }
+    }
+
+    let evidence = if passed {
+        "All Paid invoices satisfy investor_return + platform_fee == total_paid."
+    } else {
+        "Accounting identity violation: investor_return + platform_fee != total_paid on a settled invoice."
+    };
+    row(env, "settlement_accounting_identity", passed, evidence)
+}
+
 /// Run every composed invariant check and assemble the report.
 ///
 /// Read-only and independent of admin gating, so tests can exercise it directly
@@ -190,6 +317,9 @@ pub fn run_invariant_checks(env: &Env) -> InvariantReport {
     checks.push_back(check_audit_chain_integrity(env));
     checks.push_back(check_solvency(env));
     checks.push_back(check_storage_index_coherence(env));
+    checks.push_back(check_sum_investments_le_sum_invoices(env));
+    checks.push_back(check_escrow_uniqueness(env));
+    checks.push_back(check_settlement_accounting_identity(env));
 
     let mut all_passed = true;
     for c in checks.iter() {

--- a/quicklendx-contracts/src/lib.rs
+++ b/quicklendx-contracts/src/lib.rs
@@ -106,7 +106,7 @@ mod test_expired_bids_cleanup;
 mod test_freshness;
 #[cfg(all(test, feature = "legacy-tests"))]
 mod test_init;
-#[cfg(all(test, feature = "legacy-tests"))]
+#[cfg(test)]
 mod test_invariant_self_check;
 #[cfg(all(test, feature = "legacy-tests"))]
 mod test_investment_consistency;
@@ -363,6 +363,15 @@ impl QuickLendXContract {
         admin: Address,
     ) -> Result<maintenance::ExtendReport, QuickLendXError> {
         maintenance::MaintenanceControl::extend_protocol_ttl(&env, &admin)
+    }
+
+    /// Admin-gated protocol heartbeat. Authenticates `admin` as the stored protocol
+    /// admin, then runs every composed invariant check read-only.
+    pub fn invariant_self_check(
+        env: Env,
+        admin: Address,
+    ) -> Result<invariants::InvariantReport, QuickLendXError> {
+        invariants::invariant_self_check(&env, &admin)
     }
 
     /// Initialize the admin address (deprecated: use initialize)

--- a/quicklendx-contracts/src/test_invariant_self_check.rs
+++ b/quicklendx-contracts/src/test_invariant_self_check.rs
@@ -11,7 +11,8 @@ use soroban_sdk::{Address, BytesN, Env, String, Vec};
 
 use crate::invariants::{run_invariant_checks, InvariantReport};
 use crate::investment::InvestmentStorage;
-use crate::types::{Investment, InvestmentStatus};
+use crate::storage::InvoiceStorage;
+use crate::types::{Investment, InvestmentStatus, Invoice, InvoiceStatus, InvoiceCategory, Dispute, DisputeStatus};
 use crate::{QuickLendXContract, QuickLendXContractClient};
 
 fn setup() -> (Env, QuickLendXContractClient<'static>, Address, Address) {
@@ -48,14 +49,55 @@ fn make_active_investment(env: &Env) -> Investment {
     }
 }
 
+/// Build an Invoice record.
+fn make_invoice(env: &Env, invoice_id: &BytesN<32>) -> Invoice {
+    let business = Address::generate(env);
+    Invoice {
+        id: invoice_id.clone(),
+        business: business.clone(),
+        amount: 10_000,
+        currency: Address::generate(env),
+        due_date: 0,
+        status: InvoiceStatus::Pending,
+        created_at: 0,
+        description: String::from_str(env, "desc"),
+        metadata_customer_name: None,
+        metadata_customer_address: None,
+        metadata_tax_id: None,
+        metadata_notes: None,
+        metadata_line_items: Vec::new(env),
+        category: InvoiceCategory::Services,
+        tags: Vec::new(env),
+        funded_amount: 0,
+        funded_at: None,
+        investor: None,
+        settled_at: None,
+        average_rating: None,
+        total_ratings: 0,
+        ratings: Vec::new(env),
+        dispute_status: DisputeStatus::None,
+        dispute: Dispute {
+            created_by: business.clone(),
+            created_at: 0,
+            reason: String::from_str(env, ""),
+            evidence: String::from_str(env, ""),
+            resolution: String::from_str(env, ""),
+            resolved_by: business.clone(),
+            resolved_at: 0,
+        },
+        total_paid: 0,
+        payment_history: Vec::new(env),
+    }
+}
+
 #[test]
 fn test_fresh_contract_all_pass() {
     let (_env, client, _id, admin) = setup();
 
     let report = client.invariant_self_check(&admin);
 
-    // Four composed checks, all green on an empty protocol.
-    assert_eq!(report.checks.len(), 4);
+    // Seven composed checks, all green on an empty protocol.
+    assert_eq!(report.checks.len(), 7);
     assert!(report.all_passed);
 }
 
@@ -76,6 +118,8 @@ fn test_populated_healthy_state_passes() {
 
     let report = env.as_contract(&contract_id, || {
         let investment = make_active_investment(&env);
+        let invoice = make_invoice(&env, &investment.invoice_id);
+        InvoiceStorage::store_invoice(&env, &invoice);
         InvestmentStorage::store_investment(&env, &investment);
         run_invariant_checks(&env)
     });
@@ -83,6 +127,9 @@ fn test_populated_healthy_state_passes() {
     assert!(report.all_passed);
     assert!(passed_for(&env, &report, "no_orphan_investments"));
     assert!(passed_for(&env, &report, "solvency"));
+    assert!(passed_for(&env, &report, "sum_investments_le_sum_invoices"));
+    assert!(passed_for(&env, &report, "escrow_uniqueness"));
+    assert!(passed_for(&env, &report, "settlement_accounting_identity"));
 }
 
 #[test]
@@ -91,6 +138,8 @@ fn test_simulated_tampering_is_detected() {
 
     let report = env.as_contract(&contract_id, || {
         let investment = make_active_investment(&env);
+        let invoice = make_invoice(&env, &investment.invoice_id);
+        InvoiceStorage::store_invoice(&env, &invoice);
         // Store as Active so it lands in the active-investment index.
         InvestmentStorage::store_investment(&env, &investment);
 
@@ -115,6 +164,8 @@ fn test_self_check_never_modifies_state() {
 
     env.as_contract(&contract_id, || {
         let investment = make_active_investment(&env);
+        let invoice = make_invoice(&env, &investment.invoice_id);
+        InvoiceStorage::store_invoice(&env, &invoice);
         InvestmentStorage::store_investment(&env, &investment);
 
         let active_before = InvestmentStorage::get_active_investment_ids(&env).len();
@@ -128,4 +179,84 @@ fn test_self_check_never_modifies_state() {
         let second = run_invariant_checks(&env);
         assert_eq!(first, second);
     });
+}
+
+#[test]
+fn test_sum_investments_le_sum_invoices_violation() {
+    let (env, _client, contract_id, _admin) = setup();
+
+    let report = env.as_contract(&contract_id, || {
+        let investment = make_active_investment(&env);
+        let mut invoice = make_invoice(&env, &investment.invoice_id);
+        // Make invoice amount less than investment amount to trigger violation
+        invoice.amount = investment.amount - 100;
+        InvoiceStorage::store_invoice(&env, &invoice);
+        InvestmentStorage::store_investment(&env, &investment);
+        run_invariant_checks(&env)
+    });
+
+    assert!(!passed_for(&env, &report, "sum_investments_le_sum_invoices"));
+    assert!(!report.all_passed);
+}
+
+#[test]
+fn test_escrow_uniqueness_violation() {
+    let (env, _client, contract_id, _admin) = setup();
+
+    let report = env.as_contract(&contract_id, || {
+        let investment = make_active_investment(&env);
+        let invoice = make_invoice(&env, &investment.invoice_id);
+        InvoiceStorage::store_invoice(&env, &invoice);
+        InvestmentStorage::store_investment(&env, &investment);
+
+        // Tamper: store a corrupted escrow mapping where the escrow points back to a different invoice ID
+        let escrow_id = BytesN::from_array(&env, &[9u8; 32]);
+        let corrupted_escrow = crate::payments::Escrow {
+            escrow_id: escrow_id.clone(),
+            invoice_id: BytesN::from_array(&env, &[99u8; 32]), // Mismatched invoice ID
+            investor: Address::generate(&env),
+            business: Address::generate(&env),
+            amount: 500,
+            currency: Address::generate(&env),
+            created_at: 0,
+            status: crate::payments::EscrowStatus::Held,
+        };
+        env.storage().persistent().set(&corrupted_escrow.escrow_id, &corrupted_escrow);
+        
+        let invoice_key = (soroban_sdk::symbol_short!("escrow"), &invoice.id);
+        env.storage().persistent().set(&invoice_key, &escrow_id);
+
+        run_invariant_checks(&env)
+    });
+
+    assert!(!passed_for(&env, &report, "escrow_uniqueness"));
+    assert!(!report.all_passed);
+}
+
+#[test]
+fn test_settlement_accounting_identity_violation() {
+    let (env, _client, contract_id, _admin) = setup();
+
+    let report = env.as_contract(&contract_id, || {
+        let investment = make_active_investment(&env);
+        let mut invoice = make_invoice(&env, &investment.invoice_id);
+        invoice.status = InvoiceStatus::Paid;
+        invoice.total_paid = investment.amount; // healthy total_paid matches investment.amount
+        InvoiceStorage::store_invoice(&env, &invoice);
+        InvestmentStorage::store_investment(&env, &investment);
+
+        // Verify it passes first
+        let healthy_report = run_invariant_checks(&env);
+        assert!(passed_for(&env, &healthy_report, "settlement_accounting_identity"));
+
+        // Tamper: corrupt total_paid to a negative number to violate accounting identity
+        let mut tampered_invoice = invoice.clone();
+        tampered_invoice.total_paid = -100;
+        InvoiceStorage::store_invoice(&env, &tampered_invoice);
+
+        run_invariant_checks(&env)
+    });
+
+    assert!(!passed_for(&env, &report, "settlement_accounting_identity"));
+    assert!(!report.all_passed);
 }


### PR DESCRIPTION

# Pull Request Template

## 📝 Description
This PR implements the admin-callable invariant report aggregation exposing per-check pass/fail evidence rows. It extends the `InvariantReport` struct with three cross-module checks: sum of investments vs invoice amounts, escrow uniqueness per invoice, and settlement accounting identity.

Closes #1336

## 🎯 Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Security enhancement
- [ ] Other (please describe):

## 🔧 Changes Made
### Files Modified
- [invariants.rs](file:///Users/backenddevopsdeveloper/Downloads/DRIPS/vida-quicklendx-protocol/quicklendx-contracts/src/invariants.rs)
- [lib.rs](file:///Users/backenddevopsdeveloper/Downloads/DRIPS/vida-quicklendx-protocol/quicklendx-contracts/src/lib.rs)
- [test_invariant_self_check.rs](file:///Users/backenddevopsdeveloper/Downloads/DRIPS/vida-quicklendx-protocol/quicklendx-contracts/src/test_invariant_self_check.rs)

### New Files Added
- [invariant-report.md](file:///Users/backenddevopsdeveloper/Downloads/DRIPS/vida-quicklendx-protocol/quicklendx-contracts/docs/invariant-report.md)

### Key Changes
- **`sum_investments_le_sum_invoices` Check**: Enforces that the sum of all active investments is less than or equal to the sum of all invoice face values.
- **`escrow_uniqueness` Check**: Verifies that each invoice ID has at most one associated escrow mapping and that any present escrow correctly points back to that invoice ID.
- **`settlement_accounting_identity` Check**: Recalculates fees and returns for settled (`Paid`) invoices to verify that `investor_return + platform_fee == total_paid`.
- **Admin Entrypoint**: Exposed `invariant_self_check` under `impl QuickLendXContract` in `lib.rs` gated by `AdminStorage::require_admin_auth`.
- **Complexity Documentation**: Created `invariant-report.md` detailing the checks and their linear $O(N)$ scanning cost.

## 🧪 Testing
- [x] Unit tests pass
- [ ] Integration tests pass
- [x] Manual testing completed
- [ ] No breaking changes introduced
- [ ] Cross-platform compatibility verified
- [x] Edge cases tested

### Test Coverage
Added unit tests to [test_invariant_self_check.rs](file:///Users/backenddevopsdeveloper/Downloads/DRIPS/vida-quicklendx-protocol/quicklendx-contracts/src/test_invariant_self_check.rs) to verify that all new checks pass on a healthy ledger state and fail under simulated tampering/state corruption.

## 📋 Contract-Specific Checks
- [x] Soroban contract builds successfully
- [ ] WASM compilation works
- [ ] Gas usage optimized
- [ ] Security considerations reviewed
- [ ] Events properly emitted
- [x] Contract functions tested
