### PR TITLE
Add an admin entrypoint to revoke an investor KYC

### DIFF
--- a/quicklendx-contracts/src/lib.rs
+++ b/quicklendx-contracts/src/lib.rs
@@ -335,7 +335,8 @@ use verification::{
     calculate_investment_limit, calculate_investor_risk_score, compute_investor_tier,
     determine_investor_tier, get_investor_verification as do_get_investor_verification,
     normalize_tag, reject_business,
-    reject_investor as do_reject_investor, recompute_investor_tier, require_business_not_pending,
+    reject_investor as do_reject_investor, revoke_investor_kyc as do_revoke_investor_kyc,
+    recompute_investor_tier, require_business_not_pending,
     require_investor_not_pending, submit_investor_kyc as do_submit_investor_kyc,
     submit_kyc_application, validate_bid, validate_dispute_evidence, validate_dispute_resolution,
     validate_investor_investment, validate_invoice_metadata, verify_business,
@@ -2046,6 +2047,22 @@ impl QuickLendXContract {
         pause::PauseControl::require_not_paused(&env)?;
         let admin = AdminStorage::get_admin(&env).ok_or(QuickLendXError::NotAdmin)?;
         do_reject_investor(&env, &admin, &investor, reason)
+    }
+
+    /// Revoke a verified investor's KYC (admin only).
+    ///
+    /// Moves the investor from `Verified` back to `Rejected`, emits a
+    /// `kyc_revoke` event, and blocks all further bids (via
+    /// `validate_investor_investment`) until the investor re-submits KYC and is
+    /// re-verified.
+    pub fn revoke_investor_kyc(
+        env: Env,
+        investor: Address,
+        reason: String,
+    ) -> Result<(), QuickLendXError> {
+        pause::PauseControl::require_not_paused(&env)?;
+        let admin = AdminStorage::get_admin(&env).ok_or(QuickLendXError::NotAdmin)?;
+        do_revoke_investor_kyc(&env, &admin, &investor, reason)
     }
 
     /// Get investor verification record if available

--- a/quicklendx-contracts/src/test_investor_kyc.rs
+++ b/quicklendx-contracts/src/test_investor_kyc.rs
@@ -1219,4 +1219,88 @@ mod test_investor_kyc {
             .unwrap();
         assert_eq!(err, QuickLendXError::BusinessNotVerified);
     }
+
+    // ============================================================================
+    // Category: Admin revoke investor KYC (#1550)
+    // ============================================================================
+
+    /// A verified investor can bid, but once their KYC is revoked by the admin
+    /// every further bid is rejected with `BusinessNotVerified` until they are
+    /// re-verified. This is the core defence-in-depth behaviour: revocation must
+    /// immediately block new investment activity.
+    #[test]
+    fn revoked_investor_cannot_place_further_bids() {
+        let (env, client, _admin) = setup();
+        let investor = Address::generate(&env);
+        let business = Address::generate(&env);
+        let kyc_data = String::from_str(&env, "Valid KYC data");
+
+        // Verify the investor and confirm they can bid.
+        let _ = client.try_submit_investor_kyc(&investor, &kyc_data);
+        let _ = client.try_verify_investor(&investor, &100_000i128);
+
+        let invoice_id = create_verified_invoice(&env, &client, &business, 50_000);
+        let first_bid =
+            client.try_place_bid(&investor, &invoice_id, &10_000i128, &12_000i128);
+        assert!(
+            first_bid.is_ok(),
+            "verified investor must be able to bid before revocation"
+        );
+
+        // Admin revokes the investor's KYC.
+        let revoke = client.try_revoke_investor_kyc(
+            &investor,
+            &String::from_str(&env, "Sanctions screening hit"),
+        );
+        assert!(revoke.is_ok(), "admin revoke of verified investor must succeed");
+
+        // Status must have moved to Rejected.
+        let verification = client
+            .get_investor_verification(&investor)
+            .expect("verification record must still exist after revoke");
+        assert_eq!(verification.status, BusinessVerificationStatus::Rejected);
+
+        // Any further bid must now be blocked.
+        let invoice_id2 = create_verified_invoice(&env, &client, &business, 50_000);
+        let err = client
+            .try_place_bid(&investor, &invoice_id2, &5_000i128, &6_000i128)
+            .unwrap_err()
+            .unwrap();
+        assert_eq!(
+            err,
+            QuickLendXError::BusinessNotVerified,
+            "revoked investor must be blocked from bidding"
+        );
+    }
+
+    /// Revoking an investor who is not currently `Verified` (here: still
+    /// `Pending`) is rejected with `InvalidKYCStatus`, keeping the state machine
+    /// auditable.
+    #[test]
+    fn revoke_non_verified_investor_fails() {
+        let (env, client, _admin) = setup();
+        let investor = Address::generate(&env);
+
+        let _ = client
+            .try_submit_investor_kyc(&investor, &String::from_str(&env, "Pending KYC data"));
+
+        let err = client
+            .try_revoke_investor_kyc(&investor, &String::from_str(&env, "no reason"))
+            .unwrap_err()
+            .unwrap();
+        assert_eq!(err, QuickLendXError::InvalidKYCStatus);
+    }
+
+    /// Revoking an investor that has no KYC record at all returns `KYCNotFound`.
+    #[test]
+    fn revoke_investor_without_record_fails() {
+        let (env, client, _admin) = setup();
+        let investor = Address::generate(&env);
+
+        let err = client
+            .try_revoke_investor_kyc(&investor, &String::from_str(&env, "no reason"))
+            .unwrap_err()
+            .unwrap();
+        assert_eq!(err, QuickLendXError::KYCNotFound);
+    }
 }

--- a/quicklendx-contracts/src/verification.rs
+++ b/quicklendx-contracts/src/verification.rs
@@ -1228,6 +1228,72 @@ pub fn reject_investor(
     Ok(())
 }
 
+/// Revoke a previously-verified investor's KYC (admin only).
+///
+/// # Threat mitigated
+/// A verified investor whose identity/compliance status is later found to be
+/// invalid (sanctions hit, fraudulent KYC, compromised key) would otherwise
+/// retain the ability to place and fund bids indefinitely. Without an explicit
+/// revoke path, an admin can only set a new investment limit — they cannot stop
+/// the investor from continuing to bid. This entrypoint moves the investor from
+/// `Verified` back to `Rejected`, which causes `validate_investor_investment`
+/// (and therefore `validate_bid`) to fail with `BusinessNotVerified`, blocking
+/// all further bids until the investor re-submits KYC and is re-verified.
+///
+/// Emits a `kyc_revoke` event recording the investor, admin, timestamp, and
+/// reason for the audit trail.
+///
+/// # Errors
+/// - `NotAdmin` if `admin` is not a contract admin
+/// - `KYCNotFound` if the investor has no KYC record
+/// - `InvalidKYCStatus` if the investor is not currently `Verified`
+/// - `InvalidDescription` if `reason` exceeds `MAX_REJECTION_REASON_LENGTH`
+pub fn revoke_investor_kyc(
+    env: &Env,
+    admin: &Address,
+    investor: &Address,
+    reason: String,
+) -> Result<(), QuickLendXError> {
+    check_string_length(&reason, MAX_REJECTION_REASON_LENGTH)?;
+    admin.require_auth();
+    if !crate::admin::AdminStorage::is_admin(env, admin) {
+        return Err(QuickLendXError::NotAdmin);
+    }
+
+    let mut verification =
+        InvestorVerificationStorage::get(env, investor).ok_or(QuickLendXError::KYCNotFound)?;
+
+    // Only a currently-verified investor can be revoked. Pending/rejected
+    // investors are already blocked from bidding, so revoking them is a no-op
+    // that we reject explicitly to keep the state machine auditable.
+    if !matches!(verification.status, BusinessVerificationStatus::Verified) {
+        return Err(QuickLendXError::InvalidKYCStatus);
+    }
+
+    verification.status = BusinessVerificationStatus::Rejected;
+    verification.verified_at = Some(env.ledger().timestamp());
+    verification.verified_by = Some(admin.clone());
+    verification.rejection_reason = Some(reason.clone());
+    verification.compliance_notes = Some(String::from_str(env, "KYC revoked by admin"));
+
+    InvestorVerificationStorage::update(env, &verification);
+    emit_investor_kyc_revoked(env, investor, admin, &reason);
+    Ok(())
+}
+
+fn emit_investor_kyc_revoked(env: &Env, investor: &Address, admin: &Address, reason: &String) {
+    #[allow(deprecated)]
+    env.events().publish(
+        (symbol_short!("kyc_revk"),),
+        (
+            investor.clone(),
+            admin.clone(),
+            env.ledger().timestamp(),
+            reason.clone(),
+        ),
+    );
+}
+
 pub fn get_investor_verification(env: &Env, investor: &Address) -> Option<InvestorVerification> {
     InvestorVerificationStorage::get(env, investor)
 }


### PR DESCRIPTION
## Summary
Adds an admin-only `revoke_investor_kyc(investor, reason)` entrypoint. It moves a currently `Verified` investor back to `Rejected`, emits a `kyc_revoke` event (investor, admin, timestamp, reason), and thereby blocks all further bids until the investor re-submits KYC and is re-verified.

## Threat mitigated
A verified investor later found non-compliant (sanctions hit, fraudulent KYC, compromised key) would otherwise keep the ability to place and fund bids indefinitely — an admin could only adjust their limit, not stop them. Revocation flips the verification status, so `validate_investor_investment` (called by `validate_bid`) fails with `BusinessNotVerified`, immediately blocking new investment activity. Defence-in-depth; no known exploitation.

## Typed errors
Returns `InvalidKYCStatus` if the investor is not `Verified`, `KYCNotFound` if no record exists, `NotAdmin` for non-admins — no panics or generic failures.

## Tests
- `revoked_investor_cannot_place_further_bids`: verified investor bids successfully, admin revokes, subsequent bid is rejected with `BusinessNotVerified`.
- `revoke_non_verified_investor_fails` / `revoke_investor_without_record_fails`: sad paths.

Note: the repository's `main` does not currently compile (pre-existing duplicate `idempotency` module, duplicate `extend_persistent_ttl` import, missing `compute_yield`), so local `cargo test` could not be run; these are unrelated to this change and left untouched per scope.

Closes #1550