### PR TITLE
test(freshness): pin drift bounds and docs

### DIFF
--- a/quicklendx-contracts/docs/freshness.md
+++ b/quicklendx-contracts/docs/freshness.md
@@ -1,0 +1,60 @@
+# Freshness Drift Model
+
+`get_freshness(indexed_ledger_seq, indexed_ledger_timestamp, offset)` returns
+transport-friendly metadata that lets clients decide whether indexed data is
+still safe to display or act on.
+
+The contract does not return a boolean stale flag. Instead, clients derive it
+from `index_lag_seconds`, which is computed as:
+
+```text
+current ledger timestamp - indexed ledger timestamp
+```
+
+## Drift Bound
+
+The documented freshness bound is
+`DEFAULT_MAX_FRESHNESS_DRIFT_SECS = 120`.
+
+Client interpretation:
+
+| `index_lag_seconds` | Freshness state | Recommended behavior |
+|---|---|---|
+| `<= 30` | Fresh | No warning required. |
+| `31..=120` | Delayed but usable | Show a subtle delayed-data notice. |
+| `> 120` | Stale | Show a prominent stale-data warning and block high-risk financial actions. |
+
+The boundary is inclusive: `120` seconds is still usable, while `121` seconds
+is stale. Tests in `src/test_freshness_bounds.rs` pin that one-ledger-second
+transition so future changes cannot silently move the threshold.
+
+## Monotonicity
+
+For a fixed current ledger timestamp, increasing elapsed time must never report
+fresher data. In practice, older indexed ledger timestamps produce larger
+`index_lag_seconds` values. This keeps client-side stale checks stable across
+pagination and refresh loops.
+
+## Edge Cases
+
+- When the indexed timestamp equals the current ledger timestamp, the lag is
+  `0` and the data is fresh.
+- At Unix epoch start, `0 - 0` is fresh.
+- If the indexed timestamp is in the future, `index_lag_seconds` is negative.
+  Treat this as clock/indexer skew, not stale data. Clients should show a
+  diagnostic or retry, but should not permanently advance cursors from a future
+  timestamp without a later consistent read.
+
+## Client Guidance
+
+Clients should:
+
+1. Call `get_freshness` alongside any indexed data read.
+2. Parse `index_lag_seconds` as an `i64`.
+3. Treat values above `DEFAULT_MAX_FRESHNESS_DRIFT_SECS` as stale.
+4. Keep `cursor` opaque; it is pagination metadata, not an authorization token.
+5. Keep showing the lag indicator wherever indexed state affects financial
+   decisions.
+
+The detailed response-field contract is documented in
+[`docs/contracts/freshness.md`](contracts/freshness.md).

--- a/quicklendx-contracts/src/freshness.rs
+++ b/quicklendx-contracts/src/freshness.rs
@@ -1,6 +1,12 @@
 use alloc::{format, string::String as RustString};
 use soroban_sdk::{contracterror, contracttype, Env, String};
 
+/// Default client-facing drift bound for freshness reads.
+///
+/// Freshness metadata is considered usable while `index_lag_seconds <= 120`.
+/// Clients should treat `index_lag_seconds > 120` as stale data.
+pub const DEFAULT_MAX_FRESHNESS_DRIFT_SECS: i64 = 120;
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 #[contracttype]
 pub enum DataKey {
@@ -18,6 +24,9 @@ pub enum FreshnessError {
 }
 
 /// Transport-friendly freshness metadata returned by `lib.rs::get_freshness`.
+///
+/// See `quicklendx-contracts/docs/freshness.md` for the documented stale-data
+/// boundary and recommended client behavior.
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct FreshnessMetadata {

--- a/quicklendx-contracts/src/lib.rs
+++ b/quicklendx-contracts/src/lib.rs
@@ -109,6 +109,8 @@ mod test_escrow_invariant_model;
 mod test_expired_bids_cleanup;
 #[cfg(test)]
 mod test_freshness;
+#[cfg(test)]
+mod test_freshness_bounds;
 #[cfg(all(test, feature = "legacy-tests"))]
 mod test_init;
 #[cfg(test)]
@@ -3398,6 +3400,9 @@ impl QuickLendXContract {
     }
 
     /// Build API freshness metadata as string key/value pairs.
+    ///
+    /// See `quicklendx-contracts/docs/freshness.md` for the documented
+    /// freshness drift bound and client handling guidance.
     pub fn get_freshness(
         env: Env,
         indexed_ledger_seq: u32,

--- a/quicklendx-contracts/src/test_freshness_bounds.rs
+++ b/quicklendx-contracts/src/test_freshness_bounds.rs
@@ -1,0 +1,100 @@
+//! Boundary tests for the documented freshness drift threshold.
+
+use super::*;
+use soroban_sdk::{testutils::Ledger, Env, String};
+
+fn setup() -> (Env, QuickLendXContractClient<'static>) {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(QuickLendXContract, ());
+    let client = QuickLendXContractClient::new(&env, &contract_id);
+    (env, client)
+}
+
+fn index_lag_seconds(
+    env: &Env,
+    client: &QuickLendXContractClient,
+    current: u64,
+    indexed: u64,
+) -> i64 {
+    env.ledger().set_timestamp(current);
+
+    let result = client.get_freshness(&100u32, &indexed, &0u32);
+    let lag = result
+        .get(String::from_str(env, "index_lag_seconds"))
+        .unwrap();
+    let len = lag.len() as usize;
+    let mut buf = [0u8; 22];
+    lag.copy_into_slice(&mut buf[..len]);
+
+    core::str::from_utf8(&buf[..len])
+        .unwrap()
+        .parse::<i64>()
+        .unwrap()
+}
+
+fn is_stale(lag_seconds: i64) -> bool {
+    lag_seconds > freshness::DEFAULT_MAX_FRESHNESS_DRIFT_SECS
+}
+
+#[test]
+fn test_freshness_bound_is_inclusive_and_one_second_past_is_stale() {
+    let (env, client) = setup();
+    let current = 1_700_000_120u64;
+    let bound = freshness::DEFAULT_MAX_FRESHNESS_DRIFT_SECS as u64;
+
+    let exactly_at_bound = index_lag_seconds(&env, &client, current, current - bound);
+    let one_second_past_bound = index_lag_seconds(&env, &client, current, current - bound - 1);
+
+    assert_eq!(
+        exactly_at_bound,
+        freshness::DEFAULT_MAX_FRESHNESS_DRIFT_SECS
+    );
+    assert!(!is_stale(exactly_at_bound));
+    assert_eq!(
+        one_second_past_bound,
+        freshness::DEFAULT_MAX_FRESHNESS_DRIFT_SECS + 1
+    );
+    assert!(is_stale(one_second_past_bound));
+}
+
+#[test]
+fn test_freshness_lag_is_monotonic_with_elapsed_time() {
+    let (env, client) = setup();
+    let current = 1_700_001_000u64;
+    let elapsed_times = [0u64, 1, 30, 120, 121, 600];
+    let mut previous = i64::MIN;
+
+    for elapsed in elapsed_times {
+        let lag = index_lag_seconds(&env, &client, current, current - elapsed);
+
+        assert!(
+            lag >= previous,
+            "lag {lag} should not be fresher than prior lag {previous}"
+        );
+        previous = lag;
+    }
+}
+
+#[test]
+fn test_freshness_at_write_time_and_epoch_start_is_fresh() {
+    let (env, client) = setup();
+
+    let epoch_start_lag = index_lag_seconds(&env, &client, 0, 0);
+    let current_write_lag = index_lag_seconds(&env, &client, 1_700_000_000, 1_700_000_000);
+
+    assert_eq!(epoch_start_lag, 0);
+    assert!(!is_stale(epoch_start_lag));
+    assert_eq!(current_write_lag, 0);
+    assert!(!is_stale(current_write_lag));
+}
+
+#[test]
+fn test_future_indexed_timestamp_is_clock_skew_not_stale() {
+    let (env, client) = setup();
+
+    let lag = index_lag_seconds(&env, &client, 1_700_000_000, 1_700_000_005);
+
+    assert_eq!(lag, -5);
+    assert!(!is_stale(lag));
+}


### PR DESCRIPTION
Closes #1331.

## Summary
- add a documented `DEFAULT_MAX_FRESHNESS_DRIFT_SECS` boundary for freshness metadata
- add focused freshness-bound tests for the inclusive 120-second threshold, one-second stale transition, monotonic lag, write-time/epoch freshness, and future timestamp skew
- document the freshness drift model and link `get_freshness` to the docs

## Validation
- RED: `cargo test --manifest-path quicklendx-contracts/Cargo.toml test_freshness_bound_is_inclusive_and_one_second_past_is_stale -- --nocapture` initially failed with the expected missing `DEFAULT_MAX_FRESHNESS_DRIFT_SECS` error
- `cargo test --manifest-path quicklendx-contracts/Cargo.toml test_freshness_bound_is_inclusive_and_one_second_past_is_stale -- --nocapture` is currently blocked by pre-existing `origin/main` compile errors in unrelated files, including `src/dispute.rs` inner doc comments, missing `crate::contract`/`crate::test` imports, and `src/health.rs` type/method errors
- Reproduced the same compile blocker on `origin/main` at `1bcb5bc6` with the same command
- `rustfmt --check quicklendx-contracts/src/test_freshness_bounds.rs`
- `git diff --cached --check`