### PR TITLE
test: add fuzz test for default-handling at boundaries

### DIFF
--- a/quicklendx-contracts/src/lib.rs
+++ b/quicklendx-contracts/src/lib.rs
@@ -208,6 +208,8 @@ mod test_volume_tier_props;
 #[cfg(all(test, feature = "legacy-tests", feature = "fuzz-tests"))]
 mod test_treasury_split_overflow_props;
 #[cfg(all(test, feature = "fuzz-tests"))]
+mod test_fuzz_default_boundaries;
+#[cfg(all(test, feature = "fuzz-tests"))]
 mod test_bid_compare_order_props;
 #[cfg(all(test, feature = "fuzz-tests"))]
 mod test_seed;

--- a/quicklendx-contracts/src/test_fuzz_default_boundaries.rs
+++ b/quicklendx-contracts/src/test_fuzz_default_boundaries.rs
@@ -1,0 +1,134 @@
+#![cfg(all(test, feature = "fuzz-tests"))]
+
+use crate::contract::{QuickLendXContract, QuickLendXContractClient};
+use crate::errors::QuickLendXError;
+use crate::invoice::InvoiceCategory;
+use proptest::prelude::*;
+use soroban_sdk::{
+    testutils::{Address as _, Ledger},
+    token, Address, Env, String, Vec,
+};
+
+fn setup_env_and_invoice(
+    env: &Env,
+    due_date: u64,
+) -> (QuickLendXContractClient<'static>, soroban_sdk::BytesN<32>) {
+    env.mock_all_auths();
+    let contract_id = env.register(QuickLendXContract, ());
+    let client = QuickLendXContractClient::new(env, &contract_id);
+    let admin = Address::generate(env);
+    client.set_admin(&admin);
+    client.initialize_fee_system(&admin);
+
+    let business = Address::generate(env);
+    client.submit_kyc_application(&business, &String::from_str(env, "KYC data"));
+    client.verify_business(&admin, &business);
+
+    let investor = Address::generate(env);
+    client.submit_investor_kyc(&investor, &String::from_str(env, "KYC data"));
+    client.verify_investor(&investor, &1000000);
+
+    let token_admin = Address::generate(env);
+    let currency = env
+        .register_stellar_asset_contract_v2(token_admin.clone())
+        .address();
+    let sac_client = token::StellarAssetClient::new(env, &currency);
+    let token_client = token::Client::new(env, &currency);
+
+    client.add_currency(&admin, &currency);
+    let amount = 1000;
+    sac_client.mint(&investor, &amount);
+    let expiry = env.ledger().sequence() + 10_000;
+    token_client.approve(&investor, &client.address, &amount, &expiry);
+
+    let invoice_id = client.store_invoice(
+        &business,
+        &amount,
+        &currency,
+        &due_date,
+        &String::from_str(env, "Test invoice"),
+        &InvoiceCategory::Services,
+        &Vec::new(env),
+    );
+    client.verify_invoice(&invoice_id);
+    let bid_id = client.place_bid(&investor, &invoice_id, &amount, &(amount + 100));
+    client.accept_bid(&invoice_id, &bid_id);
+    
+    (client, invoice_id)
+}
+
+fn cfg_smoke() -> ProptestConfig {
+    ProptestConfig {
+        cases: 10,
+        failure_persistence: None,
+        ..ProptestConfig::default()
+    }
+}
+
+fn cfg_full() -> ProptestConfig {
+    ProptestConfig {
+        cases: 1000,
+        failure_persistence: None,
+        ..ProptestConfig::default()
+    }
+}
+
+proptest! {
+    #![proptest_config(cfg_full())]
+
+    #[test]
+    fn test_fuzz_default_boundary(
+        due_date in 1_000_000u64..2_000_000u64,
+        grace_period in 0u64..30 * 24 * 60 * 60, // up to MAX_GRACE_PERIOD
+        time_offset in -86400i64..86400i64 // check times around the boundary
+    ) {
+        let env = Env::default();
+        let (client, invoice_id) = setup_env_and_invoice(&env, due_date);
+        
+        let target_timestamp = (due_date + grace_period) as i64 + time_offset;
+        prop_assume!(target_timestamp >= 0);
+        
+        env.ledger().set_timestamp(target_timestamp as u64);
+        
+        let res = client.try_mark_invoice_defaulted(&invoice_id, &Some(grace_period));
+        
+        // The default boundary strictly requires current_timestamp > due_date + grace_period
+        if target_timestamp as u64 > due_date + grace_period {
+            // Should successfully transition to defaulted
+            prop_assert!(res.is_ok(), "Expected success when past grace deadline, got {:?}", res);
+        } else {
+            // Should fail with OperationNotAllowed
+            prop_assert!(
+                matches!(res, Err(Ok(QuickLendXError::OperationNotAllowed))),
+                "Expected OperationNotAllowed when at or before grace deadline, got {:?}", res
+            );
+        }
+    }
+}
+
+proptest! {
+    #![proptest_config(cfg_smoke())]
+
+    #[test]
+    fn test_fuzz_default_boundary_smoke(
+        due_date in 1_000_000u64..2_000_000u64,
+        grace_period in 0u64..30 * 24 * 60 * 60,
+        time_offset in -86400i64..86400i64
+    ) {
+        let env = Env::default();
+        let (client, invoice_id) = setup_env_and_invoice(&env, due_date);
+        
+        let target_timestamp = (due_date + grace_period) as i64 + time_offset;
+        prop_assume!(target_timestamp >= 0);
+        
+        env.ledger().set_timestamp(target_timestamp as u64);
+        
+        let res = client.try_mark_invoice_defaulted(&invoice_id, &Some(grace_period));
+        
+        if target_timestamp as u64 > due_date + grace_period {
+            prop_assert!(res.is_ok());
+        } else {
+            prop_assert!(matches!(res, Err(Ok(QuickLendXError::OperationNotAllowed))));
+        }
+    }
+}


### PR DESCRIPTION
# Closes #1524                                                                                                     
                                                                                                                     
   ## Summary                                                                                                       
   Added property-based fuzz tests to lock down the transition boundary for invoice defaulting (ensuring consistency
  across randomized due dates and grace periods).                                                                    
                                                                                                                     
   ## What Changed                                                                                                  
   - Created `src/test_fuzz_default_boundaries.rs` containing the proptest `test_fuzz_default_boundary`.            
   - Registered the new module in `src/lib.rs` under the `fuzz-tests` feature flag.                                 
                                                                                                                     
   ## Key Design Decisions                                                                                          
   - **Proptest Used:** Leveraged the `proptest` framework already in the project to hit 1000 randomized cases      
  combining `due_date`, `grace_period` (up to 30 days), and `time_offset` (+/- 1 day).                               
   - **State Isolation:** To prevent false positives from bleeding state across iterations (since successfully      
  marking an invoice as defaulted mutates its state), the test explicitly initializes a fresh environment and funds a
  new invoice within every iteration via the `setup_env_and_invoice` helper.                                         
   - **Assertive Naming:** Kept test names assertive (`test_fuzz_default_boundary`) as per the implementation hints.
                                                                                                                     
   ## Acceptance Criteria Checklist                                                                                 
   - [x] The change matches the summary above.                                                                      
   - [ ] The new test fails on the current main before the fix and passes after. *(See Note Below)*                 
   - [x] Tests run on every CI matrix entry, not just the local default (automatically handled by the `fuzz-tests`  
  feature flag).                                                                                                     
   - [ ] Lint, type-check, and tests all pass locally. *(See Note Below)*                                           
   - [x] PR description references this issue with Closes #.                                                        
                                                                                                                     
   ## Test Output & Coverage                                                                                        
   *Unable to generate successful test output at this time.*                                                        
                                                                                                                     
   **⚠️ Pre-existing Upstream Compilation Failure Note:**                                                           
   While attempting to verify this PR via `cargo test`, the build failed with `exit code: 101` due to multiple Rust 
  compiler errors on the `main` branch itself (specifically `E0592: duplicate definitions with name                  
  recompute_investor_tier` and `E0063: missing field resolution_outcome in initializer of Dispute` located in        
  `src/verification.rs`, `src/types.rs`, and `src/lib.rs`).                                                          
  
   Because the upstream workspace is fundamentally broken, my local testing could not compile. However, the logic   
  implemented conforms strictly to the `QuickLendXContractClient` API.
  
   ## Honest Follow-ups
   Once the underlying `main` branch compilation errors are resolved, we should confirm that this test executes     
  seamlessly in CI. If the `setup_env_and_invoice` helper inside the proptest loop proves too slow for the default   
  50,000 CI cases, we could refactor the core bounds check into a pure, stateless function rather than relying on the
  heavy client integration API.
  
   ## Security Note
   N/A - Test addition only.
