### PR TITLE
chore: consolidate query pagination helpers into pagination.rs

### DIFF
--- a/quicklendx-contracts/Cargo.lock
+++ b/quicklendx-contracts/Cargo.lock
@@ -1119,6 +1119,7 @@ dependencies = [
  "serde",
  "serde_json",
  "soroban-sdk",
+ "toml",
 ]
 
 [[package]]
@@ -1381,6 +1382,15 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -1818,6 +1828,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap 2.13.0",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
 name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2073,6 +2124,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]

--- a/quicklendx-contracts/src/investment_queries.rs
+++ b/quicklendx-contracts/src/investment_queries.rs
@@ -49,7 +49,7 @@ pub struct InvestorPortfolioSummary {
 
 /// Maximum number of records returned by paginated query endpoints.
 /// This constant ensures memory usage stays within reasonable bounds.
-pub const MAX_QUERY_LIMIT: u32 = 100;
+pub const MAX_QUERY_LIMIT: u32 = crate::pagination::MAX_QUERY_LIMIT;
 
 /// Read-only investment query helpers with pagination support
 pub struct InvestmentQueries;
@@ -92,7 +92,7 @@ impl InvestmentQueries {
     /// - Enforces maximum limit to prevent DoS attacks via large queries
     #[inline]
     pub fn cap_query_limit(limit: u32) -> u32 {
-        limit.min(MAX_QUERY_LIMIT)
+        crate::pagination::cap_query_limit(limit)
     }
 
     /// Validates pagination parameters for safety and correctness.
@@ -114,13 +114,7 @@ impl InvestmentQueries {
         limit: u32,
         total_count: u32,
     ) -> (u32, u32, bool) {
-        let capped_limit = Self::cap_query_limit(limit);
-        let safe_offset = offset.min(total_count);
-        let remaining = total_count.saturating_sub(safe_offset);
-        let actual_limit = capped_limit.min(remaining);
-        let has_more = safe_offset.saturating_add(actual_limit) < total_count;
-
-        (safe_offset, actual_limit, has_more)
+        crate::pagination::validate_pagination_params(offset, limit, total_count)
     }
 
     /// Safely calculates pagination bounds with overflow protection.
@@ -138,10 +132,7 @@ impl InvestmentQueries {
     /// - Bounds are guaranteed to be within [0, collection_size]
     /// - Handles edge cases like offset >= collection_size gracefully
     pub fn calculate_safe_bounds(offset: u32, limit: u32, collection_size: u32) -> (u32, u32) {
-        let capped_limit = Self::cap_query_limit(limit);
-        let start = offset.min(collection_size);
-        let end = start.saturating_add(capped_limit).min(collection_size);
-        (start, end)
+        crate::pagination::calculate_safe_bounds(offset, limit, collection_size)
     }
 
     /// Retrieves paginated investments for a specific investor with overflow-safe arithmetic.

--- a/quicklendx-contracts/src/lib.rs
+++ b/quicklendx-contracts/src/lib.rs
@@ -86,6 +86,7 @@ pub mod invoice_search;
 pub mod maintenance;
 pub mod monitor;
 pub mod notifications;
+pub mod pagination;
 pub mod pause;
 pub mod payments;
 pub mod profits;
@@ -115,6 +116,8 @@ mod test_escrow_event_completeness;
 mod test_bid_ttl;
 #[cfg(all(test, feature = "legacy-tests"))]
 mod test_bid_expiry_boundary;
+#[cfg(test)]
+mod test_queries;
 #[cfg(all(test, feature = "legacy-tests"))]
 mod test_cleanup_pagination;
 #[cfg(all(test, feature = "legacy-tests"))]
@@ -289,7 +292,7 @@ use crate::storage::{BidStorage, InvoiceStorage};
 pub struct QuickLendXContract;
 
 /// Maximum number of records returned by paginated query endpoints.
-pub(crate) const MAX_QUERY_LIMIT: u32 = 100;
+pub(crate) const MAX_QUERY_LIMIT: u32 = pagination::MAX_QUERY_LIMIT;
 
 /// @notice Validates and caps query limit to prevent resource abuse
 /// @param limit The requested limit value
@@ -297,7 +300,7 @@ pub(crate) const MAX_QUERY_LIMIT: u32 = 100;
 /// @dev Returns 0 if limit is 0, enforcing empty result behavior
 #[inline]
 fn cap_query_limit(limit: u32) -> u32 {
-    investment_queries::InvestmentQueries::cap_query_limit(limit)
+    pagination::cap_query_limit(limit)
 }
 
 /// @notice Validates query parameters for security and resource protection
@@ -305,15 +308,8 @@ fn cap_query_limit(limit: u32) -> u32 {
 /// @param limit The requested result limit
 /// @return Result indicating validation success or failure
 /// @dev Prevents potential overflow and ensures reasonable query bounds
-fn validate_query_params(offset: u32, _limit: u32) -> Result<(), QuickLendXError> {
-    // Check for potential overflow in offset + limit calculation
-    if offset > u32::MAX - MAX_QUERY_LIMIT {
-        return Err(QuickLendXError::InvalidAmount);
-    }
-
-    // Limit is automatically capped by cap_query_limit, but we validate the input
-    // Note: limit=0 is allowed and results in empty response
-    Ok(())
+fn validate_query_params(offset: u32, limit: u32) -> Result<(), QuickLendXError> {
+    pagination::validate_query_params(offset, limit)
 }
 
 /// Write a `u32` as ASCII decimal into `buf`, return byte length.
@@ -2732,7 +2728,6 @@ impl QuickLendXContract {
             return Vec::new(&env);
         }
 
-        let capped_limit = cap_query_limit(limit);
         let all_invoices = InvoiceStorage::get_business_invoices(&env, &business);
         let mut filtered = Vec::new(&env);
 
@@ -2751,8 +2746,7 @@ impl QuickLendXContract {
         // Apply pagination (overflow-safe)
         let mut result = Vec::new(&env);
         let len_u32 = filtered.len();
-        let start = offset.min(len_u32);
-        let end = start.saturating_add(capped_limit).min(len_u32);
+        let (start, end) = pagination::calculate_safe_bounds(offset, limit, len_u32);
         let mut idx = start;
         while idx < end {
             if let Some(invoice_id) = filtered.get(idx) {
@@ -2835,7 +2829,6 @@ impl QuickLendXContract {
             return Vec::new(&env);
         }
 
-        let capped_limit = cap_query_limit(limit);
         let verified_invoices =
             InvoiceStorage::get_invoices_by_status(&env, InvoiceStatus::Verified);
         let mut filtered = Vec::new(&env);
@@ -2866,8 +2859,7 @@ impl QuickLendXContract {
         // Apply pagination (overflow-safe)
         let mut result = Vec::new(&env);
         let len_u32 = filtered.len();
-        let start = offset.min(len_u32);
-        let end = start.saturating_add(capped_limit).min(len_u32);
+        let (start, end) = pagination::calculate_safe_bounds(offset, limit, len_u32);
         let mut idx = start;
         while idx < end {
             if let Some(invoice_id) = filtered.get(idx) {
@@ -2898,7 +2890,6 @@ impl QuickLendXContract {
             return Vec::new(&env);
         }
 
-        let capped_limit = cap_query_limit(limit);
         let all_bids = BidStorage::get_bid_records_for_invoice(&env, &invoice_id);
         let mut filtered = Vec::new(&env);
 
@@ -2915,8 +2906,7 @@ impl QuickLendXContract {
         // Apply pagination (overflow-safe)
         let mut result = Vec::new(&env);
         let len_u32 = filtered.len();
-        let start = offset.min(len_u32);
-        let end = start.saturating_add(capped_limit).min(len_u32);
+        let (start, end) = pagination::calculate_safe_bounds(offset, limit, len_u32);
         let mut idx = start;
         while idx < end {
             if let Some(bid) = filtered.get(idx) {
@@ -2947,7 +2937,6 @@ impl QuickLendXContract {
             return Vec::new(&env);
         }
 
-        let capped_limit = cap_query_limit(limit);
         let all_bid_ids = BidStorage::get_bids_by_investor_all(&env, &investor);
         let mut filtered = Vec::new(&env);
 
@@ -2966,8 +2955,7 @@ impl QuickLendXContract {
         // Apply pagination (overflow-safe)
         let mut result = Vec::new(&env);
         let len_u32 = filtered.len();
-        let start = offset.min(len_u32);
-        let end = start.saturating_add(capped_limit).min(len_u32);
+        let (start, end) = pagination::calculate_safe_bounds(offset, limit, len_u32);
         let mut idx = start;
         while idx < end {
             if let Some(bid) = filtered.get(idx) {

--- a/quicklendx-contracts/src/pagination.rs
+++ b/quicklendx-contracts/src/pagination.rs
@@ -21,6 +21,7 @@
 extern crate alloc;
 
 use alloc::vec::Vec;
+use crate::errors::QuickLendXError;
 
 /// Maximum number of records any paginated query endpoint may return in a
 /// single response.
@@ -44,6 +45,23 @@ pub const fn cap_query_limit(limit: u32) -> u32 {
     } else {
         limit
     }
+}
+
+/// Validate query parameters for security and resource protection.
+///
+/// # Arguments
+/// * `offset` - Pagination offset starting index.
+/// * `_limit` - Pagination limit.
+///
+/// # Returns
+/// * `Ok(())` if valid.
+/// * `Err(QuickLendXError::InvalidAmount)` on potential offset overflow.
+#[inline]
+pub const fn validate_query_params(offset: u32, _limit: u32) -> Result<(), QuickLendXError> {
+    if offset > u32::MAX - MAX_QUERY_LIMIT {
+        return Err(QuickLendXError::InvalidAmount);
+    }
+    Ok(())
 }
 
 /// Validate pagination parameters against a known collection size.

--- a/quicklendx-contracts/src/test_queries.rs
+++ b/quicklendx-contracts/src/test_queries.rs
@@ -24,8 +24,9 @@ use alloc::vec::Vec;
 
 use crate::pagination::{
     calculate_safe_bounds, cap_query_limit, paginate_slice, validate_pagination_params,
-    MAX_QUERY_LIMIT,
+    validate_query_params, MAX_QUERY_LIMIT,
 };
+use crate::errors::QuickLendXError;
 #[cfg(feature = "fuzz-tests")]
 use proptest::prelude::*;
 
@@ -78,6 +79,29 @@ fn test_validate_limit_zero_at_end_of_collection() {
     assert_eq!(safe_off, 50);
     assert_eq!(eff_lim, 0);
     assert!(!has_more);
+}
+
+/// `validate_query_params` checks boundaries: offset > u32::MAX - MAX_QUERY_LIMIT
+#[test]
+fn test_validate_query_params_boundaries() {
+    // Normal offset
+    assert!(validate_query_params(0, 10).is_ok());
+    assert!(validate_query_params(100, 10).is_ok());
+
+    // Boundary check
+    let max_valid_offset = u32::MAX - MAX_QUERY_LIMIT;
+    assert!(validate_query_params(max_valid_offset, 10).is_ok());
+
+    // Overflow checks
+    let invalid_offset = max_valid_offset + 1;
+    assert_eq!(
+        validate_query_params(invalid_offset, 10).unwrap_err(),
+        QuickLendXError::InvalidAmount
+    );
+    assert_eq!(
+        validate_query_params(u32::MAX, 10).unwrap_err(),
+        QuickLendXError::InvalidAmount
+    );
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Description
Consolidated pagination validation, clamping, and bounds calculation into pagination.rs. Removed duplicate implementations across lib.rs and investment_queries.rs.

Changes Made
Moved validate_query_params into pagination.rs.
Delegated capping and validation helpers in lib.rs and investment_queries.rs to pagination.rs.
Replaced manual indexing with pagination::calculate_safe_bounds in lib.rs query endpoints.
Added boundary tests for validation parameters in test_queries.rs.
Testing
  Unit tests pass

Closes #1309