### PR TITLE
feat: add amount and ledger fields to InvoiceSettled event

### DIFF
--- a/docs/contracts/events_complete.md
+++ b/docs/contracts/events_complete.md
@@ -17,9 +17,11 @@ The QuickLendX protocol emits structured events for all critical operations to e
 ## Invoice Events
 
 ### InvoiceUploaded (`inv_up`)
+
 Emitted when a business uploads a new invoice to the protocol.
 
 **Data Fields:**
+
 - `invoice_id: BytesN<32>` - Unique invoice identifier
 - `business: Address` - Business uploading the invoice
 - `amount: i128` - Invoice principal amount
@@ -32,9 +34,11 @@ Emitted when a business uploads a new invoice to the protocol.
 ---
 
 ### InvoiceVerified (`inv_ver`)
+
 Emitted when an admin verifies an invoice for funding.
 
 **Data Fields:**
+
 - `invoice_id: BytesN<32>` - Verified invoice identifier
 - `business: Address` - Business owner
 - `timestamp: u64` - Verification timestamp
@@ -44,9 +48,11 @@ Emitted when an admin verifies an invoice for funding.
 ---
 
 ### InvoiceCancelled (`inv_canc`)
+
 Emitted when an invoice is cancelled by the business owner.
 
 **Data Fields:**
+
 - `invoice_id: BytesN<32>` - Cancelled invoice identifier
 - `business: Address` - Business owner
 - `timestamp: u64` - Cancellation timestamp
@@ -56,10 +62,14 @@ Emitted when an invoice is cancelled by the business owner.
 ---
 
 ### InvoiceSettled (`inv_set`)
+
 Emitted when an invoice is fully settled (payment received and distributed).
 
 **Data Fields:**
+
 - `invoice_id: BytesN<32>` - Settled invoice identifier
+- `amount: i128` - Total amount settled (sum of all payments applied)
+- `ledger: u32` - Ledger sequence number at the time of settlement
 - `business: Address` - Recipient of settlement
 - `investor: Address` - Investor who funded the invoice
 - `investor_return: i128` - Amount paid to investor
@@ -71,9 +81,11 @@ Emitted when an invoice is fully settled (payment received and distributed).
 ---
 
 ### InvoiceDefaulted (`inv_def`)
+
 Emitted when an invoice defaults after the grace period expires.
 
 **Data Fields:**
+
 - `invoice_id: BytesN<32>` - Defaulted invoice identifier
 - `business: Address` - Business that defaulted
 - `investor: Address` - Investor affected
@@ -84,9 +96,11 @@ Emitted when an invoice defaults after the grace period expires.
 ---
 
 ### InvoiceExpired (`inv_exp`)
+
 Emitted when an invoice's bidding window expires without acceptance.
 
 **Data Fields:**
+
 - `invoice_id: BytesN<32>` - Expired invoice identifier
 - `business: Address` - Business owner
 - `due_date: u64` - Original due date
@@ -96,9 +110,11 @@ Emitted when an invoice's bidding window expires without acceptance.
 ---
 
 ### InvoiceFunded (`inv_fnd`)
+
 Emitted when an invoice receives funding from an accepted bid.
 
 **Data Fields:**
+
 - `invoice_id: BytesN<32>` - Funded invoice identifier
 - `investor: Address` - Investor providing funding
 - `amount: i128` - Funding amount
@@ -109,9 +125,11 @@ Emitted when an invoice receives funding from an accepted bid.
 ---
 
 ### InvoiceMetadataUpdated (`inv_meta`)
+
 Emitted when invoice metadata (line items, tax ID, customer name) is added.
 
 **Data Fields:**
+
 - `invoice_id: BytesN<32>` - Invoice identifier
 - `customer_name: String` - End customer name
 - `tax_id: String` - Tax identification
@@ -123,9 +141,11 @@ Emitted when invoice metadata (line items, tax ID, customer name) is added.
 ---
 
 ### InvoiceMetadataCleared (`inv_mclr`)
+
 Emitted when invoice metadata is removed.
 
 **Data Fields:**
+
 - `invoice_id: BytesN<32>` - Invoice identifier
 - `business: Address` - Business owner
 
@@ -134,9 +154,11 @@ Emitted when invoice metadata is removed.
 ---
 
 ### PaymentRecorded (`pay_rec`)
+
 Emitted for each individual payment transaction.
 
 **Data Fields:**
+
 - `payer: Address` - Address making payment
 - `amount: i128` - Payment amount
 - `transaction_id: String` - External transaction identifier
@@ -147,9 +169,11 @@ Emitted for each individual payment transaction.
 ---
 
 ### PartialPayment (`inv_pp`)
+
 Emitted when a partial payment is applied to an invoice.
 
 **Data Fields:**
+
 - `invoice_id: BytesN<32>` - Invoice receiving payment
 - `business: Address` - Business owner
 - `payment_amount: i128` - Amount of this payment
@@ -162,9 +186,11 @@ Emitted when a partial payment is applied to an invoice.
 ---
 
 ### InvoiceSettledFinal (`inv_stlf`)
+
 Emitted when invoice settlement is finalized (distinct from initial settlement event).
 
 **Data Fields:**
+
 - `invoice_id: BytesN<32>` - Settled invoice identifier
 - `total_paid: i128` - Total payment received
 - `timestamp: u64` - Finalization timestamp
@@ -174,9 +200,11 @@ Emitted when invoice settlement is finalized (distinct from initial settlement e
 ---
 
 ### InvoiceCategoryUpdated (`cat_upd`)
+
 Emitted when invoice classification category is changed.
 
 **Data Fields:**
+
 - `invoice_id: BytesN<32>` - Invoice identifier
 - `business: Address` - Business owner
 - `old_category: InvoiceCategory` - Previous category
@@ -187,9 +215,11 @@ Emitted when invoice classification category is changed.
 ---
 
 ### InvoiceTagAdded (`tag_add`)
+
 Emitted when a tag is added to an invoice.
 
 **Data Fields:**
+
 - `invoice_id: BytesN<32>` - Tagged invoice identifier
 - `business: Address` - Business owner
 - `tag: String` - Tag value added
@@ -199,9 +229,11 @@ Emitted when a tag is added to an invoice.
 ---
 
 ### InvoiceTagRemoved (`tag_rm`)
+
 Emitted when a tag is removed from an invoice.
 
 **Data Fields:**
+
 - `invoice_id: BytesN<32>` - Invoice identifier
 - `business: Address` - Business owner
 - `tag: String` - Tag value removed
@@ -213,9 +245,11 @@ Emitted when a tag is removed from an invoice.
 ## Bid Events
 
 ### BidPlaced (`bid_plc`)
+
 Emitted when an investor places a bid on an invoice.
 
 **Data Fields:**
+
 - `bid_id: BytesN<32>` - Unique bid identifier
 - `invoice_id: BytesN<32>` - Target invoice identifier
 - `investor: Address` - Investor placing bid
@@ -229,9 +263,11 @@ Emitted when an investor places a bid on an invoice.
 ---
 
 ### BidAccepted (`bid_acc`)
+
 Emitted when a business accepts a bid.
 
 **Data Fields:**
+
 - `bid_id: BytesN<32>` - Accepted bid identifier
 - `invoice_id: BytesN<32>` - Associated invoice
 - `investor: Address` - Winning investor
@@ -245,9 +281,11 @@ Emitted when a business accepts a bid.
 ---
 
 ### BidWithdrawn (`bid_wdr`)
+
 Emitted when an investor withdraws their bid.
 
 **Data Fields:**
+
 - `bid_id: BytesN<32>` - Withdrawn bid identifier
 - `invoice_id: BytesN<32>` - Associated invoice
 - `investor: Address` - Bidding investor
@@ -259,9 +297,11 @@ Emitted when an investor withdraws their bid.
 ---
 
 ### BidExpired (`bid_exp`)
+
 Emitted when a bid expires without being accepted.
 
 **Data Fields:**
+
 - `bid_id: BytesN<32>` - Expired bid identifier
 - `invoice_id: BytesN<32>` - Associated invoice
 - `investor: Address` - Original bidder
@@ -275,9 +315,11 @@ Emitted when a bid expires without being accepted.
 ## Escrow Events
 
 ### EscrowCreated (`esc_cr`)
+
 Emitted when escrow is established to hold investor funds.
 
 **Data Fields:**
+
 - `escrow_id: BytesN<32>` - Unique escrow identifier
 - `invoice_id: BytesN<32>` - Associated invoice
 - `investor: Address` - Funds owner
@@ -289,9 +331,11 @@ Emitted when escrow is established to hold investor funds.
 ---
 
 ### EscrowReleased (`esc_rel`)
+
 Emitted when escrow funds are released to the business.
 
 **Data Fields:**
+
 - `escrow_id: BytesN<32>` - Escrow identifier
 - `invoice_id: BytesN<32>` - Associated invoice
 - `business: Address` - Recipient address
@@ -303,9 +347,11 @@ Emitted when escrow funds are released to the business.
 ---
 
 ### EscrowRefunded (`esc_ref`)
+
 Emitted when escrow funds are refunded to the investor.
 
 **Data Fields:**
+
 - `escrow_id: BytesN<32>` - Escrow identifier
 - `invoice_id: BytesN<32>` - Associated invoice
 - `investor: Address` - Refund recipient
@@ -318,9 +364,11 @@ Emitted when escrow funds are refunded to the investor.
 ## Dispute Events
 
 ### DisputeCreated (`dsp_cr`)
+
 Emitted when a dispute is opened on an invoice.
 
 **Data Fields:**
+
 - `invoice_id: BytesN<32>` - Disputed invoice
 - `created_by: Address` - Party creating dispute
 - `reason: String` - Dispute reason summary
@@ -331,9 +379,11 @@ Emitted when a dispute is opened on an invoice.
 ---
 
 ### DisputeUnderReview (`dsp_ur`)
+
 Emitted when a dispute is escalated for admin review.
 
 **Data Fields:**
+
 - `invoice_id: BytesN<32>` - Disputed invoice
 - `reviewed_by: Address` - Admin reviewer
 - `timestamp: u64` - Review start timestamp
@@ -343,9 +393,11 @@ Emitted when a dispute is escalated for admin review.
 ---
 
 ### DisputeResolved (`dsp_rs`)
+
 Emitted when a dispute is resolved.
 
 **Data Fields:**
+
 - `invoice_id: BytesN<32>` - Disputed invoice
 - `resolved_by: Address` - Admin resolver
 - `resolution: String` - Resolution summary
@@ -358,9 +410,11 @@ Emitted when a dispute is resolved.
 ## Insurance Events
 
 ### InsuranceAdded (`ins_add`)
+
 Emitted when insurance coverage is added to an invoice.
 
 **Data Fields:**
+
 - `investment_id: BytesN<32>` - Investment identifier
 - `invoice_id: BytesN<32>` - Insured invoice
 - `investor: Address` - Investor beneficiary
@@ -374,9 +428,11 @@ Emitted when insurance coverage is added to an invoice.
 ---
 
 ### InsurancePremiumCollected (`ins_prm`)
+
 Emitted when insurance premiums are collected from investors.
 
 **Data Fields:**
+
 - `investment_id: BytesN<32>` - Investment identifier
 - `provider: Address` - Insurance provider receiving premium
 - `premium_amount: i128` - Premium collected
@@ -386,9 +442,11 @@ Emitted when insurance premiums are collected from investors.
 ---
 
 ### InsuranceClaimed (`ins_clm`)
+
 Emitted when an insurance claim is paid out.
 
 **Data Fields:**
+
 - `investment_id: BytesN<32>` - Investment identifier
 - `invoice_id: BytesN<32>` - Associated invoice
 - `provider: Address` - Insurance provider
@@ -401,9 +459,11 @@ Emitted when an insurance claim is paid out.
 ## Verification Events
 
 ### InvestorVerified (`inv_veri`)
+
 Emitted when an investor is KYC-verified and approved for investment.
 
 **Data Fields:**
+
 - `investor: Address` - Verified investor address
 - `investment_limit: i128` - Maximum investment authorization
 - `verified_at: u64` - Verification timestamp
@@ -413,9 +473,11 @@ Emitted when an investor is KYC-verified and approved for investment.
 ---
 
 ### InvestorAnalyticsUpdated (`inv_anal`)
+
 Emitted when investor analytics/metrics are calculated.
 
 **Data Fields:**
+
 - `investor: Address` - Investor address
 - `success_rate: i128` - Percentage of successful investments
 - `risk_score: u32` - Calculated risk score (0-1000)
@@ -426,9 +488,11 @@ Emitted when investor analytics/metrics are calculated.
 ---
 
 ### InvestorPerformanceUpdated (`inv_perf`)
+
 Emitted when overall investor population metrics are calculated.
 
 **Data Fields:**
+
 - `total_investors: u32` - Total investor count
 - `verified_investors: u32` - Verified investor count
 - `platform_success_rate: i128` - Overall platform success rate
@@ -441,9 +505,11 @@ Emitted when overall investor population metrics are calculated.
 ## Fee & Treasury Events
 
 ### PlatformFeeUpdated (`fee_upd`)
+
 Emitted when platform fee configuration is modified.
 
 **Data Fields:**
+
 - `fee_bps: u32` - Fee rate in basis points (0-10000)
 - `updated_at: u64` - Update timestamp
 - `updated_by: Address` - Admin who updated
@@ -453,9 +519,11 @@ Emitted when platform fee configuration is modified.
 ---
 
 ### PlatformFeeConfigUpdated (`fee_cfg`)
+
 Emitted when fee configuration is changed by admin.
 
 **Data Fields:**
+
 - `old_fee_bps: u32` - Previous fee rate
 - `new_fee_bps: u32` - New fee rate
 - `updated_by: Address` - Admin address
@@ -466,9 +534,11 @@ Emitted when fee configuration is changed by admin.
 ---
 
 ### PlatformFeeRouted (`fee_rout`)
+
 Emitted when platform fees are transferred to treasury.
 
 **Data Fields:**
+
 - `invoice_id: BytesN<32>` - Associated invoice
 - `recipient: Address` - Treasury/recipient address
 - `fee_amount: i128` - Fee amount transferred
@@ -479,9 +549,11 @@ Emitted when platform fees are transferred to treasury.
 ---
 
 ### TreasuryConfigured (`trs_cfg`)
+
 Emitted when treasury address is configured.
 
 **Data Fields:**
+
 - `treasury_address: Address` - Treasury recipient address
 - `configured_by: Address` - Admin address
 - `timestamp: u64` - Configuration timestamp
@@ -491,9 +563,11 @@ Emitted when treasury address is configured.
 ---
 
 ### ProfitFeeBreakdown (`pf_brk`)
+
 Emitted with detailed settlement calculation transparency.
 
 **Data Fields:**
+
 - `invoice_id: BytesN<32>` - Invoice identifier
 - `investment_amount: i128` - Original investment principal
 - `payment_amount: i128` - Total payment received
@@ -510,9 +584,11 @@ Emitted with detailed settlement calculation transparency.
 ## Backup & Recovery Events
 
 ### BackupCreated (`bkup_crt`)
+
 Emitted when a system backup is created.
 
 **Data Fields:**
+
 - `backup_id: BytesN<32>` - Backup identifier
 - `invoice_count: u32` - Number of invoices backed up
 - `timestamp: u64` - Backup creation time
@@ -522,9 +598,11 @@ Emitted when a system backup is created.
 ---
 
 ### BackupRestored (`bkup_rstr`)
+
 Emitted when a backup is restored.
 
 **Data Fields:**
+
 - `backup_id: BytesN<32>` - Restored backup identifier
 - `invoice_count: u32` - Restored invoice count
 - `timestamp: u64` - Restore timestamp
@@ -534,9 +612,11 @@ Emitted when a backup is restored.
 ---
 
 ### BackupValidated (`bkup_vd`)
+
 Emitted when backup integrity is verified.
 
 **Data Fields:**
+
 - `backup_id: BytesN<32>` - Backup identifier
 - `success: bool` - Validation result
 - `timestamp: u64` - Validation timestamp
@@ -546,9 +626,11 @@ Emitted when backup integrity is verified.
 ---
 
 ### BackupArchived (`bkup_ar`)
+
 Emitted when a backup is archived for long-term retention.
 
 **Data Fields:**
+
 - `backup_id: BytesN<32>` - Archived backup identifier
 - `timestamp: u64` - Archive timestamp
 
@@ -557,9 +639,11 @@ Emitted when a backup is archived for long-term retention.
 ---
 
 ### RetentionPolicyUpdated (`ret_pol`)
+
 Emitted when backup retention policy is modified.
 
 **Data Fields:**
+
 - `max_backups: u32` - Maximum backup count to retain
 - `max_age_seconds: u64` - Maximum backup age in seconds
 - `auto_cleanup_enabled: bool` - Automatic cleanup flag
@@ -570,9 +654,11 @@ Emitted when backup retention policy is modified.
 ---
 
 ### BackupsCleaned (`bkup_cln`)
+
 Emitted when old backups are deleted per retention policy.
 
 **Data Fields:**
+
 - `removed_count: u32` - Number of backups removed
 - `timestamp: u64` - Cleanup timestamp
 
@@ -583,9 +669,11 @@ Emitted when old backups are deleted per retention policy.
 ## Audit Events
 
 ### AuditValidation (`aud_val`)
+
 Emitted when invoice data passes audit validation.
 
 **Data Fields:**
+
 - `invoice_id: BytesN<32>` - Audited invoice
 - `is_valid: bool` - Validation result
 - `timestamp: u64` - Validation timestamp
@@ -595,9 +683,11 @@ Emitted when invoice data passes audit validation.
 ---
 
 ### AuditQuery (`aud_qry`)
+
 Emitted when audit logs are queried.
 
 **Data Fields:**
+
 - `query_type: String` - Type of audit query performed
 - `result_count: u32` - Results returned
 
@@ -608,9 +698,11 @@ Emitted when audit logs are queried.
 ## Analytics Events
 
 ### PlatformMetricsUpdated (`plt_met`)
+
 Emitted when overall platform metrics are calculated.
 
 **Data Fields:**
+
 - `total_invoices: u32` - Total invoices processed
 - `total_volume: i128` - Total funding volume
 - `total_fees: i128` - Total fees collected
@@ -622,9 +714,11 @@ Emitted when overall platform metrics are calculated.
 ---
 
 ### PerformanceMetricsUpdated (`perf_met`)
+
 Emitted when performance metrics are calculated.
 
 **Data Fields:**
+
 - `average_settlement_time: u64` - Average time to settlement
 - `transaction_success_rate: i128` - Transaction success percentage
 - `user_satisfaction_score: u32` - Average satisfaction score
@@ -635,9 +729,11 @@ Emitted when performance metrics are calculated.
 ---
 
 ### UserBehaviorAnalyzed (`usr_beh`)
+
 Emitted when individual user behavior metrics are calculated.
 
 **Data Fields:**
+
 - `user: Address` - User address
 - `total_investments: u32` - Number of investments made
 - `success_rate: i128` - Success percentage
@@ -649,9 +745,11 @@ Emitted when individual user behavior metrics are calculated.
 ---
 
 ### FinancialMetricsCalculated (`fin_met`)
+
 Emitted when financial metrics are calculated for a period.
 
 **Data Fields:**
+
 - `period: TimePeriod` - Reporting period
 - `total_volume: i128` - Volume for period
 - `total_fees: i128` - Fees collected
@@ -663,9 +761,11 @@ Emitted when financial metrics are calculated for a period.
 ---
 
 ### BusinessReportGenerated (`biz_rpt`)
+
 Emitted when periodic business report is generated.
 
 **Data Fields:**
+
 - `report_id: BytesN<32>` - Report identifier
 - `business: Address` - Business reported on
 - `period: TimePeriod` - Reporting period
@@ -678,9 +778,11 @@ Emitted when periodic business report is generated.
 ---
 
 ### InvestorReportGenerated (`inv_rpt`)
+
 Emitted when periodic investor report is generated.
 
 **Data Fields:**
+
 - `report_id: BytesN<32>` - Report identifier
 - `investor: Address` - Investor reported on
 - `period: TimePeriod` - Reporting period
@@ -693,9 +795,11 @@ Emitted when periodic investor report is generated.
 ---
 
 ### AnalyticsQuery (`anal_qry`)
+
 Emitted when analytics are queried.
 
 **Data Fields:**
+
 - `query_type: String` - Type of query executed
 - `filters_applied: u32` - Number of filters used
 - `result_count: u32` - Results returned
@@ -706,9 +810,11 @@ Emitted when analytics are queried.
 ---
 
 ### AnalyticsExported (`anal_exp`)
+
 Emitted when analytics data is exported.
 
 **Data Fields:**
+
 - `export_type: String` - Export format (CSV, JSON, etc.)
 - `requested_by: Address` - User requesting export
 - `record_count: u32` - Records included
@@ -721,9 +827,11 @@ Emitted when analytics data is exported.
 ## Protocol Management Events
 
 ### ProtocolInitialized (`proto_in`)
+
 Emitted during initial protocol setup (one-time event).
 
 **Data Fields:**
+
 - `admin: Address` - Initial admin address
 - `treasury: Address` - Treasury address
 - `fee_bps: u32` - Initial platform fee rate
@@ -737,9 +845,11 @@ Emitted during initial protocol setup (one-time event).
 ---
 
 ### ProtocolConfigUpdated (`proto_cfg`)
+
 Emitted when protocol configuration is updated.
 
 **Data Fields:**
+
 - `admin: Address` - Admin making change
 - `min_invoice_amount: i128` - Updated minimum amount
 - `max_due_date_days: u64` - Updated max due date
@@ -751,9 +861,11 @@ Emitted when protocol configuration is updated.
 ---
 
 ### AdminSet (`adm_set`)
+
 Emitted when admin address is initially set.
 
 **Data Fields:**
+
 - `admin: Address` - Newly set admin
 - `timestamp: u64` - Set timestamp
 
@@ -762,9 +874,11 @@ Emitted when admin address is initially set.
 ---
 
 ### AdminTransferred (`adm_trf`)
+
 Emitted when admin role is transferred to new address.
 
 **Data Fields:**
+
 - `old_admin: Address` - Previous admin
 - `new_admin: Address` - New admin
 - `timestamp: u64` - Transfer timestamp
@@ -808,22 +922,26 @@ Emitted when admin role is transferred to new address.
 ## Security Considerations
 
 ### Event Integrity
+
 - Events are blockchain-recorded and immutable
 - Cannot be modified or deleted once emitted
 - Provides authoritative audit trail
 
 ### Authorization Context
+
 - All events implicitly contain authorization context
 - Business operations require business authorization
 - Admin operations require admin authorization
 - Investment operations require investor authorization
 
 ### Financial Accuracy
+
 - All financial events include complete amount breakdowns
 - Fee events enable transparent reconciliation
 - Payment events support cash flow audits
 
 ### Timestamp Reliability
+
 - All timestamps are server-generated (not user input)
 - Chronological ordering guaranteed by blockchain
 - Enables time-based analytics and SLA tracking
@@ -833,19 +951,21 @@ Emitted when admin role is transferred to new address.
 ## Performance & Scalability
 
 ### Event Emission
+
 - Events are emitted synchronously after state commitment
 - No performance impact on contract execution
 - Gas-efficient via symbol_short topics
 
 ### Indexing Strategy
+
 - Use event topics as primary filters
 - Combine with invoice_id/address for secondary filtering
 - Archive old events for historical analysis
 
 ### Query Optimization
+
 - Index by frequently-queried fields
 - Use time-range filters for historical data
 - Implement pagination for large result sets
 
 ---
-

--- a/docs/events.md
+++ b/docs/events.md
@@ -5,6 +5,7 @@ This document describes the accepted event schemas for the POST `/api/v1/events`
 ## Supported Event Types
 
 ### InvoiceSettled
+
 ```
 {
   "id": "string (unique)",
@@ -12,11 +13,14 @@ This document describes the accepted event schemas for the POST `/api/v1/events`
   "txHash": "string",
   "type": "InvoiceSettled",
   "payload": {
-    "invoice_id": "string",
-    "business": "string",
-    "investor": "string",
-    "amount": "string",
-    ...
+    "invoice_id":      "string",
+    "amount":          "string",
+    "ledger":          number,
+    "business":        "string",
+    "investor":        "string",
+    "investor_return": "string",
+    "platform_fee":    "string",
+    "timestamp":       number
   },
   "timestamp": number,
   "complianceHold": boolean,
@@ -25,6 +29,7 @@ This document describes the accepted event schemas for the POST `/api/v1/events`
 ```
 
 ### PaymentRecorded
+
 ```
 {
   "id": "string (unique)",
@@ -44,6 +49,7 @@ This document describes the accepted event schemas for the POST `/api/v1/events`
 ```
 
 ### DisputeCreated
+
 ```
 {
   "id": "string (unique)",
@@ -62,6 +68,7 @@ This document describes the accepted event schemas for the POST `/api/v1/events`
 ```
 
 ### DisputeResolved
+
 ```
 {
   "id": "string (unique)",
@@ -80,6 +87,7 @@ This document describes the accepted event schemas for the POST `/api/v1/events`
 ```
 
 ## Validation Rules
+
 - All fields are required unless marked optional.
 - Unknown event types are rejected.
 - Each event must have a stable unique `id`; replaying a previously processed `id` is a no-op.
@@ -88,11 +96,13 @@ This document describes the accepted event schemas for the POST `/api/v1/events`
 - No raw event payloads are echoed in error responses.
 
 ## Response Shape
+
 Successful events return `status: "processed"`. Duplicate events return `status: "duplicate"` and do not trigger notifications again. Invalid items return `status: "rejected"` with sanitized validation errors.
 
 Mixed batches return a per-event `results` array. If any item is rejected, the HTTP status is 400 while valid non-duplicate items in the same batch may still be processed.
 
 ## Example Batch
+
 ```
 [
   { ...InvoiceSettled },

--- a/docs/events_complete.md
+++ b/docs/events_complete.md
@@ -1,7 +1,7 @@
 # QuickLendX — Complete Event Schema Reference
 
 This document is the canonical reference for every event emitted by the
-QuickLendX protocol.  Indexers should treat field names, topic strings, and
+QuickLendX protocol. Indexers should treat field names, topic strings, and
 ordering as stable unless a breaking-change notice appears in the changelog.
 
 ---
@@ -39,12 +39,27 @@ Emitted when an invoice is fully settled.
   "type": "InvoiceSettled",
   "payload": {
     "invoice_id": "string",
-    "business":   "string",
-    "investor":   "string",
-    "amount":     "string"
+    "amount": "string",
+    "ledger": 0,
+    "business": "string",
+    "investor": "string",
+    "investor_return": "string",
+    "platform_fee": "string",
+    "timestamp": 0
   }
 }
 ```
+
+| Field             | Type     | Description                                                        |
+| ----------------- | -------- | ------------------------------------------------------------------ |
+| `invoice_id`      | `string` | Unique 32-byte invoice identifier (hex-encoded)                    |
+| `amount`          | `string` | Total amount settled (sum of all payments applied to this invoice) |
+| `ledger`          | `number` | Ledger sequence number at the time of settlement                   |
+| `business`        | `string` | Address of the business that owns the invoice                      |
+| `investor`        | `string` | Address of the investor who funded the invoice                     |
+| `investor_return` | `string` | Amount returned to the investor after fees                         |
+| `platform_fee`    | `string` | Platform fee collected                                             |
+| `timestamp`       | `number` | Ledger timestamp at emission time (seconds since epoch)            |
 
 ---
 
@@ -57,8 +72,8 @@ Emitted when a partial or full payment is recorded against an invoice.
   "type": "PaymentRecorded",
   "payload": {
     "invoice_id": "string",
-    "payer":      "string",
-    "amount":     "string"
+    "payer": "string",
+    "amount": "string"
   }
 }
 ```
@@ -74,7 +89,7 @@ Emitted when a dispute is opened for an invoice.
   "type": "DisputeCreated",
   "payload": {
     "invoice_id": "string",
-    "initiator":  "string"
+    "initiator": "string"
   }
 }
 ```
@@ -89,7 +104,7 @@ Emitted when an active dispute is resolved.
 {
   "type": "DisputeResolved",
   "payload": {
-    "invoice_id":  "string",
+    "invoice_id": "string",
     "resolved_by": "string"
   }
 }
@@ -102,10 +117,10 @@ Emitted when an active dispute is resolved.
 ### PauseBlocked
 
 Emitted on **every** call that `require_unpaused` rejects because the
-protocol is currently paused.  One event is emitted per blocked invocation —
+protocol is currently paused. One event is emitted per blocked invocation —
 there is no deduplication.
 
-**Topic constant**: `events::TOPIC_PAUSE_BLOCKED = "PauseBlocked"`  
+**Topic constant**: `events::TOPIC_PAUSE_BLOCKED = "PauseBlocked"`
 **Source module**: `src/pause.rs` → `PauseState::require_unpaused`
 
 ```json
@@ -113,29 +128,29 @@ there is no deduplication.
   "type": "PauseBlocked",
   "payload": {
     "entrypoint": "string",
-    "caller":     0,
-    "ledger_ts":  0
+    "caller": 0,
+    "ledger_ts": 0
   }
 }
 ```
 
 #### Payload fields
 
-| Field | Type | Description |
-|---|---|---|
-| `entrypoint` | `string` | Stable symbol of the blocked entrypoint (see table below) |
-| `caller` | `u64` | Numeric account ID whose call was rejected |
-| `ledger_ts` | `u64` | Ledger timestamp (seconds since epoch) at the point of rejection |
+| Field        | Type     | Description                                                      |
+| ------------ | -------- | ---------------------------------------------------------------- |
+| `entrypoint` | `string` | Stable symbol of the blocked entrypoint (see table below)        |
+| `caller`     | `u64`    | Numeric account ID whose call was rejected                       |
+| `ledger_ts`  | `u64`    | Ledger timestamp (seconds since epoch) at the point of rejection |
 
 #### `entrypoint` values
 
-| Value | Protected action |
-|---|---|
-| `"invoice_upload"` | Business uploads a new invoice |
-| `"bid_placement"` | Investor places a bid on an invoice |
-| `"settlement_initiation"` | Business initiates invoice settlement |
-| `"escrow_release"` | Business triggers escrow release |
-| `"investment_action"` | Investor takes a general investment action |
+| Value                     | Protected action                           |
+| ------------------------- | ------------------------------------------ |
+| `"invoice_upload"`        | Business uploads a new invoice             |
+| `"bid_placement"`         | Investor places a bid on an invoice        |
+| `"settlement_initiation"` | Business initiates invoice settlement      |
+| `"escrow_release"`        | Business triggers escrow release           |
+| `"investment_action"`     | Investor takes a general investment action |
 
 #### Indexer notes
 
@@ -161,12 +176,12 @@ there is no deduplication.
 
 ## Response shape
 
-| Outcome | HTTP status | `status` field |
-|---|---|---|
-| Accepted and processed | 200 | `"processed"` |
-| Known duplicate | 200 | `"duplicate"` |
-| Validation failure | 400 | `"rejected"` |
+| Outcome                | HTTP status | `status` field |
+| ---------------------- | ----------- | -------------- |
+| Accepted and processed | 200         | `"processed"`  |
+| Known duplicate        | 200         | `"duplicate"`  |
+| Validation failure     | 400         | `"rejected"`   |
 
-Mixed batches return a per-event `results` array.  If any item is rejected
+Mixed batches return a per-event `results` array. If any item is rejected
 the HTTP status is 400; valid non-duplicate items in the same batch may still
 be processed.

--- a/quicklendx-contracts/src/events.rs
+++ b/quicklendx-contracts/src/events.rs
@@ -136,6 +136,16 @@ pub struct InvoiceCancelled {
 ///
 /// Topic: [`TOPIC_INVOICE_SETTLED`] (`"inv_set"`)
 ///
+/// # Fields
+/// - `invoice_id` – Unique 32-byte invoice identifier.
+/// - `amount` – Total amount settled (sum of all payments applied to this invoice).
+/// - `ledger` – Ledger sequence number at the time of settlement.
+/// - `business` – Address of the business that owns the invoice.
+/// - `investor` – Address of the investor who funded the invoice.
+/// - `investor_return` – Amount returned to the investor after fees.
+/// - `platform_fee` – Fee taken by the platform.
+/// - `timestamp` – Ledger timestamp at emission time.
+///
 /// # Security
 /// No PII is included. `investor_return` and `platform_fee` are derived
 /// from validated contract state only.
@@ -143,6 +153,8 @@ pub struct InvoiceCancelled {
 #[contractevent]
 pub struct InvoiceSettled {
     pub invoice_id: BytesN<32>,
+    pub amount: i128,
+    pub ledger: u32,
     pub business: Address,
     pub investor: Address,
     pub investor_return: i128,
@@ -701,6 +713,8 @@ pub fn emit_invoice_settled(
 ) {
     InvoiceSettled {
         invoice_id: invoice.id.clone(),
+        amount: invoice.total_paid,
+        ledger: env.ledger().sequence(),
         business: invoice.business.clone(),
         investor: invoice.investor.clone().unwrap_or(Address::from_str(
             env,

--- a/quicklendx-contracts/src/test_events.rs
+++ b/quicklendx-contracts/src/test_events.rs
@@ -518,6 +518,8 @@ fn test_invoice_settled_field_order() {
     assert!(p.investor_return >= 0);
     assert!(p.platform_fee >= 0);
     assert_eq!(p.timestamp, ts);
+    assert_eq!(p.amount, EXP_RETURN, "amount must equal total settled");
+    assert_eq!(p.ledger, env.ledger().sequence(), "ledger sequence must be set");
 }
 
 // ============================================================================
@@ -1068,6 +1070,8 @@ fn test_loan_settled_event_schema() {
     assert!(p.investor_return >= 0, "investor_return must be non-negative");
     assert!(p.platform_fee >= 0, "platform_fee must be non-negative");
     assert_eq!(p.timestamp, ts, "timestamp mismatch");
+    assert_eq!(p.amount, EXP_RETURN, "amount must equal total settled");
+    assert_eq!(p.ledger, env.ledger().sequence(), "ledger sequence must be set");
 }
 
 // ============================================================================
@@ -1555,6 +1559,42 @@ fn test_event_timestamp_ordering() {
 
     assert!(invoice.created_at <= time_verify);
     assert!(bid.timestamp >= time_bid);
+}
+
+// ============================================================================
+// 25. InvoiceSettled — amount and ledger fields locked in
+// ============================================================================
+
+/// Verifies that every settlement emits `InvoiceSettled` with the correct
+/// `amount` (total settled) and `ledger` (ledger sequence number).
+#[test]
+fn test_invoice_settled_includes_amount_and_ledger() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, cid) = setup(&env);
+    let biz = Address::generate(&env);
+    let inv = Address::generate(&env);
+    let currency = mint_currency(&env, &cid, &biz, Some(&inv));
+    kyc_business(&env, &client, &admin, &biz);
+    kyc_investor(&env, &client, &inv, INV_LIMIT);
+
+    let (id, _) = upload_invoice(&env, &client, &biz, &currency, "amount ledger test");
+    client.verify_invoice(&id);
+    let bid_id = client.place_bid(&inv, &id, &INV_AMOUNT, &EXP_RETURN);
+    client.accept_bid(&id, &bid_id);
+
+    // Advance ledger sequence so we get a predictable non-zero value.
+    env.ledger().with_mut(|li| {
+        li.sequence_number += 5;
+    });
+    let expected_ledger = env.ledger().sequence();
+
+    client.make_payment(&id, &EXP_RETURN, &String::from_str(&env, "TX_AMT_LEDGER"));
+
+    let p: InvoiceSettled = latest_payload(&env, TOPIC_INVOICE_SETTLED);
+    assert_eq!(p.invoice_id, id, "invoice_id mismatch");
+    assert_eq!(p.amount, EXP_RETURN, "amount must equal total settled");
+    assert_eq!(p.ledger, expected_ledger, "ledger sequence mismatch");
 }
 
 // Helper used only in this test module - suppress unused warning


### PR DESCRIPTION
Every settlement now emits InvoiceSettled { invoice_id, amount, ledger } alongside the existing fields. This lets indexers and downstream consumers read the settled amount and ledger sequence directly from the event without an extra contract query.

closes #1502