### PR TITLE
fix(analytics): remove duplicate test_category_breakdown module registration

### DIFF
--- a/quicklendx-contracts/src/lib.rs
+++ b/quicklendx-contracts/src/lib.rs
@@ -278,8 +278,6 @@ mod test_clock_rollover;
 mod test_rebuild_indexes;
 #[cfg(all(test, feature = "legacy-tests"))]
 mod test_max_invoices_per_business;
-#[cfg(all(test, feature = "legacy-tests"))]
-mod test_category_breakdown;
 #[cfg(test)]
 mod test_diagnostics;
 #[cfg(all(test, feature = "legacy-tests"))]


### PR DESCRIPTION
Closes #1320.

The bounded `get_category_breakdown` entrypoint and its `CategoryBreakdown` type are already implemented in `lib.rs`/`analytics.rs` (index-based, read-only, zero-count categories omitted, bounded to the 9-variant enum), and `test_category_breakdown.rs` already exists. The only outstanding defect in this feature area was a **duplicate** `mod test_category_breakdown;` declaration in `lib.rs` (an `E0428` 'defined multiple times' error). This PR removes the redundant registration so the category-breakdown test module compiles cleanly while keeping the existing, complete implementation intact.