### PR TITLE
ci(wasm): assert byte-identical builds across two clean toolchain run…

### DIFF
--- a/.github/workflows/wasm-reproducible-build.yml
+++ b/.github/workflows/wasm-reproducible-build.yml
@@ -1,0 +1,227 @@
+name: WASM Reproducible Build
+
+# Asserts that two back-to-back clean WASM builds of quicklendx-contracts
+# produce byte-identical artefacts (matching SHA-256 hashes).
+#
+# Diverging hashes signal non-determinism — build-time timestamps, non-stable
+# codegen ordering, or toolchain drift — and BLOCK release and audit sign-off.
+#
+# Cache is INTENTIONALLY DISABLED on every step so each build starts from a
+# clean state. The only permitted inputs are:
+#   • The committed source tree
+#   • The pinned toolchain from rust-toolchain.toml
+#   • The pinned dependencies from Cargo.lock
+
+on:
+  push:
+    branches: ["main"]
+    paths:
+      - "quicklendx-contracts/**"
+      - "rust-toolchain.toml"
+      - "scripts/reproducible-build.sh"
+      - ".github/workflows/wasm-reproducible-build.yml"
+  pull_request:
+    branches: ["main"]
+    paths:
+      - "quicklendx-contracts/**"
+      - "rust-toolchain.toml"
+      - "scripts/reproducible-build.sh"
+      - ".github/workflows/wasm-reproducible-build.yml"
+  workflow_dispatch:   # allow manual trigger for audit purposes
+
+env:
+  CARGO_TERM_COLOR: always
+  WASM_TARGET: wasm32-unknown-unknown
+  # Explicitly disable incremental compilation to prevent any cross-run caching.
+  CARGO_INCREMENTAL: "0"
+  # Disable sccache / any other transparent caching proxy that CI may inject.
+  RUSTC_WRAPPER: ""
+
+jobs:
+  wasm-reproducible-build:
+    name: Assert byte-identical WASM across two clean builds
+    runs-on: ubuntu-latest
+    # No cache: action-level caches are intentionally not configured here.
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        # No submodules, no LFS — keep the checkout as clean as possible.
+
+      # ── Toolchain ───────────────────────────────────────────────────────────
+
+      - name: Install Rust toolchain (pinned by rust-toolchain.toml)
+        run: |
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain none
+          source "$HOME/.cargo/env"
+          # rust-toolchain.toml drives the channel; rustup respects it automatically.
+          rustup show
+
+      - name: Add WASM build target
+        run: |
+          source "$HOME/.cargo/env"
+          rustup target add ${{ env.WASM_TARGET }}
+
+      - name: Print toolchain fingerprint (audit trail)
+        run: |
+          source "$HOME/.cargo/env"
+          echo "--- rustc ---"
+          rustc --version --verbose
+          echo "--- cargo ---"
+          cargo --version
+          echo "--- targets ---"
+          rustup target list --installed
+
+      # ── Verify build hygiene ─────────────────────────────────────────────────
+
+      - name: Verify Cargo.lock is committed
+        run: |
+          if [[ ! -f quicklendx-contracts/Cargo.lock ]]; then
+            echo "ERROR: Cargo.lock is missing. Reproducible builds require a committed lockfile." >&2
+            exit 1
+          fi
+          echo "Cargo.lock present — dependencies are pinned."
+
+      - name: Verify codegen-units = 1 in release profile
+        run: |
+          source "$HOME/.cargo/env"
+          python3 - <<'EOF'
+          import sys, re
+
+          with open("quicklendx-contracts/Cargo.toml") as f:
+              content = f.read()
+
+          # Find [profile.release] block and check codegen-units
+          in_release = False
+          for line in content.splitlines():
+              if line.strip() == "[profile.release]":
+                  in_release = True
+              elif in_release and line.startswith("["):
+                  break
+              elif in_release and "codegen-units" in line:
+                  m = re.search(r"codegen-units\s*=\s*(\d+)", line)
+                  if m and int(m.group(1)) == 1:
+                      print("✅ codegen-units = 1 confirmed.")
+                      sys.exit(0)
+                  else:
+                      print("❌ codegen-units must be 1 for reproducible builds.", file=sys.stderr)
+                      sys.exit(1)
+
+          print("❌ codegen-units not found in [profile.release].", file=sys.stderr)
+          sys.exit(1)
+          EOF
+
+      # ── Build 1 ─────────────────────────────────────────────────────────────
+
+      - name: "[Build 1] Clean all artefacts"
+        run: |
+          source "$HOME/.cargo/env"
+          cargo clean \
+            --manifest-path quicklendx-contracts/Cargo.toml \
+            --target ${{ env.WASM_TARGET }} \
+            2>/dev/null || true
+          rm -rf quicklendx-contracts/target/${{ env.WASM_TARGET }}/release
+
+      - name: "[Build 1] Compile WASM"
+        run: |
+          source "$HOME/.cargo/env"
+          cargo build \
+            --manifest-path quicklendx-contracts/Cargo.toml \
+            --target ${{ env.WASM_TARGET }} \
+            --release \
+            --locked \
+            --no-default-features
+
+      - name: "[Build 1] Record SHA-256"
+        id: hash1
+        run: |
+          WASM="quicklendx-contracts/target/${{ env.WASM_TARGET }}/release/quicklendx_contracts.wasm"
+          if [[ ! -f "${WASM}" ]]; then
+            echo "ERROR: WASM artefact not found at ${WASM}" >&2
+            exit 1
+          fi
+          HASH=$(sha256sum "${WASM}" | awk '{print $1}')
+          echo "hash=${HASH}" >> "$GITHUB_OUTPUT"
+          echo "size=$(stat -c%s "${WASM}")" >> "$GITHUB_OUTPUT"
+          echo "Build 1 SHA-256: ${HASH}"
+
+      # ── Build 2 ─────────────────────────────────────────────────────────────
+
+      - name: "[Build 2] Clean all artefacts"
+        run: |
+          source "$HOME/.cargo/env"
+          cargo clean \
+            --manifest-path quicklendx-contracts/Cargo.toml \
+            --target ${{ env.WASM_TARGET }} \
+            2>/dev/null || true
+          rm -rf quicklendx-contracts/target/${{ env.WASM_TARGET }}/release
+
+      - name: "[Build 2] Compile WASM"
+        run: |
+          source "$HOME/.cargo/env"
+          cargo build \
+            --manifest-path quicklendx-contracts/Cargo.toml \
+            --target ${{ env.WASM_TARGET }} \
+            --release \
+            --locked \
+            --no-default-features
+
+      - name: "[Build 2] Record SHA-256"
+        id: hash2
+        run: |
+          WASM="quicklendx-contracts/target/${{ env.WASM_TARGET }}/release/quicklendx_contracts.wasm"
+          HASH=$(sha256sum "${WASM}" | awk '{print $1}')
+          echo "hash=${HASH}" >> "$GITHUB_OUTPUT"
+          echo "size=$(stat -c%s "${WASM}")" >> "$GITHUB_OUTPUT"
+          echo "Build 2 SHA-256: ${HASH}"
+
+      # ── Assert ──────────────────────────────────────────────────────────────
+
+      - name: Assert hashes match (reproducibility gate)
+        env:
+          HASH_1: ${{ steps.hash1.outputs.hash }}
+          HASH_2: ${{ steps.hash2.outputs.hash }}
+          SIZE_1: ${{ steps.hash1.outputs.size }}
+          SIZE_2: ${{ steps.hash2.outputs.size }}
+        run: |
+          echo "============================================================"
+          echo "  Reproducibility verdict"
+          echo "============================================================"
+          echo "  Build 1: ${HASH_1}  (${SIZE_1} bytes)"
+          echo "  Build 2: ${HASH_2}  (${SIZE_2} bytes)"
+          echo ""
+
+          if [[ "${HASH_1}" == "${HASH_2}" ]]; then
+            echo "  ✅  PASS — hashes match. WASM build is reproducible."
+            echo "  Artefact SHA-256: ${HASH_1}"
+          else
+            echo "  ❌  FAIL — hashes DIVERGE. Build is non-deterministic." >&2
+            echo ""                                                           >&2
+            echo "  This blocks release and audit sign-off."                 >&2
+            echo "  See docs/reproducible-builds.md for investigation steps." >&2
+            exit 1
+          fi
+
+      # ── Upload artefact (for audit trails) ──────────────────────────────────
+
+      - name: Upload WASM artefact with hash manifest
+        if: success()
+        run: |
+          WASM="quicklendx-contracts/target/${{ env.WASM_TARGET }}/release/quicklendx_contracts.wasm"
+          HASH="${{ steps.hash2.outputs.hash }}"
+
+          mkdir -p wasm-release
+          cp "${WASM}" wasm-release/quicklendx_contracts.wasm
+          echo "${HASH}  quicklendx_contracts.wasm" > wasm-release/quicklendx_contracts.wasm.sha256
+
+          echo "Artefact manifest:"
+          cat wasm-release/quicklendx_contracts.wasm.sha256
+
+      - name: Upload WASM release artefacts
+        if: success()
+        uses: actions/upload-artifact@v4
+        with:
+          name: wasm-reproducible-build-${{ github.sha }}
+          path: wasm-release/
+          retention-days: 90
+          if-no-files-found: error

--- a/docs/reproducible-builds.md
+++ b/docs/reproducible-builds.md
@@ -1,0 +1,228 @@
+# Reproducible WASM Builds
+
+Stellar mainnet auditors require that the WASM artefact deployed on-chain can be
+independently rebuilt from the committed source and verified to be byte-identical.
+This document explains how QuickLendX achieves and tests that property.
+
+---
+
+## Why Reproducibility Matters
+
+| Without reproducibility | With reproducibility |
+|-------------------------|----------------------|
+| Auditors must trust the deployer's build environment | Anyone can verify the on-chain WASM matches the source |
+| Non-determinism can hide build-time secrets or tampering | Diverging hashes immediately signal a problem |
+| Re-audit required after any toolchain update | Toolchain changes are caught by CI before they reach mainnet |
+
+A build is reproducible when two independent, clean compilations of the same
+source commit produce **byte-identical** output (matching SHA-256 hashes).
+
+---
+
+## What Guarantees Determinism
+
+The following settings in `quicklendx-contracts/Cargo.toml` are **required** for
+reproducible output:
+
+```toml
+[profile.release]
+codegen-units = 1        # single codegen unit — no parallel ordering races
+lto           = true     # link-time optimisation collapses nondeterminism
+opt-level     = "z"      # fixed optimisation level
+overflow-checks = true   # does not affect determinism, kept for safety
+debug         = 0
+strip         = true
+```
+
+Additionally:
+
+| Requirement | File | Why |
+|-------------|------|-----|
+| Pinned toolchain channel | `rust-toolchain.toml` | Prevents silent rustc upgrades |
+| Committed lockfile | `quicklendx-contracts/Cargo.lock` | Pins every transitive dependency version |
+| `--locked` flag | CI / build script | Forces cargo to honour the lockfile exactly |
+| `--no-default-features` | CI / build script | Excludes dev/test features from WASM output |
+| No build-time env injection | `build.rs` (none present) | `build.rs` scripts can embed host timestamps |
+
+---
+
+## Running Locally
+
+```bash
+# From the repository root
+bash scripts/reproducible-build.sh
+```
+
+### What the script does
+
+1. Verifies the WASM target is installed (`rustup target add wasm32-unknown-unknown`).
+2. **Cleans** all build artefacts (`cargo clean` + `rm -rf target/.../release`).
+3. Runs `cargo build --target wasm32-unknown-unknown --release --locked --no-default-features` **(Build 1)**.
+4. Records the SHA-256 of the resulting `.wasm` file.
+5. **Cleans again**.
+6. Runs the same build command **(Build 2)**.
+7. Records the SHA-256.
+8. **Asserts both hashes match**. Exits `1` if they diverge.
+
+### Expected output (passing)
+
+```
+╔══════════════════════════════════════════════════════════════╗
+║  QuickLendX — WASM Reproducible-Build Verification          ║
+╚══════════════════════════════════════════════════════════════╝
+
+==> Toolchain version: stable-x86_64-unknown-linux-gnu (…)
+==> Checking WASM target… wasm32-unknown-unknown (installed)
+==> Cargo.lock status: Cargo.lock present — using pinned dependencies.
+
+============================================================
+  Build 1
+============================================================
+  SHA-256 (build 1): 3a7f9c…
+
+============================================================
+  Build 2
+============================================================
+  SHA-256 (build 2): 3a7f9c…
+
+============================================================
+  Reproducibility verdict
+============================================================
+  Build 1: 3a7f9c…
+  Build 2: 3a7f9c…
+
+  ✅  PASS — hashes match. WASM build is reproducible.
+```
+
+### Verbose mode
+
+```bash
+VERBOSE=1 bash scripts/reproducible-build.sh
+```
+
+---
+
+## CI Workflow
+
+The workflow at `.github/workflows/wasm-reproducible-build.yml` runs automatically on:
+
+- Every push to `main` that touches `quicklendx-contracts/`, `rust-toolchain.toml`,
+  or the build script/workflow itself.
+- Every pull request targeting `main` with contract changes.
+- Manual trigger via `workflow_dispatch` (for audit runs on any commit).
+
+### Key design decisions
+
+| Decision | Rationale |
+|----------|-----------|
+| **No Cargo cache** (actions/cache intentionally absent) | Cache reuse would defeat the purpose — we need two genuinely independent builds |
+| `CARGO_INCREMENTAL=0` env var | Disables incremental compilation that survives across runs in some setups |
+| `RUSTC_WRAPPER=""` | Disables sccache or similar transparent caching proxies that CI might inject |
+| `--locked` flag | CI fails fast if `Cargo.lock` is stale rather than silently resolving new deps |
+| 90-day artefact retention | Provides an audit trail for every reproducible build on `main` |
+
+The workflow uploads the final `.wasm` and a `.sha256` manifest as a GitHub Actions
+artefact, providing a timestamped, immutable record of each verified build.
+
+---
+
+## Verifying an On-Chain Deployment
+
+To verify that a deployed contract matches a source commit:
+
+```bash
+# 1. Check out the exact commit used for deployment
+git checkout <COMMIT_SHA>
+
+# 2. Run the reproducible build
+bash scripts/reproducible-build.sh
+
+# 3. Compare the printed hash against the deployed contract's WASM hash
+#    (available via Stellar's getContractWasm RPC method)
+stellar contract inspect --wasm quicklendx-contracts/target/wasm32-unknown-unknown/release/quicklendx_contracts.wasm
+```
+
+Or compute the hash manually:
+
+```bash
+sha256sum quicklendx-contracts/target/wasm32-unknown-unknown/release/quicklendx_contracts.wasm
+```
+
+---
+
+## Troubleshooting Non-Determinism
+
+If the script or CI reports diverging hashes, investigate in this order:
+
+### 1. Toolchain mismatch
+
+```bash
+rustc --version --verbose
+# Confirm Host: and commit: match between runs
+```
+
+Check `rust-toolchain.toml` — the channel must be pinned to a specific version
+(e.g. `channel = "1.78.0"`) rather than `"stable"` for maximum reproducibility.
+
+### 2. `codegen-units` not set to 1
+
+```toml
+# quicklendx-contracts/Cargo.toml
+[profile.release]
+codegen-units = 1   # ← REQUIRED
+```
+
+Multiple codegen units allow the compiler to process functions in parallel, which
+introduces ordering non-determinism.
+
+### 3. Stale Cargo.lock
+
+```bash
+cargo generate-lockfile --manifest-path quicklendx-contracts/Cargo.toml
+git diff quicklendx-contracts/Cargo.lock
+# If there is a diff, a dependency was silently upgraded.
+# Commit the updated lockfile and re-run the reproducibility check.
+```
+
+### 4. `build.rs` injecting timestamps
+
+If a dependency's `build.rs` embeds `std::time::SystemTime::now()`, `env!("OUT_DIR")`,
+or similar host-specific values, the WASM output will differ between runs.
+Identify the culprit with:
+
+```bash
+cargo build --target wasm32-unknown-unknown --release -vv 2>&1 | grep "build\[" | head -20
+```
+
+### 5. LTO not enabled
+
+Without `lto = true`, the linker may process input files in a different order
+depending on OS scheduler timing.
+
+---
+
+## Future-Proofing
+
+Any future hash divergence **blocks release**. The process is:
+
+1. CI reports `❌ FAIL`.
+2. The PR/commit is blocked from merging.
+3. The root cause is identified using the troubleshooting steps above.
+4. A fix is committed (toolchain pin, lockfile update, `build.rs` fix, etc.).
+5. The script and CI must pass before the change can land on `main`.
+
+This is intentional. A deploy to Stellar mainnet with a non-reproducible artefact
+cannot be independently verified by auditors.
+
+---
+
+## Related Files
+
+| File | Purpose |
+|------|---------|
+| `scripts/reproducible-build.sh` | Local reproducibility verification script |
+| `.github/workflows/wasm-reproducible-build.yml` | CI workflow enforcing the invariant |
+| `rust-toolchain.toml` | Pins the Rust toolchain channel |
+| `quicklendx-contracts/Cargo.toml` | Contains `[profile.release]` determinism flags |
+| `quicklendx-contracts/Cargo.lock` | Pins all transitive dependency versions |
+| `scripts/check-wasm-size.sh` | Size-budget check (complementary to reproducibility) |

--- a/scripts/reproducible-build.sh
+++ b/scripts/reproducible-build.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+# scripts/reproducible-build.sh
+#
+# Asserts byte-identical WASM output across two clean back-to-back builds.
+#
+# Stellar mainnet auditors require reproducible WASM artifacts.  This script:
+#   1. Cleans ALL Cargo build artefacts to prevent cache contamination.
+#   2. Performs build #1 and records the SHA-256 of the resulting .wasm file.
+#   3. Cleans again.
+#   4. Performs build #2 and records the SHA-256.
+#   5. Asserts both hashes match; exits 1 if they diverge.
+#
+# A diverging hash signals non-determinism (build-time timestamps, non-stable
+# codegen ordering, or host-toolchain mismatch) and BLOCKS release.
+#
+# Prerequisites
+# -------------
+#   • rustup + cargo (channel pinned by rust-toolchain.toml)
+#   • wasm32-unknown-unknown target installed
+#       rustup target add wasm32-unknown-unknown
+#   • sha256sum (coreutils) or shasum (macOS fallback)
+#
+# Usage
+# -----
+#   # From the repository root
+#   bash scripts/reproducible-build.sh
+#
+#   # Verbose mode (prints every cargo step)
+#   VERBOSE=1 bash scripts/reproducible-build.sh
+#
+# Exit codes
+# ----------
+#   0 — both hashes match (build is reproducible)
+#   1 — hashes diverge or build failed
+
+set -euo pipefail
+
+# ── Configuration ─────────────────────────────────────────────────────────────
+
+WASM_TARGET="wasm32-unknown-unknown"
+PACKAGE="quicklendx-contracts"
+WASM_FILE="quicklendx_contracts.wasm"
+WASM_PATH="quicklendx-contracts/target/${WASM_TARGET}/release/${WASM_FILE}"
+
+# Extra flags forwarded to every `cargo build` call.
+# --locked  : honour the committed Cargo.lock exactly
+# --no-default-features : exclude dev features from WASM artefact
+CARGO_FLAGS=(
+    "--manifest-path" "quicklendx-contracts/Cargo.toml"
+    "--target"        "${WASM_TARGET}"
+    "--release"
+    "--locked"
+    "--no-default-features"
+)
+
+VERBOSE="${VERBOSE:-0}"
+if [[ "${VERBOSE}" == "1" ]]; then
+    CARGO_FLAGS+=("--verbose")
+fi
+
+# ── Helper: sha256 ────────────────────────────────────────────────────────────
+
+sha256_of() {
+    local file="$1"
+    if command -v sha256sum &>/dev/null; then
+        sha256sum "$file" | awk '{print $1}'
+    elif command -v shasum &>/dev/null; then
+        shasum -a 256 "$file" | awk '{print $1}'
+    else
+        echo "ERROR: neither sha256sum nor shasum found in PATH" >&2
+        exit 1
+    fi
+}
+
+# ── Helper: clean build artefacts ─────────────────────────────────────────────
+
+clean_build() {
+    echo "==> Cleaning build artefacts…"
+    cargo clean --manifest-path quicklendx-contracts/Cargo.toml \
+        --target "${WASM_TARGET}" \
+        2>/dev/null || true
+    # Belt-and-suspenders: remove the release dir directly if cargo clean
+    # leaves anything behind (e.g. incremental caches under a different key).
+    rm -rf "quicklendx-contracts/target/${WASM_TARGET}/release"
+}
+
+# ── Helper: build and capture hash ────────────────────────────────────────────
+
+build_and_hash() {
+    local label="$1"
+
+    echo "" >&2
+    echo "============================================================" >&2
+    echo "  Build ${label}" >&2
+    echo "============================================================" >&2
+
+    cargo build "${CARGO_FLAGS[@]}" >&2
+
+    if [[ ! -f "${WASM_PATH}" ]]; then
+        echo "ERROR: Expected WASM artefact not found at ${WASM_PATH}" >&2
+        exit 1
+    fi
+
+    local hash
+    hash="$(sha256_of "${WASM_PATH}")"
+    echo "  SHA-256 (build ${label}): ${hash}" >&2
+    echo "${hash}"
+}
+
+# ── Main ──────────────────────────────────────────────────────────────────────
+
+echo ""
+echo "╔══════════════════════════════════════════════════════════════╗"
+echo "║  QuickLendX — WASM Reproducible-Build Verification          ║"
+echo "╚══════════════════════════════════════════════════════════════╝"
+echo ""
+
+# Verify toolchain pin
+echo "==> Toolchain version:"
+rustup show active-toolchain 2>/dev/null || rustc --version
+
+# Verify wasm target is installed
+echo "==> Checking WASM target…"
+rustup target list --installed | grep "${WASM_TARGET}" || {
+    echo "Installing ${WASM_TARGET}…"
+    rustup target add "${WASM_TARGET}"
+}
+
+echo ""
+echo "==> Cargo.lock status:"
+if [[ -f quicklendx-contracts/Cargo.lock ]]; then
+    echo "    Cargo.lock present — using pinned dependencies."
+else
+    echo "ERROR: Cargo.lock is missing. Reproducible builds require a committed lockfile." >&2
+    exit 1
+fi
+
+# ── Build 1 ───────────────────────────────────────────────────────────────────
+
+clean_build
+HASH_1="$(build_and_hash "1")"
+
+# ── Build 2 ───────────────────────────────────────────────────────────────────
+
+clean_build
+HASH_2="$(build_and_hash "2")"
+
+# ── Compare ───────────────────────────────────────────────────────────────────
+
+echo ""
+echo "============================================================"
+echo "  Reproducibility verdict"
+echo "============================================================"
+echo "  Build 1: ${HASH_1}"
+echo "  Build 2: ${HASH_2}"
+echo ""
+
+if [[ "${HASH_1}" == "${HASH_2}" ]]; then
+    echo "  ✅  PASS — hashes match. WASM build is reproducible."
+    echo ""
+    echo "  Artefact: ${WASM_PATH}"
+    echo "  SHA-256:  ${HASH_1}"
+    exit 0
+else
+    echo "  ❌  FAIL — hashes DIVERGE. Build is non-deterministic." >&2
+    echo "" >&2
+    echo "  This blocks release and audit sign-off." >&2
+    echo "  Common causes:" >&2
+    echo "    • codegen-units != 1 in Cargo.toml [profile.release]" >&2
+    echo "    • lto not set to 'fat' or 'true'" >&2
+    echo "    • build.rs injecting host timestamp or env vars" >&2
+    echo "    • Cargo.lock not committed (non-reproducible deps)" >&2
+    echo "    • Different rustc version between runs (check rust-toolchain.toml)" >&2
+    exit 1
+fi


### PR DESCRIPTION
## What was done

Adds a reproducible-build verification script and corresponding GitHub Actions CI
job to guarantee that QuickLendX's `wasm32-unknown-unknown` artifacts are strictly
deterministic.

---

## Why

Stellar mainnet auditors require verifiable, byte-identical builds to ensure that
what is deployed on-chain corresponds exactly to the committed source code. Any
divergence (caused by non-deterministic codegen ordering, timestamps, or toolchain
mismatches) blocks the release and audit sign-off. This CI job enforces that
invariant automatically.

---

## How

1. **Build Script (`scripts/reproducible-build.sh`)**
   A bash script that:
   - Cleans all cargo artifacts (`target/wasm32-unknown-unknown/release`).
   - Runs `cargo build --locked --no-default-features --release`.
   - Captures the SHA-256 of the output `.wasm`.
   - Repeats the exact same process a second time.
   - Asserts the two hashes are byte-identical.

2. **CI Workflow (`.github/workflows/wasm-reproducible-build.yml`)**
   A dedicated GitHub Actions workflow that:
   - Sets `CARGO_INCREMENTAL=0` and disables caches (intentional cache-miss to
     expose non-determinism).
   - Validates that `Cargo.lock` is present and `codegen-units = 1` is configured
     in the `release` profile.
   - Executes the two isolated builds and compares the output hashes.
   - Uploads the `.wasm` file and its SHA-256 manifest as a release artifact
     for future audit verification.

3. **Documentation (`docs/reproducible-builds.md`)**
   A comprehensive guide explaining:
   - Why reproducibility matters for Soroban contracts.
   - How to reproduce the build locally (or verify an on-chain deployment).
   - Troubleshooting steps for non-determinism (e.g. `LTO`, `build.rs` hygiene,
     toolchain drift).
   Linked from the `README.md` Documentation section.

---

## Validation

- Ran `bash scripts/reproducible-build.sh` locally: passed and emitted identical
  WASM hashes.
- Verified that all Cargo profile requirements (`lto`, `codegen-units`, `overflow-checks`)
  and toolchain pinnings are strictly followed.

closes #1200 