### PR TITLE
fix(contracts): restore crate compilation broken by #1451 investor-tier merge

### DIFF
--- a/quicklendx-contracts/src/lib.rs
+++ b/quicklendx-contracts/src/lib.rs
@@ -267,7 +267,7 @@ use events::{
 use investment::InvestmentStorage;
 use invoice_search::InvoiceSearch;
 use payments::{create_escrow, release_escrow, EscrowStorage};
-use profits::{calculate_profit as do_calculate_profit, PlatformFee, PlatformFeeConfig};
+use profits::{calculate_profit as do_calculate_profit, PlatformFee};
 use settlement::{
     process_partial_payment as do_process_partial_payment, settle_invoice as do_settle_invoice,
 };
@@ -1968,17 +1968,6 @@ impl QuickLendXContract {
         recompute_investor_tier(&env, &admin, &investor)
     }
 
-    /// Recompute investor tier from tracked investment performance.
-    pub fn recompute_investor_tier(
-        env: Env,
-        admin: Address,
-        investor: Address,
-    ) -> Result<(), QuickLendXError> {
-        pause::PauseControl::require_not_paused(&env)?;
-        recompute_investor_tier(&env, &admin, &investor)
-    }
-
-
     /// Verify business (admin only)
     pub fn verify_business(
         // This function is already defined in verification module
@@ -3293,6 +3282,7 @@ impl QuickLendXContract {
                 "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
             ),
             resolved_at: 0,
+            resolution_outcome: None,
         };
         InvoiceStorage::update_invoice(&env, &invoice);
         dispute::track_dispute_invoice(&env, &invoice_id);

--- a/quicklendx-contracts/src/verification.rs
+++ b/quicklendx-contracts/src/verification.rs
@@ -1222,22 +1222,12 @@ pub fn calculate_investor_risk_score(
     Ok(risk_score)
 }
 
-/// Determine investor tier based on risk score and investment history
-/// Calculate the investor tier using deterministic performance thresholds.
+/// Determine an investor's tier from their stored verification record.
 ///
-/// Promotion is based on the investor's accumulated performance counters and
-/// risk score. The mapping is stable and idempotent: the same counters always
-/// yield the same tier.
-///
-/// Threshold table:
-/// | Tier | Risk Score | Total Invested | Successful Investments | Max Default Rate |
-/// |------|------------|----------------|------------------------|------------------|
-/// | VIP | <= 10 | >= 5,000,000 | >= 50 | <= 5% |
-/// | Platinum | <= 20 | >= 1,000,000 | >= 20 | <= 10% |
-/// | Gold | <= 40 | >= 100,000 | >= 10 | <= 15% |
-/// | Silver | <= 60 | >= 10,000 | >= 3 | <= 25% |
-/// | Basic | otherwise | - | - | - |
-pub fn compute_investor_tier(
+/// Loads the investor's tracked performance counters and delegates to the
+/// deterministic [`compute_investor_tier`]. Returns [`InvestorTier::Basic`]
+/// when the investor has no verification record yet.
+pub fn determine_investor_tier(
     env: &Env,
     investor: &Address,
     risk_score: u32,
@@ -1254,6 +1244,68 @@ pub fn compute_investor_tier(
     }
 
     Ok(InvestorTier::Basic)
+}
+
+/// Calculate the investor tier using deterministic performance thresholds.
+///
+/// Promotion is based on the investor's accumulated performance counters and
+/// risk score. The mapping is stable and idempotent: the same counters always
+/// yield the same tier.
+///
+/// Threshold table (a tier requires every column in its row to be satisfied;
+/// otherwise the next lower tier is tried, falling back to `Basic`):
+/// | Tier | Risk Score | Total Invested | Successful Investments | Max Default Rate |
+/// |------|------------|----------------|------------------------|------------------|
+/// | VIP | <= 10 | >= 5,000,000 | >= 50 | <= 5% |
+/// | Platinum | <= 20 | >= 1,000,000 | >= 20 | <= 10% |
+/// | Gold | <= 40 | >= 100,000 | >= 10 | <= 15% |
+/// | Silver | <= 60 | >= 10,000 | >= 3 | <= 25% |
+/// | Basic | otherwise | - | - | - |
+///
+/// The default rate is `defaulted_investments / (successful_investments +
+/// defaulted_investments)`, evaluated without division as
+/// `defaulted * 100 <= max_pct * total_count` to stay integer-exact.
+pub fn compute_investor_tier(
+    total_invested: i128,
+    successful_investments: u32,
+    defaulted_investments: u32,
+    risk_score: u32,
+) -> Result<InvestorTier, QuickLendXError> {
+    validate_risk_score(risk_score)?;
+
+    let total_count = successful_investments as u64 + defaulted_investments as u64;
+    let defaulted = defaulted_investments as u64;
+    let default_rate_within = |max_pct: u64| defaulted * 100 <= max_pct * total_count;
+
+    let tier = if risk_score <= 10
+        && total_invested >= 5_000_000
+        && successful_investments >= 50
+        && default_rate_within(5)
+    {
+        InvestorTier::VIP
+    } else if risk_score <= 20
+        && total_invested >= 1_000_000
+        && successful_investments >= 20
+        && default_rate_within(10)
+    {
+        InvestorTier::Platinum
+    } else if risk_score <= 40
+        && total_invested >= 100_000
+        && successful_investments >= 10
+        && default_rate_within(15)
+    {
+        InvestorTier::Gold
+    } else if risk_score <= 60
+        && total_invested >= 10_000
+        && successful_investments >= 3
+        && default_rate_within(25)
+    {
+        InvestorTier::Silver
+    } else {
+        InvestorTier::Basic
+    };
+
+    Ok(tier)
 }
 
 /// Determine risk level based on risk score
@@ -1466,61 +1518,6 @@ pub fn set_investment_limit(
     verification.investment_limit = calculated_limit;
     verification.compliance_notes =
         Some(String::from_str(env, "Investment limit updated by admin"));
-
-    InvestorVerificationStorage::update(env, &verification);
-    Ok(())
-}
-
-/// Recompute investor tier and investment limit from tracked performance counters.
-///
-/// This function keeps the tier assignment deterministic and idempotent by
-/// recomputing tier from `total_invested`, `successful_investments`,
-/// `defaulted_investments`, and `risk_score`, then updating the stored record.
-/// It preserves the investor's approved base limit and applies the new tier/risk
-/// multipliers to derive the new investment limit.
-pub fn recompute_investor_tier(
-    env: &Env,
-    admin: &Address,
-    investor: &Address,
-) -> Result<(), QuickLendXError> {
-    admin.require_auth();
-    if !crate::admin::AdminStorage::is_admin(env, admin) {
-        return Err(QuickLendXError::NotAdmin);
-    }
-
-    let mut verification = InvestorVerificationStorage::get(env, investor)
-        .ok_or(QuickLendXError::KYCNotFound)?;
-
-    if !matches!(verification.status, BusinessVerificationStatus::Verified) {
-        return Err(QuickLendXError::InvalidKYCStatus);
-    }
-
-    let prior_tier = verification.tier.clone();
-    let prior_risk_level = verification.risk_level.clone();
-    let base_limit = recover_base_limit_from_current_limit(
-        verification.investment_limit,
-        &prior_tier,
-        &prior_risk_level,
-    )
-    .max(1);
-
-    let risk_score = calculate_investor_risk_score(env, investor, &verification.kyc_data)?;
-    validate_risk_score(risk_score)?;
-
-    let tier = compute_investor_tier(
-        verification.total_invested,
-        verification.successful_investments,
-        verification.defaulted_investments,
-        risk_score,
-    )?;
-    let risk_level = determine_risk_level(risk_score);
-    let investment_limit = calculate_investment_limit(&tier, &risk_level, base_limit);
-
-    verification.risk_score = risk_score;
-    verification.risk_level = risk_level;
-    verification.tier = tier;
-    verification.investment_limit = investment_limit;
-    verification.compliance_notes = Some(String::from_str(env, "Investor tier recomputed by admin"));
 
     InvestorVerificationStorage::update(env, &verification);
     Ok(())


### PR DESCRIPTION
Refs #1601 (draft — see *Needs author sign-off* below)

## Problem

`quicklendx-contracts` does **not compile** on `main` (`cac37b5f`), native or `wasm32-unknown-unknown` — 18–19 errors. It has been red since **#1451** (`f9462647`) merged in a non-compiling state, blocking CI for every PR. Full root-cause analysis in #1601.

## What this PR fixes

| Fix | Files |
| :--- | :--- |
| Reconstruct the deterministic tier model #1451 intended — keep `determine_investor_tier(env, investor, risk_score)` as the storage-backed wrapper, add the missing pure 4-arg `compute_investor_tier(total_invested, successful_investments, defaulted_investments, risk_score)` per the documented threshold table. Fixes the unresolved import/call + 4 arg-count mismatches. | `verification.rs` |
| Remove duplicated `recompute_investor_tier` definitions (+ cascading `#[contractimpl]` macro errors) | `lib.rs`, `verification.rs` |
| Drop redundant `use profits::PlatformFeeConfig` (already re-exported via `pub use types::*`) | `lib.rs` |
| Add missing `resolution_outcome` field to the `Dispute` initializer in `open_dispute` | `lib.rs` |

## Verification

```
cargo check                                            #  clean
cargo build --target wasm32-unknown-unknown --release  #  clean, no warnings
```

I could **not** run `cargo test` to exercise #1451's regression tests, because the **test target** has *separate, deeper* pre-existing breakage unrelated to this fix (see below). Instead I hand-validated the reconstructed thresholds against the behavioral expectations in `test_investor_kyc.rs` — they match:
- `…after_successful_history` (1.2M, 22 successful, 1 default) → **Platinum** ✓
- `…is_idempotent` (5.5M, 60, 2) → stable across repeated calls ✓
- `…blocks_high_default_rate` (2M, 20, 20 = 50% default) → **Basic** ✓ (the test's "50% default rate" comment confirms the denominator is `successful + defaulted`, which this implements)

## ⚠️ Needs author sign-off

The pure `compute_investor_tier` body was **lost in the #1451 merge** and reconstructed here strictly from the doc-comment threshold table. The **default-rate caps** (≤5/10/15/25%) were never in code before, so please confirm the intended semantics — particularly the default-rate denominator (`defaulted / (successful + defaulted)`). Marked **draft** until a #1451 author confirms.

## Out of scope (separate pre-existing breakage)

This PR deliberately fixes only the library/WASM compile break. The **test target** still fails to compile for unrelated reasons that predate and are independent of #1451 — these deserve their own issue:
- `DisputeResolution` doesn't satisfy native `ScVal` conversion traits (`types.rs`, `dispute_timeline.rs`)
- `Dispute` initializers missing `resolution_outcome` in `test_backup.rs`, `test_invoice_search_ranking.rs`
- `bench.rs` calls `Env::enable_invocation_metering` (not in the pinned SDK)
- `test_solvency_invariant.rs` declares a missing module (E0583)
- Two pre-existing `-D warnings` clippy lints in `escrow.rs` / `storage.rs`

No reformatting or unrelated refactors are included.