### PR TITLE
feat: add withdraw_investment entrypoint with tests

### DIFF
--- a/quicklendx-contracts/src/escrow.rs
+++ b/quicklendx-contracts/src/escrow.rs
@@ -18,8 +18,8 @@
 
 use crate::admin::AdminStorage;
 use crate::errors::QuickLendXError;
-use crate::events::{emit_escrow_refunded, emit_invoice_funded};
-use crate::payments::{create_escrow, refund_escrow, EscrowStorage};
+use crate::events::{emit_escrow_refunded, emit_investment_withdrawn, emit_invoice_funded};
+use crate::payments::{create_escrow, refund_escrow, EscrowStatus, EscrowStorage};
 use crate::storage::{BidStorage, InvestmentStorage, InvoiceStorage};
 use crate::types::{BidStatus, Investment, InvestmentStatus, InvoiceStatus};
 use crate::verification::require_business_not_pending;
@@ -264,6 +264,132 @@ pub fn refund_escrow_funds(
         &escrow.escrow_id,
         invoice_id,
         &escrow.investor,
+        escrow.amount,
+    );
+
+    Ok(())
+}
+
+/// Withdraw an active investment: refunds escrowed funds to the investor and
+/// transitions the investment to [`InvestmentStatus::Withdrawn`].
+///
+/// Only the investor who owns the investment may call this entry point.
+///
+/// # Preconditions (checked)
+/// - `investor` is authorized
+/// - The investment exists, is in [`InvestmentStatus::Active`], and belongs to `investor`
+/// - The associated escrow is still [`EscrowStatus::Held`] (funds have not been released)
+/// - The invoice is in [`InvoiceStatus::Funded`] (no settlement has occurred)
+///
+/// # Postconditions
+/// - Escrowed funds are returned to the investor via the existing `refund_escrow` path
+/// - The investment transitions `Active → Withdrawn` via `InvestmentStorage::update_investment`,
+///   which enforces `validate_transition` and removes the investment from the active index
+/// - The invoice has its funded fields cleared and status restored to `Verified`
+/// - The accepted bid is cancelled
+/// - A [`TOPIC_INVESTMENT_WITHDRAWN`] event is emitted
+///
+/// # Reentrancy
+/// The token-moving path is wrapped in `with_payment_guard` by the caller (lib.rs entrypoint).
+/// This function performs the refund before updating state, so a reentrant call would
+/// fail at the escrow status check (escrow no longer `Held`).
+///
+/// # Security
+/// - Authorization: `investor.require_auth()` ensures only the investor can withdraw
+/// - Escrow guard: `payments::refund_escrow` rejects any escrow not in `Held` status,
+///   preventing double-withdrawal even if `withdraw_investment` is called again
+/// - Transition guard: `InvestmentStorage::update_investment` calls `validate_transition`,
+///   rejecting any attempt to withdraw from a terminal state
+/// - Cross-module consistency: invoice, escrow, bid, and investment state are all updated
+///   atomically in the same function body, preserving the protocol's state machine
+///
+/// # Errors
+/// * `QuickLendXError::Unauthorized` — caller is not the investment's investor
+/// * `QuickLendXError::InvalidStatus` — investment is not Active, or escrow is not Held
+/// * `QuickLendXError::InvoiceNotFound` — invoice not found
+/// * `QuickLendXError::InvoiceNotAvailableForFunding` — invoice is not in Funded status
+/// * `QuickLendXError::StorageKeyNotFound` — escrow not found for the invoice
+pub fn withdraw_investment(
+    env: &Env,
+    invoice_id: &BytesN<32>,
+    investor: &Address,
+) -> Result<(), QuickLendXError> {
+    // 1. Mandatory authentication check
+    investor.require_auth();
+
+    // 2. Validate investment exists, is Active, and belongs to caller
+    let mut investment = InvestmentStorage::get_investment_by_invoice(env, invoice_id)
+        .ok_or(QuickLendXError::StorageKeyNotFound)?;
+
+    if investment.status != InvestmentStatus::Active {
+        return Err(QuickLendXError::InvalidStatus);
+    }
+
+    if &investment.investor != investor {
+        return Err(QuickLendXError::Unauthorized);
+    }
+
+    // 3. Validate invoice is still Funded (not yet settled/paid/defaulted)
+    let mut invoice =
+        InvoiceStorage::get_invoice(env, invoice_id).ok_or(QuickLendXError::InvoiceNotFound)?;
+
+    if invoice.status != InvoiceStatus::Funded {
+        return Err(QuickLendXError::InvalidStatus);
+    }
+
+    // 4. Validate escrow exists and is still Held
+    let escrow = EscrowStorage::get_escrow_by_invoice(env, invoice_id)
+        .ok_or(QuickLendXError::StorageKeyNotFound)?;
+
+    if escrow.status != EscrowStatus::Held {
+        return Err(QuickLendXError::InvalidStatus);
+    }
+
+    // 5. Refund escrowed funds to the investor (token transfer + escrow status → Refunded)
+    refund_escrow(env, invoice_id)?;
+
+    // 6. Restore invoice to Verified state and clear funded fields
+    let previous_status = invoice.status.clone();
+    invoice.status = InvoiceStatus::Verified;
+    invoice.funded_amount = 0;
+    invoice.funded_at = None;
+    invoice.investor = None;
+    InvoiceStorage::update_invoice(env, &invoice);
+
+    // Update invoice status lists
+    InvoiceStorage::remove_from_status_invoices(env, previous_status, invoice_id);
+    InvoiceStorage::add_to_status_invoices(env, InvoiceStatus::Verified, invoice_id);
+
+    // 7. Cancel the accepted bid
+    let bids = BidStorage::get_bid_records_for_invoice(env, invoice_id);
+    for mut bid in bids.iter() {
+        if bid.status == BidStatus::Accepted {
+            bid.status = BidStatus::Cancelled;
+            BidStorage::update_bid(env, &bid);
+            break;
+        }
+    }
+
+    // 8. Transition investment Active → Withdrawn
+    investment.status = InvestmentStatus::Withdrawn;
+    InvestmentStorage::update_investment(env, &investment);
+
+    crate::qlx_log!(env, "escrow", "Investment withdrawn successfully");
+
+    // 9. Emit events
+    emit_investment_withdrawn(
+        env,
+        &investment.investment_id,
+        invoice_id,
+        investor,
+        escrow.amount,
+    );
+
+    emit_escrow_refunded(
+        env,
+        &escrow.escrow_id,
+        invoice_id,
+        investor,
         escrow.amount,
     );
 

--- a/quicklendx-contracts/src/events.rs
+++ b/quicklendx-contracts/src/events.rs
@@ -50,6 +50,8 @@ pub const TOPIC_ESCROW_CREATED: &str = "escrow_created";
 pub const TOPIC_ESCROW_RELEASED: &str = "escrow_released";
 /// Topic for `EscrowRefunded` events.
 pub const TOPIC_ESCROW_REFUNDED: &str = "escrow_refunded";
+/// Topic for `InvestmentWithdrawn` events.
+pub const TOPIC_INVESTMENT_WITHDRAWN: &str = "investment_withdrawn";
 /// Topic for `DisputeCreated` / `DisputeOpened` events.
 pub const TOPIC_DISPUTE_CREATED: &str = "dispute_created";
 /// Topic for `DisputeUnderReview` events.
@@ -318,6 +320,18 @@ pub struct EscrowReleased {
 #[contractevent]
 pub struct EscrowRefunded {
     pub escrow_id: BytesN<32>,
+    pub invoice_id: BytesN<32>,
+    pub investor: Address,
+    pub amount: i128,
+}
+
+/// Emitted when an investor withdraws their investment before settlement.
+///
+/// Topic: [`TOPIC_INVESTMENT_WITHDRAWN`] (`"inv_wd"`)
+#[derive(Debug, PartialEq)]
+#[contractevent]
+pub struct InvestmentWithdrawn {
+    pub investment_id: BytesN<32>,
     pub invoice_id: BytesN<32>,
     pub investor: Address,
     pub amount: i128,
@@ -949,6 +963,22 @@ pub fn emit_escrow_refunded(
 ) {
     EscrowRefunded {
         escrow_id: escrow_id.clone(),
+        invoice_id: invoice_id.clone(),
+        investor: investor.clone(),
+        amount,
+    }
+    .publish(env);
+}
+
+pub fn emit_investment_withdrawn(
+    env: &Env,
+    investment_id: &BytesN<32>,
+    invoice_id: &BytesN<32>,
+    investor: &Address,
+    amount: i128,
+) {
+    InvestmentWithdrawn {
+        investment_id: investment_id.clone(),
         invoice_id: invoice_id.clone(),
         investor: investor.clone(),
         amount,

--- a/quicklendx-contracts/src/lib.rs
+++ b/quicklendx-contracts/src/lib.rs
@@ -175,6 +175,8 @@ mod test_treasury_split_overflow_props;
 mod test_init_invariants;
 #[cfg(test)]
 mod test_input_matrix;
+#[cfg(test)]
+mod test_investment_withdrawal;
 #[cfg(all(test, feature = "legacy-tests"))]
 mod test_investment_transitions;
 #[cfg(test)]
@@ -204,6 +206,7 @@ use defaults::{
 use errors::QuickLendXError;
 use escrow::{
     accept_bid_and_fund as do_accept_bid_and_fund, refund_escrow_funds as do_refund_escrow_funds,
+    withdraw_investment as do_withdraw_investment,
 };
 use events::{
     emit_bid_accepted, emit_bid_placed, emit_bid_withdrawn, emit_dispute_created,
@@ -2122,6 +2125,36 @@ impl QuickLendXContract {
     ) -> Result<(), QuickLendXError> {
         pause::PauseControl::require_not_paused(&env)?;
         reentrancy::with_payment_guard(&env, || do_refund_escrow_funds(&env, &invoice_id, &caller))
+    }
+
+    /// Withdraw an active investment, refunding escrowed funds to the investor.
+    ///
+    /// Only the investor may call this. The investment must be in `Active` status
+    /// and the associated escrow must still be `Held` (funds not yet released to
+    /// the business). On success the investment transitions `Active → Withdrawn`,
+    /// the invoice is restored to a fundable state, and the accepted bid is cancelled.
+    ///
+    /// Protected by payment reentrancy guard (see docs/contracts/security.md).
+    ///
+    /// # Returns
+    /// * `Ok(())` on successful withdrawal
+    ///
+    /// # Errors
+    /// * `Unauthorized` — caller is not the investment's investor
+    /// * `InvalidStatus` — investment is not Active, or escrow is not Held
+    /// * `InvoiceNotFound`, `StorageKeyNotFound`
+    /// * `ContractPaused` if the protocol is paused
+    /// * `OperationNotAllowed` if reentrancy is detected
+    ///
+    /// Pause-gated: rejects with `ContractPaused` when the emergency circuit
+    /// breaker is engaged, before any funds move.
+    pub fn withdraw_investment(
+        env: Env,
+        invoice_id: BytesN<32>,
+        investor: Address,
+    ) -> Result<(), QuickLendXError> {
+        pause::PauseControl::require_not_paused(&env)?;
+        reentrancy::with_payment_guard(&env, || do_withdraw_investment(&env, &invoice_id, &investor))
     }
 
     /// Check for overdue invoices and send notifications (admin or automated process)

--- a/quicklendx-contracts/src/test_investment_transitions.rs
+++ b/quicklendx-contracts/src/test_investment_transitions.rs
@@ -293,18 +293,15 @@ fn test_transition_active_to_withdrawn() {
     // Verify initial state
     let investment = ctx.get_investment(&invoice_id);
     assert_eq!(investment.status, InvestmentStatus::Active);
+    assert!(ctx.is_in_active_index(&investment.investment_id));
 
-    // Investor withdraws (before settlement or other terminal event)
-    // Note: This depends on the contract having a withdraw_investment function
-    // For now, we document the expectation
-    let _investment_id = investment.investment_id.clone();
+    // Investor withdraws
+    ctx.client.withdraw_investment(&invoice_id, &investor);
 
-    // If withdraw is possible from Active state:
-    // ctx.client.withdraw_investment(&_investment_id);
-    // let withdrawn_investment = ctx.get_investment(&invoice_id);
-    // assert_eq!(withdrawn_investment.status, InvestmentStatus::Withdrawn);
-    // assert!(!ctx.is_in_active_index(&_investment_id));
-    // ctx.assert_no_orphans();
+    let withdrawn_investment = ctx.get_investment(&invoice_id);
+    assert_eq!(withdrawn_investment.status, InvestmentStatus::Withdrawn);
+    assert!(!ctx.is_in_active_index(&withdrawn_investment.investment_id));
+    ctx.assert_no_orphans();
 }
 
 // ────────────────────────────────────────────────────────────────────────────

--- a/quicklendx-contracts/src/test_investment_withdrawal.rs
+++ b/quicklendx-contracts/src/test_investment_withdrawal.rs
@@ -1,0 +1,357 @@
+use super::*;
+use crate::alloc::string::ToString;
+use crate::errors::QuickLendXError;
+use crate::investment::{InvestmentStatus, InvestmentStorage};
+use crate::invoice::InvoiceCategory;
+use crate::payments::{EscrowStatus, EscrowStorage};
+use crate::types::InvoiceStatus;
+use crate::events::TOPIC_INVESTMENT_WITHDRAWN;
+use soroban_sdk::{
+    testutils::{Address as _, Events, Ledger},
+    token, xdr, Address, BytesN, Env, String, Symbol, TryFromVal, Val, Vec,
+};
+
+fn setup_env() -> (Env, QuickLendXContractClient<'static>, Address, Address, Address, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+    let contract_id = env.register(QuickLendXContract, ());
+    let client = QuickLendXContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    client.set_admin(&admin);
+    client.initialize_fee_system(&admin);
+    let business = Address::generate(&env);
+    let investor = Address::generate(&env);
+    (env, client, contract_id, admin, business, investor)
+}
+
+fn make_token(
+    env: &Env,
+    contract_id: &Address,
+    business: &Address,
+    investor: &Address,
+) -> Address {
+    let token_admin = Address::generate(env);
+    let currency = env
+        .register_stellar_asset_contract_v2(token_admin)
+        .address();
+    let sac = token::StellarAssetClient::new(env, &currency);
+    sac.mint(business, &100_000i128);
+    sac.mint(investor, &100_000i128);
+    sac.mint(contract_id, &1i128);
+    let tok = token::Client::new(env, &currency);
+    let exp = env.ledger().sequence() + 50_000;
+    tok.approve(business, contract_id, &400_000i128, &exp);
+    tok.approve(investor, contract_id, &400_000i128, &exp);
+    currency
+}
+
+fn setup_funded_investment(
+    env: &Env,
+    client: &QuickLendXContractClient<'static>,
+    admin: &Address,
+    business: &Address,
+    investor: &Address,
+    currency: &Address,
+    invoice_amount: i128,
+    bid_amount: i128,
+) -> BytesN<32> {
+    client.submit_kyc_application(business, &String::from_str(env, "KYC"));
+    client.verify_business(admin, business);
+
+    client.submit_investor_kyc(investor, &String::from_str(env, "KYC"));
+    client.verify_investor(investor, &200_000i128);
+
+    let due_date = env.ledger().timestamp() + 86_400;
+    let invoice_id = client.upload_invoice(
+        business,
+        &invoice_amount,
+        currency,
+        &due_date,
+        &String::from_str(env, "Test invoice"),
+        &InvoiceCategory::Services,
+        &Vec::new(env),
+    );
+    client.verify_invoice(&invoice_id);
+
+    let bid_id = client.place_bid(investor, &invoice_id, &bid_amount, &(bid_amount + 100));
+    client.accept_bid(&invoice_id, &bid_id);
+
+    invoice_id
+}
+
+fn get_investment(
+    env: &Env,
+    contract_id: &Address,
+    invoice_id: &BytesN<32>,
+) -> crate::types::Investment {
+    env.as_contract(contract_id, || {
+        InvestmentStorage::get_investment_by_invoice(env, invoice_id)
+            .expect("Investment should exist")
+    })
+}
+
+fn is_in_active_index(
+    env: &Env,
+    contract_id: &Address,
+    investment_id: &BytesN<32>,
+) -> bool {
+    env.as_contract(contract_id, || {
+        InvestmentStorage::get_active_investment_ids(env)
+            .iter()
+            .any(|id| id == *investment_id)
+    })
+}
+
+/// Test: Investor successfully withdraws an active investment
+#[test]
+fn test_withdrawal_success() {
+    let (env, client, contract_id, admin, business, investor) = setup_env();
+    let currency = make_token(&env, &contract_id, &business, &investor);
+
+    let invoice_id = setup_funded_investment(
+        &env, &client, &admin, &business, &investor, &currency, 1000, 1000,
+    );
+
+    let investment = get_investment(&env, &contract_id, &invoice_id);
+    assert_eq!(investment.status, InvestmentStatus::Active);
+    assert!(is_in_active_index(&env, &contract_id, &investment.investment_id));
+
+    client.withdraw_investment(&invoice_id, &investor);
+
+    let withdrawn = get_investment(&env, &contract_id, &invoice_id);
+    assert_eq!(withdrawn.status, InvestmentStatus::Withdrawn);
+    assert!(!is_in_active_index(&env, &contract_id, &investment.investment_id));
+
+    let invoice = client.get_invoice(&invoice_id);
+    assert_eq!(invoice.status, InvoiceStatus::Verified);
+    assert_eq!(invoice.funded_amount, 0);
+    assert!(invoice.funded_at.is_none());
+    assert!(invoice.investor.is_none());
+
+    let escrow = env.as_contract(&contract_id, || {
+        EscrowStorage::get_escrow_by_invoice(&env, &invoice_id).unwrap()
+    });
+    assert_eq!(escrow.status, EscrowStatus::Refunded);
+
+    assert!(env.as_contract(&contract_id, || {
+        InvestmentStorage::validate_no_orphan_investments(&env)
+    }));
+}
+
+/// Test: Withdrawal after settlement (already Completed) is rejected
+#[test]
+fn test_withdraw_after_settlement_rejected() {
+    let (env, client, contract_id, admin, business, investor) = setup_env();
+    let currency = make_token(&env, &contract_id, &business, &investor);
+
+    let invoice_id = setup_funded_investment(
+        &env, &client, &admin, &business, &investor, &currency, 1000, 1000,
+    );
+
+    client.settle_invoice(&invoice_id, &1000);
+
+    let err = client.try_withdraw_investment(&invoice_id, &investor).unwrap_err().unwrap();
+    assert_eq!(err, QuickLendXError::InvalidStatus);
+}
+
+/// Test: Withdrawal by non-investor is rejected
+#[test]
+fn test_withdraw_by_non_investor_rejected() {
+    let (env, client, contract_id, admin, business, investor) = setup_env();
+    let currency = make_token(&env, &contract_id, &business, &investor);
+
+    let invoice_id = setup_funded_investment(
+        &env, &client, &admin, &business, &investor, &currency, 1000, 1000,
+    );
+
+    let stranger = Address::generate(&env);
+
+    let err = client.try_withdraw_investment(&invoice_id, &stranger).unwrap_err().unwrap();
+    assert_eq!(err, QuickLendXError::Unauthorized);
+}
+
+/// Test: Double withdrawal is rejected (investment already terminal)
+#[test]
+fn test_double_withdraw_rejected() {
+    let (env, client, contract_id, admin, business, investor) = setup_env();
+    let currency = make_token(&env, &contract_id, &business, &investor);
+
+    let invoice_id = setup_funded_investment(
+        &env, &client, &admin, &business, &investor, &currency, 1000, 1000,
+    );
+
+    client.withdraw_investment(&invoice_id, &investor);
+
+    let err = client.try_withdraw_investment(&invoice_id, &investor).unwrap_err().unwrap();
+    assert_eq!(err, QuickLendXError::InvalidStatus);
+}
+
+/// Test: Withdrawal when escrow already released is rejected
+#[test]
+fn test_withdraw_after_escrow_released_rejected() {
+    let (env, client, contract_id, admin, business, investor) = setup_env();
+    let currency = make_token(&env, &contract_id, &business, &investor);
+
+    let invoice_id = setup_funded_investment(
+        &env, &client, &admin, &business, &investor, &currency, 1000, 1000,
+    );
+
+    client.release_escrow_funds(&invoice_id);
+
+    let err = client.try_withdraw_investment(&invoice_id, &investor).unwrap_err().unwrap();
+    assert_eq!(err, QuickLendXError::InvalidStatus);
+}
+
+/// Test: Withdrawal when escrow already refunded is rejected
+#[test]
+fn test_withdraw_after_escrow_refunded_rejected() {
+    let (env, client, contract_id, admin, business, investor) = setup_env();
+    let currency = make_token(&env, &contract_id, &business, &investor);
+
+    let invoice_id = setup_funded_investment(
+        &env, &client, &admin, &business, &investor, &currency, 1000, 1000,
+    );
+
+    client.refund_escrow_funds(&invoice_id, &business);
+
+    let err = client.try_withdraw_investment(&invoice_id, &investor).unwrap_err().unwrap();
+    assert_eq!(err, QuickLendXError::InvalidStatus);
+}
+
+fn count_events_with_topic(env: &Env, topic_str: &str) -> usize {
+    let topic_sym = Symbol::new(env, topic_str);
+    let topic_xdr = xdr::ScVal::try_from_val(env, &topic_sym).expect("topic to ScVal");
+    env.events()
+        .all()
+        .events()
+        .iter()
+        .filter(|e| match &e.body {
+            xdr::ContractEventBody::V0(body) => body.topics.first() == Some(&topic_xdr),
+        })
+        .count()
+}
+
+/// Test: Event emission for successful withdrawal
+#[test]
+fn test_withdrawal_emits_events() {
+    let (env, client, contract_id, admin, business, investor) = setup_env();
+    let currency = make_token(&env, &contract_id, &business, &investor);
+
+    let invoice_id = setup_funded_investment(
+        &env, &client, &admin, &business, &investor, &currency, 1000, 1000,
+    );
+
+    let before = count_events_with_topic(&env, TOPIC_INVESTMENT_WITHDRAWN);
+    client.withdraw_investment(&invoice_id, &investor);
+    let after = count_events_with_topic(&env, TOPIC_INVESTMENT_WITHDRAWN);
+    assert_eq!(after, before + 1, "withdrawal should emit exactly one InvestmentWithdrawn event");
+}
+
+/// Test: Withdrawn investment is immutable (no further transitions)
+#[test]
+fn test_withdrawn_immutable() {
+    let result = InvestmentStatus::validate_transition(
+        &InvestmentStatus::Withdrawn,
+        &InvestmentStatus::Active,
+    );
+    assert!(result.is_err());
+
+    let result = InvestmentStatus::validate_transition(
+        &InvestmentStatus::Withdrawn,
+        &InvestmentStatus::Completed,
+    );
+    assert!(result.is_err());
+
+    let result = InvestmentStatus::validate_transition(
+        &InvestmentStatus::Withdrawn,
+        &InvestmentStatus::Defaulted,
+    );
+    assert!(result.is_err());
+
+    let result = InvestmentStatus::validate_transition(
+        &InvestmentStatus::Withdrawn,
+        &InvestmentStatus::Refunded,
+    );
+    assert!(result.is_err());
+}
+
+/// Test: Active index does not contain withdrawn investments
+#[test]
+fn test_withdrawn_not_in_active_index() {
+    let (env, client, contract_id, admin, business, investor) = setup_env();
+    let currency = make_token(&env, &contract_id, &business, &investor);
+
+    let invoice_id = setup_funded_investment(
+        &env, &client, &admin, &business, &investor, &currency, 1000, 1000,
+    );
+
+    let investment = get_investment(&env, &contract_id, &invoice_id);
+    client.withdraw_investment(&invoice_id, &investor);
+
+    env.as_contract(&contract_id, || {
+        let active_ids = InvestmentStorage::get_active_investment_ids(&env);
+        for id in active_ids.iter() {
+            let inv = InvestmentStorage::get_investment(&env, &id).unwrap();
+            assert_eq!(inv.status, InvestmentStatus::Active);
+        }
+    });
+    assert!(!is_in_active_index(&env, &contract_id, &investment.investment_id));
+    assert!(env.as_contract(&contract_id, || {
+        InvestmentStorage::validate_no_orphan_investments(&env)
+    }));
+}
+
+/// Test: Reentrant withdrawal inside payment guard is rejected
+#[test]
+fn test_withdraw_reentrant_rejected() {
+    let (env, client, contract_id, admin, business, investor) = setup_env();
+    let currency = make_token(&env, &contract_id, &business, &investor);
+
+    let invoice_id = setup_funded_investment(
+        &env, &client, &admin, &business, &investor, &currency, 1000, 1000,
+    );
+
+    let guard_key = soroban_sdk::symbol_short!("pay_lock");
+    env.as_contract(&contract_id, || {
+        env.storage().instance().set(&guard_key, &true);
+    });
+
+    let err = client.try_withdraw_investment(&invoice_id, &investor).unwrap_err().unwrap();
+    assert_eq!(err, QuickLendXError::OperationNotAllowed);
+
+    env.as_contract(&contract_id, || {
+        env.storage().instance().set(&guard_key, &false);
+    });
+}
+
+/// Test: Investor can invest in a new invoice after withdrawal
+#[test]
+fn test_investor_can_invest_again_after_withdrawal() {
+    let (env, client, contract_id, admin, business, investor) = setup_env();
+    let currency = make_token(&env, &contract_id, &business, &investor);
+
+    let invoice_id = setup_funded_investment(
+        &env, &client, &admin, &business, &investor, &currency, 1000, 1000,
+    );
+
+    client.withdraw_investment(&invoice_id, &investor);
+
+    let due_date = env.ledger().timestamp() + 86_400;
+    let invoice2_id = client.upload_invoice(
+        &business,
+        &2000,
+        &currency,
+        &due_date,
+        &String::from_str(&env, "Second invoice"),
+        &InvoiceCategory::Services,
+        &Vec::new(&env),
+    );
+    client.verify_invoice(&invoice2_id);
+
+    let bid2_id = client.place_bid(&investor, &invoice2_id, &2000, &2100);
+    client.accept_bid(&invoice2_id, &bid2_id);
+
+    let investment2 = get_investment(&env, &contract_id, &invoice2_id);
+    assert_eq!(investment2.status, InvestmentStatus::Active);
+}


### PR DESCRIPTION
- Add InvestmentWithdrawn event, emit_investment_withdrawn helper
- Add withdraw_investment in escrow.rs with reentrancy guard
- Wire entrypoint in lib.rs
- Add 11 tests (success, rejection cases, events, reentrancy, re-invest)

closes: #1349 