### PR TITLE
feat(storage): add retention-windowed prune_terminal_invoices

### DIFF
--- a/quicklendx-contracts/docs/storage-ttl-policy.md
+++ b/quicklendx-contracts/docs/storage-ttl-policy.md
@@ -88,3 +88,66 @@ loss**. Once Soroban host reclaims an expired entry:
 There is **no recovery mechanism** for entries that have been garbage-collected
 by the host. Operators must ensure the weekly extension job is reliable and
 monitored.
+
+## Pruning Terminal Invoices
+
+`prune_terminal_invoices` removes fully-resolved (terminal-state) invoices from
+persistent storage after a configurable retention window. This bounds long-term
+storage costs and reduces the number of keys touched by each TTL-extension sweep.
+
+### Eligible statuses
+
+Only invoices in a **terminal status** may be pruned:
+
+| Status      | Terminal timestamp field      |
+|-------------|-------------------------------|
+| `Paid`      | `settled_at`                  |
+| `Defaulted` | `created_at` (fallback)       |
+| `Cancelled` | `created_at` (fallback)       |
+| `Refunded`  | `created_at` (fallback)       |
+
+Invoices in `Pending`, `Verified`, or `Funded` status are **never** pruned,
+regardless of age. This safety guard protects active and disputed invoices.
+
+### Retention window
+
+The caller supplies `older_than_secs` — a minimum age in ledger seconds. An
+invoice is pruned only when:
+
+```
+terminal_timestamp + older_than_secs < current_ledger_timestamp
+```
+
+A value of `0` prunes all terminal invoices (useful for testing or full cleanup).
+A value of `30 * 24 * 3600` (~30 days) matches the protocol's
+`PERSISTENT_TTL_THRESHOLD` and is the recommended production setting.
+
+### Irreversibility
+
+Pruning removes the invoice record **and all secondary index entries** (status,
+business, customer, tax_id, tag, category) from persistent storage. **There is no
+undo.** Operators should test with a dry-run retention window (e.g., 10 years)
+to inspect which invoices would be affected before running with a real window.
+
+### Pagination
+
+The prune is paginated with a max page size of 100. Pass `next_offset` from the
+returned `PruneReport` as `offset` on the next call. Because pruning deletes
+entries, the offset may shift between pages; callers should restart from
+`offset = 0` when a page returns `scanned = 0`.
+
+### Entrypoint
+
+```rust
+fn prune_terminal_invoices(
+    env: Env,
+    admin: Address,
+    older_than_secs: u64,
+    offset: u32,
+    limit: u32,
+) -> Result<PruneReport, QuickLendXError>
+```
+
+- **Authorization**: admin-only (checked via `AdminStorage::require_admin`).
+- **Returns**: `PruneReport { scanned, pruned, next_offset }`.
+- **Safe**: never touches non-terminal invoices regardless of age.

--- a/quicklendx-contracts/src/lib.rs
+++ b/quicklendx-contracts/src/lib.rs
@@ -3471,6 +3471,43 @@ impl QuickLendXContract {
         Ok(report)
     }
 
+    /// Prune terminal-state invoices whose terminal timestamp is older than
+    /// `older_than_secs` from the current ledger timestamp.
+    ///
+    /// Only invoices in a terminal status (`Paid`, `Defaulted`, `Cancelled`,
+    /// `Refunded`) are eligible. For `Paid` invoices the terminal timestamp
+    /// is `settled_at`; for other terminal statuses it falls back to
+    /// `created_at`. Invoices in `Pending`, `Verified`, or `Funded` status
+    /// are never pruned regardless of age.
+    ///
+    /// Each pruned invoice is removed from all secondary indexes (status,
+    /// business, customer, tax_id, tag, category) and from primary persistent
+    /// storage. This operation is **irreversible** — there is no undo.
+    ///
+    /// # Resumability
+    /// The operation is paginated and resumable. Pass the `next_offset` from the
+    /// returned `PruneReport` as `offset` on the next call. Stop when
+    /// `next_offset` stops advancing (last page reached).
+    ///
+    /// # Arguments
+    /// * `admin`           - Must be the current protocol admin (auth required).
+    /// * `older_than_secs` - Retention window in seconds. Only invoices whose
+    ///                       terminal timestamp is older than this are pruned.
+    /// * `offset`          - Zero-based start position in the full invoice list.
+    /// * `limit`           - Max invoices to scan per call (capped at 100).
+    pub fn prune_terminal_invoices(
+        env: Env,
+        admin: Address,
+        older_than_secs: u64,
+        offset: u32,
+        limit: u32,
+    ) -> Result<PruneReport, QuickLendXError> {
+        admin.require_auth();
+        AdminStorage::require_admin(&env, &admin)?;
+        let report = InvoiceStorage::prune_terminal_invoices_page(&env, older_than_secs, offset, limit);
+        Ok(report)
+    }
+
     /// Repair missing held escrow reserve entries for one token from indexed invoice records.
     ///
     /// The first call (`offset = 0`) snapshots the current status-derived
@@ -3511,3 +3548,6 @@ mod test_settlement_auto_release;
 
 #[cfg(all(test, feature = "legacy-tests"))]
 mod test_settlement_dispute_interaction;
+
+#[cfg(test)]
+mod test_prune_terminal_invoices;

--- a/quicklendx-contracts/src/storage.rs
+++ b/quicklendx-contracts/src/storage.rs
@@ -8,7 +8,7 @@ use soroban_sdk::{contracttype, symbol_short, Address, BytesN, Env, String, Symb
 use crate::protocol_limits;
 use crate::types::{
     BidStatus, InvestmentStatus, Invoice, InvoiceCategory, InvoiceStatus,
-    PlatformFeeConfig, RebuildReport,
+    PlatformFeeConfig, PruneReport, RebuildReport,
 };
 
 /// Default TTL threshold for persistent storage (adjust the value as needed)
@@ -1024,6 +1024,69 @@ impl InvoiceStorage {
         RebuildReport {
             scanned: end.saturating_sub(start),
             reindexed,
+            next_offset: end,
+        }
+    }
+
+    /// Prune terminal-state invoices whose terminal timestamp is older than
+    /// `older_than_secs` from the current ledger timestamp.
+    ///
+    /// Only invoices in a terminal status (`Paid`, `Defaulted`, `Cancelled`,
+    /// `Refunded`) are eligible. For `Paid` invoices the terminal timestamp
+    /// is `settled_at`; for other terminal statuses it falls back to
+    /// `created_at`. Invoices in `Pending`, `Verified`, or `Funded` status
+    /// are never pruned regardless of age.
+    ///
+    /// The operation is paginated via `offset`/`limit` (capped at 100 per
+    /// page) and removes each pruned invoice from all secondary indexes
+    /// (status, business, customer, tax_id, tag, category) and from primary
+    /// persistent storage via [`delete_invoice`](Self::delete_invoice).
+    ///
+    /// # Resumability
+    /// Pass the `next_offset` from the returned `PruneReport` as `offset`
+    /// on the next call. Stop when `next_offset` stops advancing (last page).
+    ///
+    /// # Returns
+    /// A `PruneReport` containing:
+    /// * `scanned`   — number of invoice IDs examined in this page.
+    /// * `pruned`    — number of invoices actually deleted.
+    /// * `next_offset` — offset for the next call.
+    pub fn prune_terminal_invoices_page(
+        env: &Env,
+        older_than_secs: u64,
+        offset: u32,
+        limit: u32,
+    ) -> PruneReport {
+        const MAX_PRUNE_PAGE: u32 = 100;
+        let capped = if limit > MAX_PRUNE_PAGE { MAX_PRUNE_PAGE } else { limit };
+
+        let now = env.ledger().timestamp();
+        let all_ids = Self::get_all_invoice_ids(env);
+        let total = all_ids.len() as u32;
+
+        let start = offset.min(total);
+        let end = start.saturating_add(capped).min(total);
+
+        let mut pruned: u32 = 0;
+        let mut i = start;
+        while i < end {
+            if let Some(id) = all_ids.get(i) {
+                if let Some(invoice) = Self::get(env, &id) {
+                    if invoice.status.is_terminal() {
+                        let terminal_ts = invoice.settled_at.unwrap_or(invoice.created_at);
+                        if terminal_ts.saturating_add(older_than_secs) < now {
+                            Self::delete_invoice(env, &id);
+                            pruned = pruned.saturating_add(1);
+                        }
+                    }
+                }
+            }
+            i = i.saturating_add(1);
+        }
+
+        PruneReport {
+            scanned: end.saturating_sub(start),
+            pruned,
             next_offset: end,
         }
     }

--- a/quicklendx-contracts/src/test_prune_terminal_invoices.rs
+++ b/quicklendx-contracts/src/test_prune_terminal_invoices.rs
@@ -1,0 +1,372 @@
+use super::*;
+use crate::alloc::string::ToString;
+use crate::errors::QuickLendXError;
+use crate::invoice::InvoiceCategory;
+use crate::storage::InvoiceStorage;
+use crate::types::InvoiceStatus;
+use soroban_sdk::{
+    testutils::{Address as _, Ledger},
+    token, Address, BytesN, Env, String, Vec,
+};
+
+struct TestFixture {
+    env: Env,
+    client: QuickLendXContractClient<'static>,
+    contract_id: Address,
+    admin: Address,
+    business: Address,
+    investor: Address,
+    currency: Address,
+}
+
+impl TestFixture {
+    fn setup() -> Self {
+        let env = Env::default();
+        env.mock_all_auths();
+        env.ledger().set_timestamp(1_000_000);
+        let contract_id = env.register(QuickLendXContract, ());
+        let client = QuickLendXContractClient::new(&env, &contract_id);
+        let admin = Address::generate(&env);
+        client.set_admin(&admin);
+        client.initialize_fee_system(&admin);
+        let business = Address::generate(&env);
+        let investor = Address::generate(&env);
+
+        // KYC once
+        let kyc = String::from_str(&env, "KYC");
+        client.submit_kyc_application(&business, &kyc);
+        client.verify_business(&admin, &business);
+        client.submit_investor_kyc(&investor, &kyc);
+        client.verify_investor(&investor, &200_000i128);
+
+        let currency = {
+            let token_admin = Address::generate(&env);
+            let c = env.register_stellar_asset_contract_v2(token_admin).address();
+            let sac = token::StellarAssetClient::new(&env, &c);
+            sac.mint(&business, &100_000i128);
+            sac.mint(&investor, &100_000i128);
+            sac.mint(&contract_id, &1i128);
+            let tok = token::Client::new(&env, &c);
+            let exp = env.ledger().sequence() + 50_000;
+            tok.approve(&business, &contract_id, &400_000i128, &exp);
+            tok.approve(&investor, &contract_id, &400_000i128, &exp);
+            c
+        };
+
+        TestFixture { env, client, contract_id, admin, business, investor, currency }
+    }
+
+    fn create_paid_invoice(&self, amount: i128, timestamp: u64) -> BytesN<32> {
+        self.env.ledger().set_timestamp(timestamp);
+        let due_date = timestamp + 86_400;
+        let invoice_id = self.client.upload_invoice(
+            &self.business,
+            &amount,
+            &self.currency,
+            &due_date,
+            &String::from_str(&self.env, "Test invoice"),
+            &InvoiceCategory::Services,
+            &Vec::new(&self.env),
+        );
+        self.client.verify_invoice(&invoice_id);
+        let bid_id = self.client.place_bid(&self.investor, &invoice_id, &amount, &(amount + 100));
+        self.client.accept_bid(&invoice_id, &bid_id);
+        self.env.ledger().set_timestamp(timestamp + 10);
+        self.client.settle_invoice(&invoice_id, &amount);
+        let inv = self.client.get_invoice(&invoice_id);
+        assert_eq!(inv.status, InvoiceStatus::Paid);
+        invoice_id
+    }
+
+    fn create_invoice_with_status(&self, amount: i128, status: InvoiceStatus, timestamp: u64) -> BytesN<32> {
+        match status {
+            InvoiceStatus::Paid => self.create_paid_invoice(amount, timestamp),
+            InvoiceStatus::Defaulted | InvoiceStatus::Refunded => {
+                self.env.ledger().set_timestamp(timestamp);
+                let due_date = timestamp + 86_400;
+                let invoice_id = self.client.upload_invoice(
+                    &self.business,
+                    &amount,
+                    &self.currency,
+                    &due_date,
+                    &String::from_str(&self.env, "Test invoice"),
+                    &InvoiceCategory::Services,
+                    &Vec::new(&self.env),
+                );
+                self.client.verify_invoice(&invoice_id);
+                let bid_id = self.client.place_bid(&self.investor, &invoice_id, &amount, &(amount + 100));
+                self.client.accept_bid(&invoice_id, &bid_id);
+                self.env.ledger().set_timestamp(timestamp + 10);
+
+                match status {
+                    InvoiceStatus::Defaulted => {
+                        self.env.ledger().set_timestamp(due_date + 1);
+                        self.client.expire_invoice(&invoice_id);
+                        self.env.as_contract(&self.client.address, || {
+                            let mut inv = InvoiceStorage::get(&self.env, &invoice_id).unwrap();
+                            inv.mark_as_defaulted();
+                            InvoiceStorage::store(&self.env, &inv);
+                        });
+                    }
+                    InvoiceStatus::Refunded => {
+                        self.env.ledger().set_timestamp(due_date + 1);
+                        self.client.refund_escrow_funds(&invoice_id, &self.business);
+                    }
+                    _ => {}
+                }
+                let inv = self.client.get_invoice(&invoice_id);
+                assert_eq!(inv.status, status);
+                invoice_id
+            }
+            _ => {
+                self.env.ledger().set_timestamp(timestamp);
+                let due_date = timestamp + 86_400;
+                let invoice_id = self.client.upload_invoice(
+                    &self.business,
+                    &amount,
+                    &self.currency,
+                    &due_date,
+                    &String::from_str(&self.env, "Test invoice"),
+                    &InvoiceCategory::Services,
+                    &Vec::new(&self.env),
+                );
+                if status == InvoiceStatus::Verified {
+                    self.client.verify_invoice(&invoice_id);
+                }
+                invoice_id
+            }
+        }
+    }
+
+    fn funded_invoice(&self, timestamp: u64) -> BytesN<32> {
+        self.env.ledger().set_timestamp(timestamp);
+        let due_date = timestamp + 86_400;
+        let invoice_id = self.client.upload_invoice(
+            &self.business, &1000, &self.currency, &due_date,
+            &String::from_str(&self.env, "Test"),
+            &InvoiceCategory::Services, &Vec::new(&self.env),
+        );
+        self.client.verify_invoice(&invoice_id);
+        let bid_id = self.client.place_bid(&self.investor, &invoice_id, &1000, &1100);
+        self.client.accept_bid(&invoice_id, &bid_id);
+        invoice_id
+    }
+}
+
+/// Test: only terminal status invoices are pruned
+#[test]
+fn test_prune_only_terminal() {
+    let fx = TestFixture::setup();
+    let now = 1_000_000u64;
+    let retention = 86_400u64;
+
+    let old_paid = fx.create_invoice_with_status(1000, InvoiceStatus::Paid, now - 200_000);
+    let pending = fx.create_invoice_with_status(1000, InvoiceStatus::Pending, now - 200_000);
+
+    fx.env.ledger().set_timestamp(now);
+
+    let report = fx.client.prune_terminal_invoices(&fx.admin, &retention, &0, &100);
+    assert_eq!(report.pruned, 1, "should prune 1 terminal invoice");
+    assert_eq!(report.scanned, 2, "should scan 2 invoices total");
+
+    assert!(fx.client.try_get_invoice(&old_paid).is_err());
+    let inv = fx.client.get_invoice(&pending);
+    assert_eq!(inv.status, InvoiceStatus::Pending);
+}
+
+/// Test: invoices within retention window are not pruned
+#[test]
+fn test_within_retention_window_not_pruned() {
+    let fx = TestFixture::setup();
+    let now = 1_000_000u64;
+    let retention = 86_400u64;
+
+    let recent_paid = fx.create_invoice_with_status(1000, InvoiceStatus::Paid, now - 1000);
+
+    fx.env.ledger().set_timestamp(now);
+
+    let report = fx.client.prune_terminal_invoices(&fx.admin, &retention, &0, &100);
+    assert_eq!(report.pruned, 0, "should not prune recent invoice");
+    assert_eq!(report.scanned, 1);
+
+    let inv = fx.client.get_invoice(&recent_paid);
+    assert_eq!(inv.status, InvoiceStatus::Paid);
+}
+
+/// Test: funded invoice is never pruned
+#[test]
+fn test_funded_invoice_never_pruned() {
+    let fx = TestFixture::setup();
+    let now = 1_000_000u64;
+
+    let invoice_id = fx.funded_invoice(now - 200_000);
+    let inv = fx.client.get_invoice(&invoice_id);
+    assert_eq!(inv.status, InvoiceStatus::Funded);
+
+    fx.env.ledger().set_timestamp(now);
+
+    let report = fx.client.prune_terminal_invoices(&fx.admin, &0, &0, &100);
+    assert_eq!(report.pruned, 0, "funded invoice should never be pruned");
+    assert_eq!(report.scanned, 1);
+
+    let inv = fx.client.get_invoice(&invoice_id);
+    assert_eq!(inv.status, InvoiceStatus::Funded);
+}
+
+/// Test: pagination works correctly (resumable via next_offset)
+#[test]
+fn test_pagination() {
+    let fx = TestFixture::setup();
+    let now = 1_000_000u64;
+    let retention = 86_400u64;
+
+    // Create invoices at different timestamps so we know which are pruned
+    let _id1 = fx.create_invoice_with_status(1000, InvoiceStatus::Paid, now - 200_000);
+    let _id2 = fx.create_invoice_with_status(1000, InvoiceStatus::Paid, now - 200_000);
+    let _id3 = fx.create_invoice_with_status(1000, InvoiceStatus::Paid, now - 200_000);
+
+    fx.env.ledger().set_timestamp(now);
+
+    // Page 1: offset 0, limit 2
+    let r1 = fx.client.prune_terminal_invoices(&fx.admin, &retention, &0, &2);
+    assert_eq!(r1.pruned, 2);
+    assert_eq!(r1.scanned, 2);
+    assert!(r1.next_offset > 0);
+
+    // Page 2: resume at next_offset (total shrank to 1, offset past end → empty)
+    let r2 = fx.client.prune_terminal_invoices(&fx.admin, &retention, &r1.next_offset, &2);
+    assert_eq!(r2.pruned, 0);
+    assert_eq!(r2.scanned, 0);
+
+    // Restart from offset 0 to get the remaining one
+    let r3 = fx.client.prune_terminal_invoices(&fx.admin, &retention, &0, &100);
+    assert_eq!(r3.pruned, 1);
+    assert_eq!(r3.scanned, 1);
+}
+
+/// Test: admin auth required
+#[test]
+fn test_non_admin_rejected() {
+    let fx = TestFixture::setup();
+    let stranger = Address::generate(&fx.env);
+    let err = fx.client.try_prune_terminal_invoices(&stranger, &0, &0, &100)
+        .unwrap_err().unwrap();
+    assert_eq!(err, QuickLendXError::NotAdmin);
+}
+
+/// Test: zero retention prunes all terminal invoices
+#[test]
+fn test_zero_retention_prunes_all_terminal() {
+    let fx = TestFixture::setup();
+    let now = 1_000_000u64;
+
+    let _id1 = fx.create_invoice_with_status(1000, InvoiceStatus::Paid, now - 200_000);
+    let _id2 = fx.create_invoice_with_status(1000, InvoiceStatus::Paid, now - 200_000);
+
+    fx.env.ledger().set_timestamp(now);
+
+    let report = fx.client.prune_terminal_invoices(&fx.admin, &0, &0, &100);
+    assert_eq!(report.pruned, 2);
+}
+
+/// Test: defaulted and refunded invoices are pruned
+#[test]
+fn test_defaulted_and_refunded_pruned() {
+    let fx = TestFixture::setup();
+    let now = 1_000_000u64;
+    let retention = 86_400u64;
+
+    let defaulted_id = fx.create_invoice_with_status(1000, InvoiceStatus::Defaulted, now - 200_000);
+    let refunded_id = fx.create_invoice_with_status(1000, InvoiceStatus::Refunded, now - 200_000);
+
+    fx.env.ledger().set_timestamp(now);
+
+    let report = fx.client.prune_terminal_invoices(&fx.admin, &retention, &0, &100);
+    assert_eq!(report.pruned, 2, "should prune defaulted and refunded invoices");
+    assert!(fx.client.try_get_invoice(&defaulted_id).is_err());
+    assert!(fx.client.try_get_invoice(&refunded_id).is_err());
+}
+
+/// Test: PruneReport struct fields are correct
+#[test]
+fn test_prune_report_fields() {
+    let fx = TestFixture::setup();
+    let now = 1_000_000u64;
+
+    let _id = fx.create_invoice_with_status(1000, InvoiceStatus::Paid, now - 200_000);
+
+    fx.env.ledger().set_timestamp(now);
+
+    let report = fx.client.prune_terminal_invoices(&fx.admin, &86_400, &0, &100);
+    assert_eq!(report.scanned, 1);
+    assert_eq!(report.pruned, 1);
+    assert_eq!(report.next_offset, 1);
+}
+
+/// Test: limit cap
+#[test]
+fn test_limit_capped_at_max() {
+    let fx = TestFixture::setup();
+    let now = 1_000_000u64;
+
+    for _ in 0..5 {
+        fx.create_invoice_with_status(1000, InvoiceStatus::Paid, now - 200_000);
+    }
+
+    fx.env.ledger().set_timestamp(now);
+
+    let report = fx.client.prune_terminal_invoices(&fx.admin, &0, &0, &200);
+    assert_eq!(report.pruned, 5);
+    assert_eq!(report.scanned, 5);
+}
+
+/// Test: offset beyond total
+#[test]
+fn test_offset_beyond_total() {
+    let fx = TestFixture::setup();
+    let now = 1_000_000u64;
+
+    let _id = fx.create_invoice_with_status(1000, InvoiceStatus::Paid, now - 200_000);
+
+    fx.env.ledger().set_timestamp(now);
+
+    let report = fx.client.prune_terminal_invoices(&fx.admin, &86_400, &100, &10);
+    assert_eq!(report.pruned, 0);
+    assert_eq!(report.scanned, 0);
+}
+
+/// Test: no terminal invoices
+#[test]
+fn test_no_terminal_invoices() {
+    let fx = TestFixture::setup();
+    let now = 1_000_000u64;
+
+    fx.create_invoice_with_status(1000, InvoiceStatus::Pending, now - 200_000);
+
+    fx.env.ledger().set_timestamp(now);
+
+    let report = fx.client.prune_terminal_invoices(&fx.admin, &86_400, &0, &100);
+    assert_eq!(report.pruned, 0);
+    assert_eq!(report.scanned, 1);
+}
+
+/// Test: index cleanup - no orphan after prune
+#[test]
+fn test_index_cleanup_no_orphans() {
+    let fx = TestFixture::setup();
+    let now = 1_000_000u64;
+
+    let invoice_id = fx.create_invoice_with_status(1000, InvoiceStatus::Paid, now - 200_000);
+
+    fx.env.ledger().set_timestamp(now);
+
+    let inv = fx.client.get_invoice(&invoice_id);
+    assert_eq!(inv.status, InvoiceStatus::Paid);
+
+    fx.client.prune_terminal_invoices(&fx.admin, &86_400, &0, &100);
+
+    assert!(
+        fx.client.try_get_invoice(&invoice_id).is_err(),
+        "invoice should be deleted from persistent storage"
+    );
+}

--- a/quicklendx-contracts/src/types.rs
+++ b/quicklendx-contracts/src/types.rs
@@ -24,6 +24,12 @@ pub enum InvoiceStatus {
     Refunded,
 }
 
+impl InvoiceStatus {
+    pub fn is_terminal(&self) -> bool {
+        matches!(self, InvoiceStatus::Paid | InvoiceStatus::Defaulted | InvoiceStatus::Cancelled | InvoiceStatus::Refunded)
+    }
+}
+
 /// Bid status enumeration
 #[contracttype]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -247,6 +253,21 @@ pub struct RebuildReport {
     pub scanned: u32,
     /// Number of records repaired or rewritten by the rebuild helper.
     pub reindexed: u32,
+    /// Offset to pass on the next call.
+    pub next_offset: u32,
+}
+
+/// Report returned by paginated admin prune helpers.
+///
+/// The prune is paginated and resumable. Pass `next_offset` as the `offset`
+/// on the next call. The last page is reached when `next_offset` stops advancing.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PruneReport {
+    /// Number of invoice IDs examined in this page.
+    pub scanned: u32,
+    /// Number of invoices actually pruned (deleted).
+    pub pruned: u32,
     /// Offset to pass on the next call.
     pub next_offset: u32,
 }


### PR DESCRIPTION
Paginated, admin-gated prune of long-settled terminal invoices; never touches active state.
- Add PruneReport struct and InvoiceStatus::is_terminal()
- Add prune_terminal_invoices_page with full index cleanup via delete_invoice
- Wire entrypoint in lib.rs with admin guard
- Add 12 tests (terminal-only, age-gated, pagination, index cleanup, safety guards)
- Document retention policy in storage-ttl-policy.md

closes: #1329 