### PR TITLE
test: enforce per-window fee cap and add regression test (Closes #1579)

### DIFF
--- a/quicklendx-contracts/src/fees.rs
+++ b/quicklendx-contracts/src/fees.rs
@@ -15,6 +15,9 @@ const MIN_FEE_BPS: u32 = 0;
 const BPS_DENOMINATOR: i128 = 10_000;
 const DEFAULT_PLATFORM_FEE_BPS: u32 = 200; // 2%
 const MAX_PLATFORM_FEE_BPS: u32 = 1000; // 10%
+/// Maximum total fees that may be collected in a single revenue period/window.
+/// Enforced to prevent unbounded fee accumulation per accounting period.
+pub const MAX_FEE_PER_WINDOW: i128 = 5_000_000_000_000; // 5M stroops
 const ROTATION_TTL_SECONDS: u64 = 604_800; // 7 days
 /// Minimum delay before a pending rotation can be confirmed (1 day).
 /// Prevents same-block finalisation and gives the admin a window to cancel.
@@ -834,8 +837,16 @@ impl FeeManager {
                 transaction_count: 0,
             });
 
-        revenue_data.total_collected =
-            Self::checked_add(revenue_data.total_collected, total_amount)?;
+        // Enforce a hard cap on total fees collected per period/window.
+        let projected_total = revenue_data
+            .total_collected
+            .checked_add(total_amount)
+            .ok_or(QuickLendXError::ArithmeticOverflow)?;
+        if projected_total > MAX_FEE_PER_WINDOW {
+            return Err(QuickLendXError::InvalidFeeConfiguration);
+        }
+
+        revenue_data.total_collected = projected_total;
         revenue_data.pending_distribution =
             Self::checked_add(revenue_data.pending_distribution, total_amount)?;
         revenue_data.transaction_count = revenue_data.transaction_count.saturating_add(1);

--- a/quicklendx-contracts/src/test_fees.rs
+++ b/quicklendx-contracts/src/test_fees.rs
@@ -798,6 +798,34 @@ fn test_comprehensive_fee_calculation() {
     assert_eq!(fees, 1403);
 }
 
+/// Regression test: ensure total fees collected in a period cannot exceed the protocol cap
+#[test]
+fn test_fee_cap_per_window_rejects_excessive_collection() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(crate::QuickLendXContract, ());
+    let client = QuickLendXContractClient::new(&env, &contract_id);
+    let admin = setup_admin(&env, &client);
+    let user = setup_investor(&env, &client, &admin);
+
+    client.initialize_fee_system(&admin);
+
+    // Collect an amount just below the cap - should succeed
+    let cap = crate::fees::MAX_FEE_PER_WINDOW;
+    let first_amount: i128 = cap.saturating_sub(1);
+    let mut fees = Map::new(&env);
+    fees.set(FeeType::Platform, first_amount);
+    client.collect_transaction_fees(&user, &fees, &first_amount);
+
+    // Now attempt to collect a small amount that would push the period total over the cap
+    let mut extra = Map::new(&env);
+    extra.set(FeeType::Platform, 2i128);
+    let res = client.try_collect_transaction_fees(&user, &extra, &2i128);
+    let err = res.err().expect("collecting beyond cap must fail");
+    let contract_err = err.expect("expected contract invoke error");
+    assert_eq!(contract_err, QuickLendXError::InvalidFeeConfiguration);
+}
+
 // ============================================================================
 // Treasury Configuration Tests
 // ============================================================================


### PR DESCRIPTION
Adds MAX_FEE_PER_WINDOW cap and regression test ensuring collection beyond the cap fails.\n\nCloses #1579