### PR TITLE
feat(audit): add OpType enum for typed audit-log emission

### DIFF
--- a/docs/contracts/events.md
+++ b/docs/contracts/events.md
@@ -247,8 +247,10 @@ This document is the canonical reference for every Soroban event emitted by Quic
 #### `aud_qry`
 
 ```
-(query_type: String, result_count: u32)
+(query_type: OpType, result_count: u32)
 ```
+
+`OpType` is a `#[contracttype]` enum defined in `audit.rs` with variants: `InvoiceCreated`, `InvoiceUploaded`, `InvoiceVerified`, `InvoiceFunded`, `InvoicePaid`, `InvoiceDefaulted`, `InvoiceStatusChanged`, `InvoiceRated`, `BidPlaced`, `BidAccepted`, `BidWithdrawn`, `EscrowCreated`, `EscrowReleased`, `EscrowRefunded`, `PaymentProcessed`, `SettlementCompleted`.
 
 ---
 

--- a/docs/contracts/events_complete.md
+++ b/docs/contracts/events_complete.md
@@ -598,8 +598,10 @@ Emitted when invoice data passes audit validation.
 Emitted when audit logs are queried.
 
 **Data Fields:**
-- `query_type: String` - Type of audit query performed
+- `query_type: OpType` - Typed audit operation discriminator (see `OpType` enum)
 - `result_count: u32` - Results returned
+
+`OpType` variants: `InvoiceCreated`, `InvoiceUploaded`, `InvoiceVerified`, `InvoiceFunded`, `InvoicePaid`, `InvoiceDefaulted`, `InvoiceStatusChanged`, `InvoiceRated`, `BidPlaced`, `BidAccepted`, `BidWithdrawn`, `EscrowCreated`, `EscrowReleased`, `EscrowRefunded`, `PaymentProcessed`, `SettlementCompleted`.
 
 **Use Case:** Monitor audit access, security tracking
 

--- a/quicklendx-contracts/src/audit.rs
+++ b/quicklendx-contracts/src/audit.rs
@@ -36,7 +36,7 @@
 use crate::errors::QuickLendXError;
 use crate::types::{Invoice, InvoiceStatus};
 use soroban_sdk::{
-    contracttype, symbol_short, xdr::ToXdr, Address, Bytes, BytesN, Env, String, Vec,
+    contracttype, symbol_short, xdr::ToXdr, Address, Bytes, BytesN, Env, String, Symbol, Vec,
 };
 
 /// Audit operation types
@@ -59,6 +59,101 @@ pub enum AuditOperation {
     EscrowRefunded,
     PaymentProcessed,
     SettlementCompleted,
+}
+
+/// Typed operation types used by audit-log emission.
+///
+/// Mirrors [`AuditOperation`] but provides a `to_symbol()` conversion for
+/// Soroban event topics, so downstream consumers can match on a typed enum
+/// rather than free-form strings.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum OpType {
+    InvoiceCreated,
+    InvoiceUploaded,
+    InvoiceVerified,
+    InvoiceFunded,
+    InvoicePaid,
+    InvoiceDefaulted,
+    InvoiceStatusChanged,
+    InvoiceRated,
+    BidPlaced,
+    BidAccepted,
+    BidWithdrawn,
+    EscrowCreated,
+    EscrowReleased,
+    EscrowRefunded,
+    PaymentProcessed,
+    SettlementCompleted,
+}
+
+impl OpType {
+    /// Return the Soroban `Symbol` used as the event topic / discriminator.
+    pub fn to_symbol(&self) -> Symbol {
+        match self {
+            OpType::InvoiceCreated => symbol_short!("inv_crt"),
+            OpType::InvoiceUploaded => symbol_short!("inv_up"),
+            OpType::InvoiceVerified => symbol_short!("inv_ver"),
+            OpType::InvoiceFunded => symbol_short!("inv_fnd"),
+            OpType::InvoicePaid => symbol_short!("inv_pd"),
+            OpType::InvoiceDefaulted => symbol_short!("inv_def"),
+            OpType::InvoiceStatusChanged => symbol_short!("inv_stch"),
+            OpType::InvoiceRated => symbol_short!("inv_rt"),
+            OpType::BidPlaced => symbol_short!("bid_plc"),
+            OpType::BidAccepted => symbol_short!("bid_acc"),
+            OpType::BidWithdrawn => symbol_short!("bid_wdr"),
+            OpType::EscrowCreated => symbol_short!("esc_cr"),
+            OpType::EscrowReleased => symbol_short!("esc_rel"),
+            OpType::EscrowRefunded => symbol_short!("esc_ref"),
+            OpType::PaymentProcessed => symbol_short!("pay_prc"),
+            OpType::SettlementCompleted => symbol_short!("stl_cmp"),
+        }
+    }
+
+    /// Numeric tag used for hash-chain computation.
+    pub fn tag(&self) -> u8 {
+        match self {
+            OpType::InvoiceCreated => 0,
+            OpType::InvoiceUploaded => 1,
+            OpType::InvoiceVerified => 2,
+            OpType::InvoiceFunded => 3,
+            OpType::InvoicePaid => 4,
+            OpType::InvoiceDefaulted => 5,
+            OpType::InvoiceStatusChanged => 6,
+            OpType::InvoiceRated => 7,
+            OpType::BidPlaced => 8,
+            OpType::BidAccepted => 9,
+            OpType::BidWithdrawn => 10,
+            OpType::EscrowCreated => 11,
+            OpType::EscrowReleased => 12,
+            OpType::EscrowRefunded => 13,
+            OpType::PaymentProcessed => 14,
+            OpType::SettlementCompleted => 15,
+        }
+    }
+}
+
+impl From<AuditOperation> for OpType {
+    fn from(op: AuditOperation) -> Self {
+        match op {
+            AuditOperation::InvoiceCreated => OpType::InvoiceCreated,
+            AuditOperation::InvoiceUploaded => OpType::InvoiceUploaded,
+            AuditOperation::InvoiceVerified => OpType::InvoiceVerified,
+            AuditOperation::InvoiceFunded => OpType::InvoiceFunded,
+            AuditOperation::InvoicePaid => OpType::InvoicePaid,
+            AuditOperation::InvoiceDefaulted => OpType::InvoiceDefaulted,
+            AuditOperation::InvoiceStatusChanged => OpType::InvoiceStatusChanged,
+            AuditOperation::InvoiceRated => OpType::InvoiceRated,
+            AuditOperation::BidPlaced => OpType::BidPlaced,
+            AuditOperation::BidAccepted => OpType::BidAccepted,
+            AuditOperation::BidWithdrawn => OpType::BidWithdrawn,
+            AuditOperation::EscrowCreated => OpType::EscrowCreated,
+            AuditOperation::EscrowReleased => OpType::EscrowReleased,
+            AuditOperation::EscrowRefunded => OpType::EscrowRefunded,
+            AuditOperation::PaymentProcessed => OpType::PaymentProcessed,
+            AuditOperation::SettlementCompleted => OpType::SettlementCompleted,
+        }
+    }
 }
 
 /// Fixed genesis sentinel for invoice-local audit hash chains.

--- a/quicklendx-contracts/src/events.rs
+++ b/quicklendx-contracts/src/events.rs
@@ -1,5 +1,6 @@
 #![allow(deprecated)]
 
+use crate::audit::OpType;
 use crate::fees::FeeType;
 use crate::payments::Escrow;
 use crate::types::Bid;
@@ -489,7 +490,7 @@ pub struct AuditValidation {
 
 #[contractevent]
 pub struct AuditQuery {
-    pub query_type: String,
+    pub query_type: OpType,
     pub result_count: u32,
 }
 
@@ -593,9 +594,6 @@ pub fn emit_ttl_extended(env: &Env, kind: &String, count: u32) {
     }
     .publish(env);
 }
-
-
-
 
 #[contractevent]
 pub struct RevenueDistributed {
@@ -1113,7 +1111,7 @@ pub fn emit_audit_validation(env: &Env, invoice_id: &BytesN<32>, is_valid: bool)
     .publish(env);
 }
 
-pub fn emit_audit_query(env: &Env, query_type: String, result_count: u32) {
+pub fn emit_audit_query(env: &Env, query_type: OpType, result_count: u32) {
     AuditQuery {
         query_type,
         result_count,


### PR DESCRIPTION
Closes #1497

## Summary

Replace the free-form `String` in `AuditQuery.query_type` with a typed `OpType` enum, so downstream consumers can match on a typed enum rather than free-form strings.

## Changes

- **`quicklendx-contracts/src/audit.rs`**: Added `OpType` enum (16 variants mirroring `AuditOperation`), with `to_symbol()` for Soroban event topics, `tag()` for hash-chain computation, and `From<AuditOperation>` for backwards compatibility.
- **`quicklendx-contracts/src/events.rs`**: Changed `AuditQuery.query_type` from `String` to `OpType`; updated `emit_audit_query` signature accordingly.
- **`docs/contracts/events.md`** + **`docs/contracts/events_complete.md`**: Updated `aud_qry` schema to reflect `OpType`.

## Backwards Compatibility

- `AuditOperation` is untouched — existing audit storage, queries, and indices are unchanged.
- `OpType` is a parallel enum with `From<AuditOperation>` conversion.
- No contract storage layout changes.

## Verification

- `cargo fmt --check` passes on both changed files.
- Pre-existing compilation errors in `verification.rs` and `lib.rs` prevent full build/tests — these are unrelated to this change (confirmed no errors reference `audit.rs` or `events.rs`).