### PR TITLE
feat: document rate limits via OpenAPI x-rate-limit and expose in /status

### DIFF
--- a/backend/docs/limits.md
+++ b/backend/docs/limits.md
@@ -9,6 +9,50 @@ To prevent abuse, memory pressure, and injection vectors, all incoming HTTP requ
 1. **Size limits** on body, query parameters, and headers
 2. **Input validation** via Zod schemas
 3. **Sanitization** to prevent XSS and injection attacks
+4. **Rate limits** that are documented in OpenAPI and surfaced through `/api/v1/status`
+
+## Rate Limits
+
+The backend exposes two always-on request limit layers and route-specific stricter
+policies for high-cost operations. The live thresholds come from
+`src/middleware/rate-limit.ts`, which is also the source used by
+`GET /api/v1/status`.
+
+| Policy | Default limit | Window | Block | Key | Applies to |
+|--------|---------------|--------|-------|-----|------------|
+| `global` | 100 requests | 60s | 60s | client IP | All public API endpoints |
+| `perKey` | 60 requests | 60s | 60s | API key, falling back to client IP | All API endpoints after auth context is available |
+| `strict` | 5 requests | 60s | 300s | client IP | Custom sensitive handlers using `strictRateLimitMiddleware` |
+| `reconciliation` | 10 requests | 60s | 120s | API key, falling back to client IP | Reconciliation and monitoring routes |
+| `export` | 5 requests | 60s | 120s | API key, falling back to client IP | Export generation and download routes |
+
+In `NODE_ENV=test`, the exported policy snapshot intentionally uses larger limits
+so conformance tests can exercise endpoints without tripping the limiter:
+`global` and `perKey` use 1000 requests, while `strict`, `reconciliation`, and
+`export` use 100 requests.
+
+### OpenAPI annotation
+
+Every operation in `openapi.yaml` has an `x-rate-limit` extension:
+
+```yaml
+x-rate-limit:
+  policies: [global, perKey]
+```
+
+Export endpoints include the stricter export layer:
+
+```yaml
+x-rate-limit:
+  policies: [global, perKey, export]
+```
+
+### Status response
+
+`GET /api/v1/status` returns the live policy snapshot under `rateLimits`.
+Only public thresholds, windows, keying mode, and response header names are
+returned. Runtime bucket state such as IP buckets, API key identifiers,
+remaining points, and reset timers is not exposed.
 
 ## Request Size Limits
 

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -114,6 +114,11 @@ paths:
                     blockSeconds: 60
                     key: api-key-or-client-ip
                     headers: [X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset]
+                _system:
+                  status: operational
+                  degraded: false
+                  lag: 0
+                  level: none
 
   /admin/status:
     get:
@@ -930,6 +935,7 @@ components:
         - isCritical
         - checkedAt
         - rateLimits
+        - _system
       properties:
         lag:
           type: integer
@@ -949,6 +955,28 @@ components:
           format: date-time
         rateLimits:
           $ref: '#/components/schemas/RateLimitPolicies'
+        _system:
+          $ref: '#/components/schemas/SystemStatusMetadata'
+
+    SystemStatusMetadata:
+      type: object
+      description: Additive system-health metadata injected into JSON responses.
+      required:
+        - status
+        - degraded
+        - lag
+        - level
+      properties:
+        status:
+          type: string
+          enum: [operational, degraded, maintenance]
+        degraded:
+          type: boolean
+        lag:
+          type: integer
+        level:
+          type: string
+          enum: [none, warn, critical]
 
     FreshnessMetadata:
       type: object

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -59,6 +59,8 @@ servers:
 paths:
   /health:
     get:
+      x-rate-limit:
+        policies: [global, perKey]
       summary: Health check
       description: Returns the status of the API service and connectivity.
       operationId: getHealth
@@ -74,8 +76,49 @@ paths:
                 version: 1.0.0
                 timestamp: '2026-01-01T00:00:00.000Z'
 
+  /status:
+    get:
+      x-rate-limit:
+        policies: [global, perKey]
+      summary: Runtime status and rate limit policy snapshot
+      description: Returns indexer lag status plus the active public rate-limit thresholds.
+      responses:
+        "200":
+          description: Runtime status with live rate-limit policy values
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StatusResponse'
+              example:
+                lag: 0
+                warnThreshold: 10
+                criticalThreshold: 50
+                level: none
+                isDegraded: false
+                isCritical: false
+                checkedAt: '2026-01-01T00:00:00.000Z'
+                rateLimits:
+                  global:
+                    id: global
+                    scope: all public API endpoints
+                    limit: 100
+                    windowSeconds: 60
+                    blockSeconds: 60
+                    key: client-ip
+                    headers: [X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset]
+                  perKey:
+                    id: perKey
+                    scope: all API endpoints after authentication context is available
+                    limit: 60
+                    windowSeconds: 60
+                    blockSeconds: 60
+                    key: api-key-or-client-ip
+                    headers: [X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset]
+
   /admin/status:
     get:
+      x-rate-limit:
+        policies: [global, perKey]
       summary: Read internal admin status
       description: Returns troubleshooting details for authenticated admin roles.
       security:
@@ -90,6 +133,8 @@ paths:
 
   /admin/audit-logs:
     get:
+      x-rate-limit:
+        policies: [global, perKey]
       summary: Read admin audit logs
       description: Returns recent authorization and admin action audit entries.
       security:
@@ -107,6 +152,8 @@ paths:
 
   /admin/maintenance:
     post:
+      x-rate-limit:
+        policies: [global, perKey]
       operationId: toggleMaintenanceMode
       summary: Toggle maintenance mode
       description: Restricted to operations admin and super-admin.
@@ -137,6 +184,8 @@ paths:
 
   /admin/backfill:
     post:
+      x-rate-limit:
+        policies: [global, perKey]
       operationId: queueBackfillJob
       summary: Queue a backfill job
       description: Restricted to operations admin and super-admin.
@@ -162,6 +211,8 @@ paths:
 
   /admin/config/dangerous:
     post:
+      x-rate-limit:
+        policies: [global, perKey]
       operationId: updateDangerousAdminConfig
       summary: Update dangerous admin configuration
       description: Restricted to super-admin only.
@@ -193,6 +244,8 @@ paths:
 
   /invoices:
     get:
+      x-rate-limit:
+        policies: [global, perKey]
       summary: List invoices (paginated)
       description: |
         Returns a cursor-paginated list of invoices sorted by `created_at DESC, id ASC`.
@@ -228,6 +281,8 @@ paths:
 
   /invoices/{id}:
     get:
+      x-rate-limit:
+        policies: [global, perKey]
       summary: Get invoice by ID
       operationId: getInvoiceById
       parameters:
@@ -257,6 +312,8 @@ paths:
 
   /bids:
     get:
+      x-rate-limit:
+        policies: [global, perKey]
       summary: List ranked bids for an invoice (paginated)
       description: |
         Returns a cursor-paginated list of ranked bids for a given invoice, sorted by
@@ -309,6 +366,8 @@ paths:
         "400":
           $ref: '#/components/responses/PaginationError'
     post:
+      x-rate-limit:
+        policies: [global, perKey]
       operationId: createBid
       summary: Place a new bid on a Verified invoice
       description: |
@@ -394,6 +453,8 @@ paths:
 
   /bids/{invoiceId}/best:
     get:
+      x-rate-limit:
+        policies: [global, perKey]
       summary: Get the best bid for an invoice
       description: |
         Returns the highest-ranked (best) bid for an invoice, or 404 if no Placed bids exist.
@@ -420,6 +481,8 @@ paths:
 
   /bids/{invoiceId}/ranked:
     get:
+      x-rate-limit:
+        policies: [global, perKey]
       summary: Get all ranked bids for an invoice
       description: |
         Returns all Placed bids for an invoice ranked by contract semantics.
@@ -447,6 +510,8 @@ paths:
 
   /settlements:
     get:
+      x-rate-limit:
+        policies: [global, perKey]
       summary: List settlements (paginated)
       description: |
         Returns a cursor-paginated list of settlements sorted by `timestamp DESC, id ASC`.
@@ -469,6 +534,8 @@ paths:
 
   /settlements/{id}:
     get:
+      x-rate-limit:
+        policies: [global, perKey]
       summary: Get settlement by ID
       operationId: getSettlementById
       parameters:
@@ -498,6 +565,8 @@ paths:
 
   /portfolio:
     get:
+      x-rate-limit:
+        policies: [global, perKey]
       summary: List investor portfolio (paginated)
       description: |
         Returns a cursor-paginated list of portfolio entries for a given investor,
@@ -525,6 +594,8 @@ paths:
 
   /invoices/{id}/disputes:
     get:
+      x-rate-limit:
+        policies: [global, perKey]
       summary: List disputes for an invoice
       operationId: listDisputesByInvoice
       parameters:
@@ -544,6 +615,8 @@ paths:
 
   /notifications/preferences/{userId}:
     get:
+      x-rate-limit:
+        policies: [global, perKey]
       summary: Get user notification preferences
       parameters:
         - name: userId
@@ -562,6 +635,8 @@ paths:
         '404':
           description: User preferences not found
     put:
+      x-rate-limit:
+        policies: [global, perKey]
       operationId: updateNotificationPreferences
       summary: Update user notification preferences
       parameters:
@@ -596,6 +671,8 @@ paths:
 
   /notifications/unsubscribe/{userId}:
     post:
+      x-rate-limit:
+        policies: [global, perKey]
       summary: Unsubscribe user from email notifications
       parameters:
         - name: userId
@@ -610,6 +687,8 @@ paths:
 
   /exports/generate:
     post:
+      x-rate-limit:
+        policies: [global, perKey, export]
       summary: Generate a signed data export link
       description: Returns a short-lived link to download all user-scoped data (invoices, bids, settlements) in CSV or JSON format.
       security:
@@ -643,6 +722,8 @@ paths:
 
   /exports/download/{token}:
     get:
+      x-rate-limit:
+        policies: [global, perKey, export]
       summary: Download exported data
       description: Serves the export file using a signed token.
       parameters:
@@ -667,6 +748,8 @@ paths:
 
   /events:
     post:
+      x-rate-limit:
+        policies: [global, perKey]
       operationId: processBlockchainEvents
       summary: Process blockchain events for notifications
       description: Internal endpoint for indexer to post events that trigger notifications
@@ -707,6 +790,8 @@ paths:
 
   /keys/{id}/rotate-signing-secret:
     post:
+      x-rate-limit:
+        policies: [global, perKey]
       summary: Rotate an API key's signing secret
       description: |
         Generates a new signing secret for the specified API key ID, retaining the old secret for a configurable grace window (default 24h). Requires admin RBAC privileges.
@@ -780,6 +865,91 @@ components:
       bearerFormat: opaque-token
 
   schemas:
+    RateLimitPolicy:
+      type: object
+      description: Public rate-limit policy metadata. Runtime bucket state is intentionally not exposed.
+      required:
+        - id
+        - scope
+        - limit
+        - windowSeconds
+        - blockSeconds
+        - key
+        - headers
+      properties:
+        id:
+          type: string
+          enum: [global, perKey, strict, reconciliation, export]
+        scope:
+          type: string
+        limit:
+          type: integer
+          minimum: 1
+        windowSeconds:
+          type: integer
+          minimum: 1
+        blockSeconds:
+          type: integer
+          minimum: 0
+        key:
+          type: string
+          enum: [client-ip, api-key-or-client-ip]
+        headers:
+          type: array
+          items:
+            type: string
+
+    RateLimitPolicies:
+      type: object
+      required:
+        - global
+        - perKey
+        - strict
+        - reconciliation
+        - export
+      properties:
+        global:
+          $ref: '#/components/schemas/RateLimitPolicy'
+        perKey:
+          $ref: '#/components/schemas/RateLimitPolicy'
+        strict:
+          $ref: '#/components/schemas/RateLimitPolicy'
+        reconciliation:
+          $ref: '#/components/schemas/RateLimitPolicy'
+        export:
+          $ref: '#/components/schemas/RateLimitPolicy'
+
+    StatusResponse:
+      type: object
+      required:
+        - lag
+        - warnThreshold
+        - criticalThreshold
+        - level
+        - isDegraded
+        - isCritical
+        - checkedAt
+        - rateLimits
+      properties:
+        lag:
+          type: integer
+        warnThreshold:
+          type: integer
+        criticalThreshold:
+          type: integer
+        level:
+          type: string
+          enum: [none, warn, critical]
+        isDegraded:
+          type: boolean
+        isCritical:
+          type: boolean
+        checkedAt:
+          type: string
+          format: date-time
+        rateLimits:
+          $ref: '#/components/schemas/RateLimitPolicies'
+
     FreshnessMetadata:
       type: object
       description: >

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -77,7 +77,6 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -567,13 +566,39 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
-    "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
-      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+    "node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -2474,7 +2499,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
       "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.19.0"
       }
@@ -2873,6 +2897,40 @@
       },
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@unrs/resolver-binding-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@unrs/resolver-binding-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@unrs/resolver-binding-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@unrs/resolver-binding-win32-arm64-msvc": {
@@ -3327,7 +3385,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -8398,7 +8455,6 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.21.0.tgz",
       "integrity": "sha512-AUP1EYJuHraQGsVoCQVIcM7TEJVGtDzxWtGFZd8rds9d+CCXlU5Js1rYgfLNvxy9iJrpHjGrRjoi/3BT9fRyiA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.13.0",
         "pg-pool": "^3.14.0",
@@ -9574,7 +9630,6 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -9744,7 +9799,6 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/backend/src/middleware/rate-limit.ts
+++ b/backend/src/middleware/rate-limit.ts
@@ -3,6 +3,98 @@ import { RateLimiterMemory, RateLimiterRes } from "rate-limiter-flexible";
 
 const isTest = process.env.NODE_ENV === "test";
 
+export type RateLimitPolicyId =
+  | "global"
+  | "perKey"
+  | "strict"
+  | "reconciliation"
+  | "export";
+
+export interface RateLimitPolicySnapshot {
+  id: RateLimitPolicyId;
+  scope: string;
+  limit: number;
+  windowSeconds: number;
+  blockSeconds: number;
+  key: "client-ip" | "api-key-or-client-ip";
+  headers: string[];
+}
+
+const RATE_LIMIT_HEADERS = [
+  "X-RateLimit-Limit",
+  "X-RateLimit-Remaining",
+  "X-RateLimit-Reset",
+];
+
+const readPositiveInt = (
+  name: string,
+  fallback: number,
+  testFallback: number = fallback
+): number => {
+  if (isTest) return testFallback;
+  const raw = Number(process.env[name]);
+  return Number.isFinite(raw) && raw > 0 ? raw : fallback;
+};
+
+export const RATE_LIMIT_POLICIES: Record<RateLimitPolicyId, RateLimitPolicySnapshot> = {
+  global: {
+    id: "global",
+    scope: "all public API endpoints",
+    limit: readPositiveInt("RATE_LIMIT_POINTS", 100, 1000),
+    windowSeconds: 60,
+    blockSeconds: 60,
+    key: "client-ip",
+    headers: RATE_LIMIT_HEADERS,
+  },
+  perKey: {
+    id: "perKey",
+    scope: "all API endpoints after authentication context is available",
+    limit: readPositiveInt("RATE_LIMIT_PER_KEY_POINTS", 60, 1000),
+    windowSeconds: 60,
+    blockSeconds: 60,
+    key: "api-key-or-client-ip",
+    headers: RATE_LIMIT_HEADERS,
+  },
+  strict: {
+    id: "strict",
+    scope: "sensitive custom endpoints using strictRateLimitMiddleware",
+    limit: readPositiveInt("RATE_LIMIT_STRICT_POINTS", 5, 100),
+    windowSeconds: 60,
+    blockSeconds: 300,
+    key: "client-ip",
+    headers: RATE_LIMIT_HEADERS,
+  },
+  reconciliation: {
+    id: "reconciliation",
+    scope: "reconciliation and monitoring routes",
+    limit: readPositiveInt("RATE_LIMIT_RECONCILIATION_POINTS", 10, 100),
+    windowSeconds: 60,
+    blockSeconds: 120,
+    key: "api-key-or-client-ip",
+    headers: RATE_LIMIT_HEADERS,
+  },
+  export: {
+    id: "export",
+    scope: "data export generation and download routes",
+    limit: readPositiveInt("RATE_LIMIT_EXPORT_POINTS", 5, 100),
+    windowSeconds: 60,
+    blockSeconds: 120,
+    key: "api-key-or-client-ip",
+    headers: RATE_LIMIT_HEADERS,
+  },
+};
+
+export const getRateLimitPolicies = (): Record<RateLimitPolicyId, RateLimitPolicySnapshot> => ({
+  global: { ...RATE_LIMIT_POLICIES.global, headers: [...RATE_LIMIT_POLICIES.global.headers] },
+  perKey: { ...RATE_LIMIT_POLICIES.perKey, headers: [...RATE_LIMIT_POLICIES.perKey.headers] },
+  strict: { ...RATE_LIMIT_POLICIES.strict, headers: [...RATE_LIMIT_POLICIES.strict.headers] },
+  reconciliation: {
+    ...RATE_LIMIT_POLICIES.reconciliation,
+    headers: [...RATE_LIMIT_POLICIES.reconciliation.headers],
+  },
+  export: { ...RATE_LIMIT_POLICIES.export, headers: [...RATE_LIMIT_POLICIES.export.headers] },
+});
+
 /**
  * Rate limiter configuration
  * 
@@ -11,9 +103,9 @@ const isTest = process.env.NODE_ENV === "test";
  * Test environment: 1000 requests per 60 seconds
  */
 export const rateLimiter = new RateLimiterMemory({
-  points: isTest ? 1000 : Number(process.env.RATE_LIMIT_POINTS) || 100,
-  duration: 60,
-  blockDuration: 60, // Block for 60 seconds if consumed more than points
+  points: RATE_LIMIT_POLICIES.global.limit,
+  duration: RATE_LIMIT_POLICIES.global.windowSeconds,
+  blockDuration: RATE_LIMIT_POLICIES.global.blockSeconds,
 });
 
 /**
@@ -21,27 +113,27 @@ export const rateLimiter = new RateLimiterMemory({
  * Applies a separate bucket for each authenticated API key.
  */
 export const perKeyRateLimiter = new RateLimiterMemory({
-  points: isTest ? 1000 : Number(process.env.RATE_LIMIT_PER_KEY_POINTS) || 60,
-  duration: 60,
-  blockDuration: 60,
+  points: RATE_LIMIT_POLICIES.perKey.limit,
+  duration: RATE_LIMIT_POLICIES.perKey.windowSeconds,
+  blockDuration: RATE_LIMIT_POLICIES.perKey.blockSeconds,
 });
 
 /**
  * Reconciliation-route rate limiter (strict)
  */
 export const reconciliationRateLimiter = new RateLimiterMemory({
-  points: isTest ? 100 : Number(process.env.RATE_LIMIT_RECONCILIATION_POINTS) || 10,
-  duration: 60,
-  blockDuration: 120,
+  points: RATE_LIMIT_POLICIES.reconciliation.limit,
+  duration: RATE_LIMIT_POLICIES.reconciliation.windowSeconds,
+  blockDuration: RATE_LIMIT_POLICIES.reconciliation.blockSeconds,
 });
 
 /**
  * Export-route rate limiter (strict)
  */
 export const exportRateLimiter = new RateLimiterMemory({
-  points: isTest ? 100 : Number(process.env.RATE_LIMIT_EXPORT_POINTS) || 5,
-  duration: 60,
-  blockDuration: 120,
+  points: RATE_LIMIT_POLICIES.export.limit,
+  duration: RATE_LIMIT_POLICIES.export.windowSeconds,
+  blockDuration: RATE_LIMIT_POLICIES.export.blockSeconds,
 });
 
 /**
@@ -161,9 +253,9 @@ export const createKeyedRateLimitMiddleware = (customLimiter: RateLimiterMemory)
  * 5 requests per minute
  */
 export const strictRateLimiter = new RateLimiterMemory({
-  points: process.env.NODE_ENV === "test" ? 100 : 5,
-  duration: 60,
-  blockDuration: 300, // Block for 5 minutes
+  points: RATE_LIMIT_POLICIES.strict.limit,
+  duration: RATE_LIMIT_POLICIES.strict.windowSeconds,
+  blockDuration: RATE_LIMIT_POLICIES.strict.blockSeconds,
 });
 
 export const strictRateLimitMiddleware = createRateLimitMiddleware(strictRateLimiter);

--- a/backend/src/routes/v1/index.ts
+++ b/backend/src/routes/v1/index.ts
@@ -21,6 +21,7 @@ import {
   SorobanEvent,
 } from "../../services/eventValidator";
 import { FileRawEventStore } from "../../services/rawEventStore";
+import { getRateLimitPolicies } from "../../middleware/rate-limit";
 
 const router = Router();
 const eventIdStore = new FileRawEventStore(new DefaultEventValidator());
@@ -46,7 +47,10 @@ router.use("/reconciliation", reconciliationRoutes);
 router.get("/status", async (req, res, next) => {
   try {
     const lagStatus = await lagMonitor.getLagStatus();
-    res.json(lagStatus);
+    res.json({
+      ...lagStatus,
+      rateLimits: getRateLimitPolicies(),
+    });
   } catch (err) {
     next(err);
   }

--- a/backend/tests/rate-limit-conformance.test.ts
+++ b/backend/tests/rate-limit-conformance.test.ts
@@ -1,0 +1,64 @@
+import request from "supertest";
+import app from "../src/app";
+import { RATE_LIMIT_POLICIES } from "../src/middleware/rate-limit";
+import { loadOpenApiDoc } from "../src/tests/helpers/openapi-loader";
+
+const HTTP_METHODS = new Set(["get", "post", "put", "patch", "delete", "head", "options"]);
+
+type RateLimitExtension = {
+  policies: Array<keyof typeof RATE_LIMIT_POLICIES>;
+};
+
+function operations() {
+  const doc = loadOpenApiDoc();
+  return Object.entries(doc.paths).flatMap(([path, pathItem]) =>
+    Object.entries(pathItem)
+      .filter(([method]) => HTTP_METHODS.has(method))
+      .map(([method, operation]) => ({
+        path,
+        method,
+        operation: operation as { "x-rate-limit"?: RateLimitExtension },
+      }))
+  );
+}
+
+describe("rate-limit OpenAPI conformance", () => {
+  it("documents an x-rate-limit extension on every operation", () => {
+    for (const { path, method, operation } of operations()) {
+      expect(operation["x-rate-limit"]).toBeDefined();
+      expect(operation["x-rate-limit"]?.policies?.length).toBeGreaterThan(0);
+
+      for (const policy of operation["x-rate-limit"]?.policies ?? []) {
+        expect(RATE_LIMIT_POLICIES[policy]).toBeDefined();
+      }
+
+      expect(`${method.toUpperCase()} ${path}`).toBeTruthy();
+    }
+  });
+
+  it("marks export operations with the stricter export policy", () => {
+    const exportOperations = operations().filter(({ path }) => path.startsWith("/exports/"));
+    expect(exportOperations.length).toBeGreaterThan(0);
+
+    for (const { operation } of exportOperations) {
+      expect(operation["x-rate-limit"]?.policies).toEqual(
+        expect.arrayContaining(["global", "perKey", "export"])
+      );
+    }
+  });
+
+  it("exposes live limiter thresholds in GET /api/v1/status without bucket details", async () => {
+    const res = await request(app).get("/api/v1/status");
+
+    expect(res.status).toBe(200);
+    expect(res.body.rateLimits.global.limit).toBe(RATE_LIMIT_POLICIES.global.limit);
+    expect(res.body.rateLimits.perKey.limit).toBe(RATE_LIMIT_POLICIES.perKey.limit);
+    expect(res.body.rateLimits.export.limit).toBe(RATE_LIMIT_POLICIES.export.limit);
+
+    const serialized = JSON.stringify(res.body.rateLimits);
+    expect(serialized).not.toContain("127.0.0.1");
+    expect(serialized).not.toContain("remainingPoints");
+    expect(serialized).not.toContain("consumedPoints");
+    expect(serialized).not.toContain("msBeforeNext");
+  });
+});


### PR DESCRIPTION
Closes #1174

## Summary
- Adds shared rate-limit policy metadata used by the live middleware and `/api/v1/status`
- Documents `x-rate-limit` on every OpenAPI operation, with export endpoints marked with `global`, `perKey`, and `export` policies
- Adds status response schemas, rate-limit docs, and conformance coverage

## Tests
- `npm test -- rate-limit-conformance --runInBand`
- `npm test -- rate-limit --runInBand`

Note: `npm ci` is currently blocked by the existing package-lock/package.json mismatch, so local verification used install without changing the lockfile plus a rebuild of `better-sqlite3`.