### PR TITLE
ci: add per-package rustdoc workflow

### DIFF
--- a/.github/workflows/rustdoc.yml
+++ b/.github/workflows/rustdoc.yml
@@ -1,0 +1,52 @@
+name: Rustdoc
+
+on:
+  push:
+    branches: ["main"]
+    paths:
+      - ".github/workflows/rustdoc.yml"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "src/**"
+      - "quicklendx-contracts/**"
+  pull_request:
+    branches: ["main"]
+    paths:
+      - ".github/workflows/rustdoc.yml"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "src/**"
+      - "quicklendx-contracts/**"
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  cargo-doc:
+    name: cargo doc (${{ matrix.package.name }})
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - name: root contract crate
+            working-directory: .
+          - name: quicklendx-contracts
+            working-directory: quicklendx-contracts
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        run: |
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+          source "$HOME/.cargo/env"
+          rustup show
+
+      - name: Generate package rustdoc
+        working-directory: ${{ matrix.package.working-directory }}
+        run: |
+          source "$HOME/.cargo/env"
+          cargo doc --no-deps --locked

--- a/docs/RUSTDOC.md
+++ b/docs/RUSTDOC.md
@@ -98,6 +98,20 @@ The published URL is updated automatically on every tag push — no manual step 
 
 If the published URL returns a 404, the most likely cause is that no tag has been pushed yet for the current development cycle. Generate the docs locally using the command above, or check the repository's Actions tab to confirm the publish workflow ran successfully.
 
+## Pull request validation
+
+Every push to `main` and every pull request that touches contract sources,
+Cargo metadata, or the rustdoc workflow runs `.github/workflows/rustdoc.yml`.
+That workflow checks each contract package independently:
+
+| Package | Working directory | Command |
+|---|---|---|
+| Root contract crate | `.` | `cargo doc --no-deps --locked` |
+| Smart contract package | `quicklendx-contracts/` | `cargo doc --no-deps --locked` |
+
+The matrix keeps rustdoc failures scoped to the package that introduced them
+and prevents a healthy package from hiding a broken API surface in another one.
+
 ---
 
 ## Related documentation


### PR DESCRIPTION
## Summary
- Add `.github/workflows/rustdoc.yml` with a per-package matrix for the root contract crate and `quicklendx-contracts/`.
- Run `cargo doc --no-deps --locked` for each package so rustdoc failures are scoped to the package that introduced them.
- Document the PR/main rustdoc validation path in `docs/RUSTDOC.md`.

Closes #1481

## Tests
- `git diff --cached --check` before commit
- Attempted `cargo doc --no-deps --locked` in both `.` and `quicklendx-contracts/`; local Windows environment cannot complete because MSVC `link.exe` is not installed. The workflow runs on `ubuntu-latest`, where this local linker issue should not apply.

## Notes
- The existing base branch has known Rust CI failures on `src/lib.rs` (`unclosed delimiter`) from earlier PR checks. This PR adds an isolated rustdoc workflow and does not modify contract source.