### PR TITLE
feat: propagate request_id through audit log and outbound RPC headers

### DIFF
--- a/backend/docs/audit-log.md
+++ b/backend/docs/audit-log.md
@@ -32,6 +32,7 @@ Each line in a `.jsonl` file is a valid JSON object:
   },
   "ip": "10.0.0.42",
   "userAgent": "curl/8.4.0",
+  "requestId": "01ARZ3NDEKTSV4RRFFQ69G5FAV",
   "effect": "Webhook secret rotated for keyId: wh-live-key-001",
   "success": true
 }
@@ -49,6 +50,7 @@ Each line in a `.jsonl` file is a valid JSON object:
 | `redactedParams` | object | Same as params, sensitive fields replaced |
 | `ip` | string | Client IP (first IP from X-Forwarded-For) |
 | `userAgent` | string | Client User-Agent header |
+| `requestId` | string? | Correlation/request id of the originating API call, propagated from the inbound `X-Request-Id` header via async-local-storage. Absent for entries written outside a request scope (e.g. background workers). |
 | `effect` | string | Human-readable summary of the resulting change |
 | `success` | boolean | Whether the operation completed successfully |
 | `errorMessage` | string? | Error message if `success` is false |

--- a/backend/docs/logging.md
+++ b/backend/docs/logging.md
@@ -59,6 +59,42 @@ X-Request-Id: client-123  ──►   X-Request-Id: client-123  (if valid)
                               X-Request-Id: 01H9K4W2... (if invalid/missing)
 ```
 
+### Down-Stack Propagation: Audit Log & Outbound RPC
+
+The correlation id (request id) flows through the entire backend call stack
+without manual threading. The chain is:
+
+```
+Inbound HTTP request
+  │  X-Request-Id: client-123   (or absent → server-generated ULID)
+  ▼
+request-logger middleware
+  │  sanitize / generate id, echo X-Request-Id response header,
+  │  open AsyncLocalStorage context: withCorrelationId(id, next)
+  ▼
+Route handlers & service layer (run inside the ALS context)
+  ├─► auditService.append()      → getCorrelationId() → AuditEntry.requestId
+  └─► rpcClient.call()           → getCorrelationId() → X-Request-Id header
+                                                         on the outbound
+                                                         Soroban RPC request
+```
+
+Because the context is opened with `AsyncLocalStorage`, the id survives
+`await`, `setTimeout`, `setImmediate`, and Promise chains, so async callbacks
+observe the correct id and concurrent requests never cross-contaminate.
+
+**Audit entries** (`src/services/auditService.ts`): every entry written within a
+request scope is stamped with `requestId` taken from the active context, so a
+backend mutation (e.g. `WEBHOOK_SECRET_ROTATE`) can be traced back to the API
+call that triggered it. An explicit `requestId` on the entry takes precedence;
+otherwise the field is omitted when no context is active (background workers).
+See [`docs/audit-log.md`](./audit-log.md).
+
+**Outbound RPC** (`src/services/rpcClient.ts`): the reliable RPC client forwards
+the active id as an `X-Request-Id` header on every JSON-RPC call to the upstream
+Soroban RPC, extending the trace beyond the QuickLendX backend. When there is no
+request context the header is simply omitted.
+
 ### Implementation Details
 
 **Request Context Storage**
@@ -66,6 +102,8 @@ X-Request-Id: client-123  ──►   X-Request-Id: client-123  (if valid)
 - Uses Node.js `AsyncLocalStorage` for thread-safe context propagation
 - Automatic context isolation prevents bleeding between concurrent requests
 - Context is automatically available in all downstream async operations
+- `request-logger.ts` opens the context via `withCorrelationId(id, next)`, so
+  the id is live for the full duration of request handling
 
 **Middleware Integration**
 

--- a/backend/src/lib/requestContext.ts
+++ b/backend/src/lib/requestContext.ts
@@ -31,10 +31,19 @@ export function runWithContext<T>(correlationId: string, fn: () => T): T {
 
 /**
  * Get the correlation ID for the current async context.
- * Returns undefined if called outside a request context.
+ * Returns null if called outside a request context.
  */
-export function getCorrelationId(): string | undefined {
-  return storage.getStore()?.correlationId;
+export function getCorrelationId(): string | null {
+  return storage.getStore()?.correlationId ?? null;
+}
+
+/**
+ * Return the correlation ID for the current async context, or generate a new
+ * ULID when no context is active. Useful for code paths (background workers,
+ * scheduled jobs) that may run with or without an inbound request.
+ */
+export function getOrGenerateCorrelationId(): string {
+  return getCorrelationId() ?? generateCorrelationId();
 }
 
 /**
@@ -55,13 +64,41 @@ export function generateCorrelationId(): string {
 
 /**
  * Sanitize a client-supplied correlation ID to prevent log injection.
- * Accepts only alphanumeric characters and hyphens, max 128 chars.
- * Returns null if the value fails validation.
+ *
+ * Leading/trailing whitespace is trimmed, then the value must consist solely
+ * of alphanumerics, hyphens, and underscores and be 1–128 characters long.
+ * Any other character (newlines, carriage returns, tabs, ANSI escapes, null
+ * bytes, internal spaces, …) causes the value to be rejected. Returns null
+ * when validation fails.
  */
 export function sanitizeCorrelationId(raw: unknown): string | null {
   if (typeof raw !== "string") return null;
-  const sanitized = raw.replace(/[^a-zA-Z0-9\-]/g, "");
-  if (sanitized.length === 0 || sanitized.length > 128) return null;
-  if (sanitized !== raw) return null;
-  return sanitized;
+  const trimmed = raw.trim();
+  if (trimmed.length === 0 || trimmed.length > 128) return null;
+  if (!/^[A-Za-z0-9_-]+$/.test(trimmed)) return null;
+  return trimmed;
+}
+
+/**
+ * Express middleware that establishes the async-local-storage request context
+ * from an already-resolved correlation/request id on the request object.
+ *
+ * It prefers `req.correlationId`, falling back to `req.requestId`. When neither
+ * is present the request proceeds without a context (downstream callers fall
+ * back to generating their own id). All downstream async work — audit writes,
+ * outbound RPC calls, event processing — can read the id via getCorrelationId().
+ */
+export function createRequestContextMiddleware() {
+  return function requestContextMiddleware(
+    req: { correlationId?: string; requestId?: string },
+    _res: unknown,
+    next: () => void
+  ): void {
+    const id = req.correlationId ?? req.requestId;
+    if (id) {
+      runWithContext(id, next);
+    } else {
+      next();
+    }
+  };
 }

--- a/backend/src/middleware/request-logger.ts
+++ b/backend/src/middleware/request-logger.ts
@@ -161,7 +161,10 @@ export function createRequestLogger(
       }
     });
 
-    next();
+    // Establish the async-local-storage context for the remainder of the
+    // request. Every downstream handler, audit write, and outbound RPC call
+    // can now read this id via getCorrelationId() without manual threading.
+    withCorrelationId(correlationId, next);
   };
 }
 

--- a/backend/src/services/auditService.ts
+++ b/backend/src/services/auditService.ts
@@ -1,6 +1,7 @@
 import * as fs from "fs";
 import * as path from "path";
 import { ulid } from "ulid";
+import { getCorrelationId } from "../lib/requestContext";
 import {
   AuditEntry,
   AuditEntrySchema,
@@ -54,8 +55,13 @@ class AuditService {
   }
 
   append(entry: Omit<AuditEntry, "id" | "timestamp">): AuditEntry {
+    // Stamp the originating request id from async-local-storage so the audit
+    // entry can be traced back to the inbound API call. An explicit value on
+    // the entry wins; otherwise we fall back to the active request context.
+    const requestId = entry.requestId ?? getCorrelationId() ?? undefined;
     const full: AuditEntry = {
       ...entry,
+      requestId,
       id: this.generateId(),
       timestamp: new Date().toISOString(),
     };

--- a/backend/src/services/rpcClient.ts
+++ b/backend/src/services/rpcClient.ts
@@ -1,5 +1,6 @@
 import { config } from "../config";
 import { URL } from "url";
+import { getCorrelationId } from "../lib/requestContext";
 
 export enum CircuitState {
   CLOSED = "CLOSED",
@@ -96,10 +97,21 @@ export class ReliableRpcClient {
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), this.options.timeoutMs);
 
+    // Forward the originating request id (from async-local-storage) to the
+    // upstream Soroban RPC so the call can be correlated end-to-end. Absent a
+    // request context (e.g. background workers) the header is simply omitted.
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+    };
+    const requestId = getCorrelationId();
+    if (requestId) {
+      headers["X-Request-Id"] = requestId;
+    }
+
     try {
       const response = await fetch(config.STELLAR_RPC_URL, {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
+        headers,
         body: JSON.stringify({
           jsonrpc: "2.0",
           id: Date.now(),

--- a/backend/src/types/audit.ts
+++ b/backend/src/types/audit.ts
@@ -34,6 +34,13 @@ export const SENSITIVE_FIELDS = new Set([
 export const AuditEntrySchema = z.object({
   id: z.string(),
   timestamp: z.string().datetime(),
+  /**
+   * Correlation/request id of the originating API call, propagated from the
+   * inbound `X-Request-Id` header via async-local-storage. Optional because
+   * audit entries written outside a request scope (e.g. background workers)
+   * may have no inbound request to correlate against.
+   */
+  requestId: z.string().optional(),
   actor: z.string(),
   operation: AuditOperationSchema,
   params: z.record(z.string(), z.unknown()),

--- a/backend/tests/request-id-propagation.test.ts
+++ b/backend/tests/request-id-propagation.test.ts
@@ -1,0 +1,304 @@
+/**
+ * Request ID propagation — end-to-end.
+ *
+ * Verifies the chain described in docs/logging.md:
+ *
+ *   inbound X-Request-Id header
+ *     → request-logger opens an AsyncLocalStorage context
+ *       → auditService.append() stamps AuditEntry.requestId
+ *       → rpcClient.call() forwards X-Request-Id to upstream Soroban RPC
+ *
+ * Also asserts the context survives async boundaries, never cross-contaminates
+ * between concurrent requests, and does not leak across event-loop ticks.
+ */
+import {
+  describe,
+  expect,
+  it,
+  jest,
+  beforeAll,
+  afterAll,
+  beforeEach,
+} from "@jest/globals";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+
+import { createRequestLogger, Logger } from "../src/middleware/request-logger";
+import { getCorrelationId } from "../src/lib/requestContext";
+import { auditService } from "../src/services/auditService";
+import { rpcClient } from "../src/services/rpcClient";
+import { AuditEntry } from "../src/types/audit";
+
+const ULID_RE = /^[0-9A-HJKMNP-TV-Z]{26}$/;
+
+// ── Test doubles ──────────────────────────────────────────────────────────────
+
+/** Logger that swallows output so tests don't spam stdout. */
+const silentLogger: Logger = { info: () => {}, error: () => {} };
+
+interface FakeRes {
+  statusCode: number;
+  setHeader(name: string, value: string): void;
+  getHeader(name: string): string | undefined;
+  json(body: unknown): unknown;
+  on(event: string, cb: () => void): FakeRes;
+  emit(event: string): void;
+}
+
+function makeReq(headers: Record<string, unknown> = {}) {
+  return {
+    method: "POST",
+    path: "/api/v1/test",
+    query: {} as Record<string, unknown>,
+    body: {} as Record<string, unknown>,
+    headers,
+  };
+}
+
+function makeRes(): FakeRes {
+  const headers: Record<string, string> = {};
+  const listeners: Record<string, Array<() => void>> = {};
+  return {
+    statusCode: 200,
+    setHeader(name, value) {
+      headers[name.toLowerCase()] = value;
+    },
+    getHeader(name) {
+      return headers[name.toLowerCase()];
+    },
+    json(body) {
+      return body;
+    },
+    on(event, cb) {
+      (listeners[event] ??= []).push(cb);
+      return this;
+    },
+    emit(event) {
+      (listeners[event] ?? []).forEach((cb) => cb());
+    },
+  };
+}
+
+/**
+ * Drive the request-logger middleware and run `work` inside the established
+ * request context. Resolves once `work` completes. Returns the FakeRes so the
+ * echoed X-Request-Id response header can be asserted.
+ */
+function runRequest(
+  headers: Record<string, unknown>,
+  work: () => void | Promise<void>
+): Promise<FakeRes> {
+  const middleware = createRequestLogger(silentLogger);
+  const req = makeReq(headers);
+  const res = makeRes();
+  return new Promise<FakeRes>((resolve, reject) => {
+    middleware(req as never, res as never, () => {
+      Promise.resolve()
+        .then(work)
+        .then(() => {
+          res.emit("finish"); // exercise the structured-log finish handler
+          resolve(res);
+        })
+        .catch(reject);
+    });
+  });
+}
+
+/** Append a minimal audit entry (requestId is filled from context). */
+function appendAudit(effect: string): AuditEntry {
+  return auditService.append({
+    actor: "test-actor",
+    operation: "CONFIG_CHANGE",
+    params: {},
+    redactedParams: {},
+    ip: "10.0.0.1",
+    userAgent: "jest",
+    effect,
+    success: true,
+  });
+}
+
+// ── fetch capture for rpcClient outbound headers ──────────────────────────────
+
+let capturedHeaders: Array<Record<string, string>>;
+let originalFetch: typeof globalThis.fetch;
+
+function installFetchSpy() {
+  originalFetch = globalThis.fetch;
+  globalThis.fetch = jest.fn(async (_url: unknown, init?: unknown) => {
+    const headers = ((init as { headers?: Record<string, string> })?.headers ??
+      {}) as Record<string, string>;
+    capturedHeaders.push(headers);
+    return {
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      json: async () => ({ jsonrpc: "2.0", id: 1, result: { healthy: true } }),
+    } as Response;
+  }) as unknown as typeof globalThis.fetch;
+}
+
+// ── Suite ─────────────────────────────────────────────────────────────────────
+
+describe("request id propagation", () => {
+  let auditDir: string;
+
+  beforeAll(() => {
+    auditDir = fs.mkdtempSync(path.join(os.tmpdir(), "qlx-audit-"));
+    auditService.setAuditDir(auditDir);
+    installFetchSpy();
+  });
+
+  afterAll(() => {
+    globalThis.fetch = originalFetch;
+    fs.rmSync(auditDir, { recursive: true, force: true });
+  });
+
+  beforeEach(() => {
+    auditService.clearAll();
+    capturedHeaders = [];
+  });
+
+  it("flows from inbound header to audit entry and outbound RPC header", async () => {
+    const inbound = "client-trace-123";
+    let entry: AuditEntry | undefined;
+
+    const res = await runRequest({ "x-request-id": inbound }, async () => {
+      expect(getCorrelationId()).toBe(inbound);
+      entry = appendAudit("config changed");
+      await rpcClient.call("getHealth");
+    });
+
+    // echoed back to the caller
+    expect(res.getHeader("X-Request-Id")).toBe(inbound);
+    // stamped on the audit entry
+    expect(entry?.requestId).toBe(inbound);
+    // forwarded to the upstream RPC
+    expect(capturedHeaders).toHaveLength(1);
+    expect(capturedHeaders[0]["X-Request-Id"]).toBe(inbound);
+  });
+
+  it("trims and accepts whitespace-padded inbound ids", async () => {
+    let entry: AuditEntry | undefined;
+    const res = await runRequest({ "x-request-id": "  padded-id-9  " }, () => {
+      entry = appendAudit("padded");
+    });
+    expect(res.getHeader("X-Request-Id")).toBe("padded-id-9");
+    expect(entry?.requestId).toBe("padded-id-9");
+  });
+
+  it("generates a server-side ULID when the inbound id is missing", async () => {
+    let observed: string | null = null;
+    let entry: AuditEntry | undefined;
+
+    const res = await runRequest({}, () => {
+      observed = getCorrelationId();
+      entry = appendAudit("generated");
+    });
+
+    expect(observed).toMatch(ULID_RE);
+    expect(res.getHeader("X-Request-Id")).toBe(observed);
+    expect(entry?.requestId).toBe(observed);
+  });
+
+  it("generates a fresh ULID when the inbound id is invalid (log injection)", async () => {
+    const malicious = "bad\nid; rm -rf /";
+    let observed: string | null = null;
+
+    const res = await runRequest({ "x-request-id": malicious }, () => {
+      observed = getCorrelationId();
+    });
+
+    expect(observed).toMatch(ULID_RE);
+    expect(res.getHeader("X-Request-Id")).not.toBe(malicious);
+  });
+
+  it("exposes the same id to async callbacks (await, setTimeout, setImmediate)", async () => {
+    const inbound = "async-trace-7";
+    const seen: Array<string | null> = [];
+
+    await runRequest({ "x-request-id": inbound }, async () => {
+      await Promise.resolve();
+      seen.push(getCorrelationId());
+
+      await new Promise<void>((resolve) =>
+        setTimeout(() => {
+          seen.push(getCorrelationId());
+          resolve();
+        }, 5)
+      );
+
+      await new Promise<void>((resolve) =>
+        setImmediate(() => {
+          // audit append inside a deferred callback still sees the id
+          seen.push(appendAudit("deferred").requestId ?? null);
+          resolve();
+        })
+      );
+    });
+
+    expect(seen).toEqual([inbound, inbound, inbound]);
+  });
+
+  it("does not cross-contaminate concurrent requests", async () => {
+    const results: Record<string, { audit?: string; header?: string }> = {
+      "req-aaa-1": {},
+      "req-bbb-2": {},
+      "req-ccc-3": {},
+    };
+
+    await Promise.all(
+      Object.keys(results).map((id) =>
+        runRequest({ "x-request-id": id }, async () => {
+          // jitter so the requests genuinely interleave
+          await new Promise((r) => setTimeout(r, Math.floor(Math.random() * 10)));
+          results[id].audit = appendAudit(`work ${id}`).requestId;
+          const before = capturedHeaders.length;
+          await rpcClient.call("getHealth");
+          results[id].header = capturedHeaders[before]["X-Request-Id"];
+        })
+      )
+    );
+
+    for (const id of Object.keys(results)) {
+      expect(results[id].audit).toBe(id);
+      expect(results[id].header).toBe(id);
+    }
+
+    // every audit entry on disk carries exactly one of the three ids
+    const persisted = auditService.getAllEntries();
+    expect(persisted).toHaveLength(3);
+    expect(persisted.map((e) => e.requestId).sort()).toEqual(
+      Object.keys(results).sort()
+    );
+  });
+
+  it("does not leak context across event-loop ticks", async () => {
+    expect(getCorrelationId()).toBeNull();
+
+    await runRequest({ "x-request-id": "leak-check-1" }, () => {
+      expect(getCorrelationId()).toBe("leak-check-1");
+    });
+
+    // immediately after the request completes the context is gone
+    expect(getCorrelationId()).toBeNull();
+
+    // and a tick scheduled entirely outside any request sees no context
+    await new Promise<void>((resolve) =>
+      setImmediate(() => {
+        expect(getCorrelationId()).toBeNull();
+        resolve();
+      })
+    );
+  });
+
+  it("omits requestId and the RPC header when there is no request context", async () => {
+    const entry = appendAudit("no context");
+    expect(entry.requestId).toBeUndefined();
+
+    await rpcClient.call("getHealth");
+    expect(capturedHeaders).toHaveLength(1);
+    expect(capturedHeaders[0]["X-Request-Id"]).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Closes #1172

## 📝 Description
Threads the inbound `X-Request-Id` down the backend stack so a backend mutation can be traced back to the originating API call, and forwards the same id on outbound Soroban RPC calls.

## 🎯 Type of Change
- [x] New feature

## 🔧 Changes Made
### Files Modified
- `backend/src/middleware/request-logger.ts` — opens an `AsyncLocalStorage` request context (`withCorrelationId(id, next)`) for the full request lifecycle
- `backend/src/services/auditService.ts` — `append()` stamps `AuditEntry.requestId` from the active context
- `backend/src/services/rpcClient.ts` — forwards `X-Request-Id` on outbound JSON-RPC calls
- `backend/src/types/audit.ts` — adds optional `requestId` to `AuditEntrySchema`
- `backend/src/lib/requestContext.ts` — restores `getOrGenerateCorrelationId` / `createRequestContextMiddleware`; aligns `sanitizeCorrelationId` with the `X-Request-Id` contract
- `backend/docs/logging.md`, `backend/docs/audit-log.md` — document the propagation chain

### New Files Added
- `backend/tests/request-id-propagation.test.ts`

## 🧪 Testing
- [x] Unit tests pass

### Test Coverage
`npm test -- request-id` — covers inbound header to audit entry to outbound RPC header, ULID fallback on missing/invalid id, async propagation (`await`/`setTimeout`/`setImmediate`), parallel-request isolation, and no context leak across event-loop ticks.

## 🔗 Related Issues
Closes #1172
