### PR TITLE
[1304] Add admin batch-pause-and-snapshot maintenance entrypoint coordinating pause.rs and maintenance.rs

### DIFF
--- a/docs/contracts/operations.md
+++ b/docs/contracts/operations.md
@@ -160,3 +160,33 @@ function:
 | Pause | `PauseControl::require_not_paused` | `ContractPaused` (2100) |
 
 Entrypoints that must respect both states should call both guards.
+
+---
+
+## Incident Mode (Coordinated Pause + Maintenance)
+
+For **security incident response**, use the coordinated entrypoints instead of
+calling `pause` and `set_maintenance_mode` separately. A single
+`enter_incident_mode` invocation atomically engages both circuit breakers and
+returns an auditable snapshot.
+
+### API
+
+#### `enter_incident_mode(admin, reason) → IncidentSnapshot`
+
+| Field | Type | Description |
+|---|---|---|
+| `is_paused` | `bool` | Hard pause flag after the call |
+| `is_maintenance` | `bool` | Maintenance flag after the call |
+| `reason` | `String` | Stored maintenance reason (max 256 bytes) |
+| `timestamp` | `u64` | Ledger timestamp when the snapshot was taken |
+
+**Errors:** `NotAdmin`, `InvalidDescription` (reason too long).
+
+#### `exit_incident_mode(admin) → IncidentSnapshot`
+
+Clears both pause and maintenance. Idempotent when already in normal operation.
+
+### Runbook
+
+See [`reliability.md`](../../reliability.md#on-chain-incident-mode-protocol-runbook) for the operator checklist.

--- a/quicklendx-contracts/src/incident.rs
+++ b/quicklendx-contracts/src/incident.rs
@@ -1,0 +1,93 @@
+//! Coordinated incident mode: atomically pauses the protocol and enters maintenance mode.
+//!
+//! QuickLendX has two independent circuit breakers — the hard `PauseControl::set_paused`
+//! and the softer `MaintenanceControl::set_maintenance_mode`. During an incident,
+//! operators need a single atomic action that engages both and returns an auditable
+//! snapshot for the runbook.
+
+use crate::admin::AdminStorage;
+use crate::errors::QuickLendXError;
+use crate::maintenance::{MaintenanceControl, MAX_REASON_LEN};
+use crate::pause::PauseControl;
+use soroban_sdk::{contracttype, Address, Env, String};
+
+/// Health snapshot returned when entering or exiting incident mode.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct IncidentSnapshot {
+    /// Whether the hard pause flag is set.
+    pub is_paused: bool,
+    /// Whether maintenance mode is active.
+    pub is_maintenance: bool,
+    /// Stored maintenance reason (empty when not in maintenance).
+    pub reason: String,
+    /// Ledger timestamp at the moment the snapshot was captured.
+    pub timestamp: u64,
+}
+
+pub struct IncidentControl;
+
+impl IncidentControl {
+    /// Atomically engage incident mode: hard pause plus maintenance with reason.
+    ///
+    /// # Atomicity
+    /// Admin credentials and `reason` length are validated before any storage
+    /// write. On Soroban the entire invocation reverts when this function returns
+    /// `Err`, so callers never observe a half-applied pause without maintenance
+    /// (or vice versa) from a failed `enter_incident_mode`.
+    ///
+    /// Writes are ordered maintenance-first, then pause. Both flags commit
+    /// together on success.
+    ///
+    /// # Recovery
+    /// If pause and maintenance were toggled separately and drifted out of sync,
+    /// call [`Self::exit_incident_mode`] to clear both, or re-call this function
+    /// to realign them and refresh the reason.
+    ///
+    /// Re-entering while already in incident mode is idempotent and updates the
+    /// stored reason.
+    pub fn enter_incident_mode(
+        env: &Env,
+        admin: &Address,
+        reason: &String,
+    ) -> Result<IncidentSnapshot, QuickLendXError> {
+        admin.require_auth();
+        AdminStorage::require_admin(env, admin)?;
+
+        if reason.len() > MAX_REASON_LEN {
+            return Err(QuickLendXError::InvalidDescription);
+        }
+
+        MaintenanceControl::apply_maintenance_mode(env, true, reason, admin)?;
+        PauseControl::apply_paused(env, true);
+
+        Ok(Self::snapshot_from_state(env))
+    }
+
+    /// Atomically clear incident mode: unpause and disable maintenance.
+    ///
+    /// Idempotent when neither flag is set — both are cleared to `false` and an
+    /// empty-reason snapshot is returned.
+    pub fn exit_incident_mode(
+        env: &Env,
+        admin: &Address,
+    ) -> Result<IncidentSnapshot, QuickLendXError> {
+        admin.require_auth();
+        AdminStorage::require_admin(env, admin)?;
+
+        PauseControl::apply_paused(env, false);
+        MaintenanceControl::apply_maintenance_mode(env, false, &String::from_str(env, ""), admin)?;
+
+        Ok(Self::snapshot_from_state(env))
+    }
+
+    fn snapshot_from_state(env: &Env) -> IncidentSnapshot {
+        IncidentSnapshot {
+            is_paused: PauseControl::is_paused(env),
+            is_maintenance: MaintenanceControl::is_maintenance_mode(env),
+            reason: MaintenanceControl::get_maintenance_reason(env)
+                .unwrap_or_else(|| String::from_str(env, "")),
+            timestamp: env.ledger().timestamp(),
+        }
+    }
+}

--- a/quicklendx-contracts/src/lib.rs
+++ b/quicklendx-contracts/src/lib.rs
@@ -56,6 +56,7 @@ pub mod health;
 pub mod events;
 pub mod fees;
 pub mod freshness;
+pub mod incident;
 pub mod init;
 pub mod invariants;
 pub mod investment;
@@ -177,6 +178,8 @@ mod test_init_invariants;
 mod test_input_matrix;
 #[cfg(all(test, feature = "legacy-tests"))]
 mod test_investment_transitions;
+#[cfg(test)]
+mod test_incident;
 #[cfg(test)]
 mod test_invoice_metadata;
 #[cfg(test)]
@@ -655,6 +658,27 @@ impl QuickLendXContract {
     /// Return whether the contract is currently paused.
     pub fn is_paused(env: Env) -> bool {
         pause::PauseControl::is_paused(&env)
+    }
+
+    /// Atomically enter incident mode: hard pause plus maintenance with reason.
+    ///
+    /// Coordinates [`pause::PauseControl`] and [`maintenance::MaintenanceControl`]
+    /// in a single admin-gated invocation and returns an [`incident::IncidentSnapshot`]
+    /// for runbook/audit tooling.
+    pub fn enter_incident_mode(
+        env: Env,
+        admin: Address,
+        reason: String,
+    ) -> Result<incident::IncidentSnapshot, QuickLendXError> {
+        incident::IncidentControl::enter_incident_mode(&env, &admin, &reason)
+    }
+
+    /// Atomically exit incident mode: unpause and disable maintenance.
+    pub fn exit_incident_mode(
+        env: Env,
+        admin: Address,
+    ) -> Result<incident::IncidentSnapshot, QuickLendXError> {
+        incident::IncidentControl::exit_incident_mode(&env, &admin)
     }
 
     /// Get a snapshot of the protocol's current health status.

--- a/quicklendx-contracts/src/maintenance.rs
+++ b/quicklendx-contracts/src/maintenance.rs
@@ -81,7 +81,16 @@ impl MaintenanceControl {
         reason: &String,
     ) -> Result<(), QuickLendXError> {
         AdminStorage::require_admin(env, admin)?;
+        Self::apply_maintenance_mode(env, enabled, reason, admin)
+    }
 
+    /// Write maintenance flags without re-checking admin (caller must authorize).
+    pub(crate) fn apply_maintenance_mode(
+        env: &Env,
+        enabled: bool,
+        reason: &String,
+        actor: &Address,
+    ) -> Result<(), QuickLendXError> {
         if enabled && reason.len() > MAX_REASON_LEN {
             return Err(QuickLendXError::InvalidDescription);
         }
@@ -100,7 +109,7 @@ impl MaintenanceControl {
             env.storage().instance().remove(&MAINTENANCE_REASON_KEY);
             env.events().publish(
                 (symbol_short!("MAINT"), symbol_short!("disabled")),
-                admin.clone(),
+                actor.clone(),
             );
         }
 

--- a/quicklendx-contracts/src/pause.rs
+++ b/quicklendx-contracts/src/pause.rs
@@ -45,8 +45,13 @@ impl PauseControl {
         admin.require_auth();
         AdminStorage::require_admin(env, admin)?;
 
-        env.storage().instance().set(&PAUSED_KEY, &paused);
+        Self::apply_paused(env, paused);
         Ok(())
+    }
+
+    /// Write the pause flag without re-checking admin (caller must authorize).
+    pub(crate) fn apply_paused(env: &Env, paused: bool) {
+        env.storage().instance().set(&PAUSED_KEY, &paused);
     }
 
     /// @notice Reject business-state operations while the protocol is paused.

--- a/quicklendx-contracts/src/test_incident.rs
+++ b/quicklendx-contracts/src/test_incident.rs
@@ -1,0 +1,185 @@
+//! Tests for coordinated incident mode (`enter_incident_mode` / `exit_incident_mode`).
+
+#![cfg(test)]
+
+use crate::errors::QuickLendXError;
+use crate::incident::IncidentSnapshot;
+use crate::invoice::InvoiceCategory;
+use crate::maintenance::{MaintenanceControl, MAX_REASON_LEN};
+use crate::pause::PauseControl;
+use crate::{QuickLendXContract, QuickLendXContractClient};
+use soroban_sdk::testutils::Address as _;
+use soroban_sdk::{Address, Env, String, Vec};
+
+fn setup(env: &Env) -> (QuickLendXContractClient<'static>, Address) {
+    env.mock_all_auths();
+    let contract_id = env.register(QuickLendXContract, ());
+    let client = QuickLendXContractClient::new(env, &contract_id);
+    let admin = Address::generate(env);
+    client.initialize_admin(&admin);
+    (client, admin)
+}
+
+fn reason(env: &Env, msg: &str) -> String {
+    String::from_str(env, msg)
+}
+
+#[test]
+fn test_enter_incident_mode_sets_pause_and_maintenance() {
+    let env = Env::default();
+    let (client, admin) = setup(&env);
+    let msg = "Oracle feed anomaly — freezing writes";
+
+    let snapshot = client.enter_incident_mode(&admin, &reason(&env, msg));
+
+    assert!(snapshot.is_paused);
+    assert!(snapshot.is_maintenance);
+    assert_eq!(snapshot.reason, reason(&env, msg));
+    assert_eq!(snapshot.timestamp, env.ledger().timestamp());
+    assert!(client.is_paused());
+    assert!(MaintenanceControl::is_maintenance_mode(&env));
+    assert_eq!(
+        MaintenanceControl::get_maintenance_reason(&env).unwrap(),
+        reason(&env, msg)
+    );
+}
+
+#[test]
+fn test_enter_incident_mode_rejects_non_admin() {
+    let env = Env::default();
+    let (client, _admin) = setup(&env);
+    let attacker = Address::generate(&env);
+
+    let result = client.try_enter_incident_mode(&attacker, &reason(&env, "attack"));
+    assert_eq!(result.unwrap_err().unwrap(), QuickLendXError::NotAdmin);
+    assert!(!client.is_paused());
+    assert!(!MaintenanceControl::is_maintenance_mode(&env));
+}
+
+#[test]
+fn test_enter_incident_mode_rejects_oversized_reason() {
+    let env = Env::default();
+    let (client, admin) = setup(&env);
+
+    let oversized: String = {
+        let bytes = soroban_sdk::Bytes::from_slice(
+            &env,
+            &vec![b'x'; (MAX_REASON_LEN + 1) as usize],
+        );
+        String::try_from_bytes(&bytes).unwrap()
+    };
+
+    let result = client.try_enter_incident_mode(&admin, &oversized);
+    assert_eq!(result.unwrap_err().unwrap(), QuickLendXError::InvalidDescription);
+    assert!(!client.is_paused());
+    assert!(!MaintenanceControl::is_maintenance_mode(&env));
+}
+
+#[test]
+fn test_enter_incident_mode_idempotent_reentry_updates_reason() {
+    let env = Env::default();
+    let (client, admin) = setup(&env);
+
+    client.enter_incident_mode(&admin, &reason(&env, "First incident"));
+    let snapshot = client.enter_incident_mode(&admin, &reason(&env, "Escalated incident"));
+
+    assert!(snapshot.is_paused);
+    assert!(snapshot.is_maintenance);
+    assert_eq!(snapshot.reason, reason(&env, "Escalated incident"));
+}
+
+#[test]
+fn test_exit_incident_mode_clears_both_flags() {
+    let env = Env::default();
+    let (client, admin) = setup(&env);
+
+    client.enter_incident_mode(&admin, &reason(&env, "Investigating"));
+    let snapshot = client.exit_incident_mode(&admin);
+
+    assert!(!snapshot.is_paused);
+    assert!(!snapshot.is_maintenance);
+    assert_eq!(snapshot.reason, reason(&env, ""));
+    assert!(!client.is_paused());
+    assert!(!MaintenanceControl::is_maintenance_mode(&env));
+    assert!(MaintenanceControl::get_maintenance_reason(&env).is_none());
+}
+
+#[test]
+fn test_exit_incident_mode_idempotent_when_not_active() {
+    let env = Env::default();
+    let (client, admin) = setup(&env);
+
+    assert!(!client.is_paused());
+    let snapshot = client.exit_incident_mode(&admin);
+
+    assert_eq!(
+        snapshot,
+        IncidentSnapshot {
+            is_paused: false,
+            is_maintenance: false,
+            reason: reason(&env, ""),
+            timestamp: env.ledger().timestamp(),
+        }
+    );
+}
+
+#[test]
+fn test_exit_incident_mode_rejects_non_admin() {
+    let env = Env::default();
+    let (client, admin) = setup(&env);
+    let attacker = Address::generate(&env);
+
+    client.enter_incident_mode(&admin, &reason(&env, "Incident"));
+    let result = client.try_exit_incident_mode(&attacker);
+    assert_eq!(result.unwrap_err().unwrap(), QuickLendXError::NotAdmin);
+    assert!(client.is_paused());
+    assert!(MaintenanceControl::is_maintenance_mode(&env));
+}
+
+#[test]
+fn test_incident_mode_blocks_store_invoice() {
+    let env = Env::default();
+    let (client, admin) = setup(&env);
+    let business = Address::generate(&env);
+    let currency = Address::generate(&env);
+    let due_date = env.ledger().timestamp() + 86_400;
+
+    client.enter_incident_mode(&admin, &reason(&env, "Security review"));
+
+    let result = client.try_store_invoice(
+        &business,
+        &1_000i128,
+        &currency,
+        &due_date,
+        &String::from_str(&env, "Blocked"),
+        &InvoiceCategory::Services,
+        &Vec::new(&env),
+    );
+    assert_eq!(result.unwrap_err().unwrap(), QuickLendXError::ContractPaused);
+}
+
+#[test]
+fn test_unpause_alone_leaves_maintenance_active() {
+    let env = Env::default();
+    let (client, admin) = setup(&env);
+
+    client.enter_incident_mode(&admin, &reason(&env, "Drift test"));
+    client.unpause(&admin);
+
+    assert!(!PauseControl::is_paused(&env));
+    assert!(MaintenanceControl::is_maintenance_mode(&env));
+}
+
+#[test]
+fn test_reenter_realigns_drifted_flags() {
+    let env = Env::default();
+    let (client, admin) = setup(&env);
+
+    client.pause(&admin);
+    assert!(client.is_paused());
+    assert!(!MaintenanceControl::is_maintenance_mode(&env));
+
+    let snapshot = client.enter_incident_mode(&admin, &reason(&env, "Realign"));
+    assert!(snapshot.is_paused);
+    assert!(snapshot.is_maintenance);
+}

--- a/quicklendx-contracts/src/test_incident.rs
+++ b/quicklendx-contracts/src/test_incident.rs
@@ -24,6 +24,11 @@ fn reason(env: &Env, msg: &str) -> String {
     String::from_str(env, msg)
 }
 
+fn reason_of_len(env: &Env, len: usize) -> String {
+    let s = "x".repeat(len);
+    String::from_str(env, &s)
+}
+
 #[test]
 fn test_enter_incident_mode_sets_pause_and_maintenance() {
     let env = Env::default();
@@ -61,13 +66,7 @@ fn test_enter_incident_mode_rejects_oversized_reason() {
     let env = Env::default();
     let (client, admin) = setup(&env);
 
-    let oversized: String = {
-        let bytes = soroban_sdk::Bytes::from_slice(
-            &env,
-            &vec![b'x'; (MAX_REASON_LEN + 1) as usize],
-        );
-        String::try_from_bytes(&bytes).unwrap()
-    };
+    let oversized = reason_of_len(&env, (MAX_REASON_LEN + 1) as usize);
 
     let result = client.try_enter_incident_mode(&admin, &oversized);
     assert_eq!(result.unwrap_err().unwrap(), QuickLendXError::InvalidDescription);

--- a/reliability.md
+++ b/reliability.md
@@ -41,3 +41,32 @@ Example Response:
 ## Recovery
 
 Once metrics fall below degraded thresholds for a complete batch cycle, the controller automatically promotes the strategy back toward `Normal`.
+
+---
+
+## On-Chain Incident Mode (Protocol Runbook)
+
+During a **security incident**, operators must not call `pause` and
+`set_maintenance_mode` as separate transactions — that leaves a window where the
+protocol is half-frozen and half-live.
+
+Use the coordinated contract entrypoints instead:
+
+| Action | Entrypoint | Effect |
+| --- | --- | --- |
+| Engage incident response | `enter_incident_mode(admin, reason)` | Atomically sets hard pause **and** maintenance mode with an on-chain reason; returns `IncidentSnapshot` (`is_paused`, `is_maintenance`, `reason`, `timestamp`) for audit/runbook logs |
+| Clear incident response | `exit_incident_mode(admin)` | Atomically clears both flags; idempotent when already normal |
+
+**Operator checklist**
+
+1. Call `enter_incident_mode` with a concise reason (≤ 256 bytes).
+2. Record the returned `IncidentSnapshot` in the incident ticket.
+3. Use read-only queries (`get_protocol_health`, `get_invoice`, etc.) while investigating.
+4. When safe, call `exit_incident_mode` and confirm both flags are `false`.
+
+**Recovery from drift:** If pause and maintenance were toggled independently and
+are out of sync, call `exit_incident_mode` to reset both, or `enter_incident_mode`
+to realign them and refresh the reason.
+
+See [`docs/contracts/operations.md`](docs/contracts/operations.md) for the full
+pause vs. maintenance matrix.


### PR DESCRIPTION
## Summary
- Add atomic `enter_incident_mode` / `exit_incident_mode` contract entrypoints coordinating `PauseControl` and `MaintenanceControl`
- Return `IncidentSnapshot` (pause flag, maintenance flag, reason, ledger timestamp) for runbook/audit tooling
- Add unit tests and incident runbook notes in `reliability.md` and `docs/contracts/operations.md`

Closes #1304

## Test plan
- [x] `test_enter_incident_mode_sets_pause_and_maintenance`
- [x] `test_enter_incident_mode_rejects_non_admin`
- [x] `test_enter_incident_mode_rejects_oversized_reason`
- [x] `test_enter_incident_mode_idempotent_reentry_updates_reason`
- [x] `test_exit_incident_mode_clears_both_flags`
- [x] `test_exit_incident_mode_idempotent_when_not_active`
- [x] `test_incident_mode_blocks_store_invoice`
- [x] `test_reenter_realigns_drifted_flags`

Made with [Cursor](https://cursor.com)