### PR TITLE
fix(freshness): reject ledger_seq == 0 at get_freshness entrypoint boundary

### DIFF
--- a/quicklendx-contracts/src/errors.rs
+++ b/quicklendx-contracts/src/errors.rs
@@ -186,6 +186,10 @@ pub enum QuickLendXError {
     DuplicateDefaultTransition = 2202,
     BackupVersionUnsupported = 2203,
     DuplicateBid = 2204,
+    /// Caller supplied ledger sequence 0, which is not a valid Soroban ledger sequence.
+    /// Ledger sequences start at 1; sequence 0 indicates an uninitialised or default-constructed value.
+    /// BREAKING: Do not renumber this variant. public ABI consumption.
+    InvalidLedgerSequence = 2205,
 }
 
 impl From<QuickLendXError> for Symbol {
@@ -283,6 +287,7 @@ impl From<QuickLendXError> for Symbol {
             QuickLendXError::InvoiceFrozen => symbol_short!("INV_FRZ"),
             QuickLendXError::SelfTransfer => symbol_short!("SELF_TR"),
             QuickLendXError::DuplicateBid => symbol_short!("BID_DUP"),
+            QuickLendXError::InvalidLedgerSequence => symbol_short!("LGR_SEQ"),
         }
     }
 }

--- a/quicklendx-contracts/src/lib.rs
+++ b/quicklendx-contracts/src/lib.rs
@@ -3892,6 +3892,19 @@ impl QuickLendXContract {
 
     /// Build API freshness metadata as string key/value pairs.
     ///
+    /// # Errors
+    ///
+    /// Returns [] when
+    /// . Stellar/Soroban ledger sequences start at 1;
+    /// a value of 0 indicates an uninitialised or default-constructed caller
+    /// argument and must be rejected at the entrypoint boundary to prevent
+    /// stale or misleading freshness data from reaching downstream consumers.
+    ///
+    /// **Threat model**: accepting sequence 0 would allow a caller to supply a
+    /// sentinel "not-yet-indexed" value and receive a freshness response that
+    /// appears valid but represents no real ledger state. Downstream consumers
+    /// that cache the cursor  could serve permanently stale data.
+    ///
     /// See `quicklendx-contracts/docs/freshness.md` for the documented
     /// freshness drift bound and client handling guidance.
     pub fn get_freshness(
@@ -3899,7 +3912,14 @@ impl QuickLendXContract {
         indexed_ledger_seq: u32,
         indexed_ledger_timestamp: u64,
         offset: u32,
-    ) -> Map<String, String> {
+    ) -> Result<Map<String, String>, QuickLendXError> {
+        // Guard: ledger sequences start at 1 in Soroban; 0 is never a valid
+        // on-chain ledger sequence and indicates a caller bug or an attempt to
+        // inject a sentinel that bypasses freshness checks.
+        if indexed_ledger_seq == 0 {
+            return Err(QuickLendXError::InvalidLedgerSequence);
+        }
+
         let meta = freshness::FreshnessMetadata::from_env(
             &env,
             indexed_ledger_seq,
@@ -3921,7 +3941,7 @@ impl QuickLendXContract {
             meta.last_updated_at,
         );
         result.set(String::from_str(&env, "cursor"), meta.cursor);
-        result
+        Ok(result)
     }
 
     // ============================================================================

--- a/quicklendx-contracts/src/test_freshness.rs
+++ b/quicklendx-contracts/src/test_freshness.rs
@@ -20,7 +20,7 @@ fn test_get_freshness_returns_all_keys() {
     env.ledger().set_sequence_number(500);
     env.ledger().set_timestamp(1_700_000_000);
 
-    let result = client.get_freshness(&500u32, &1_700_000_000u64, &0u32);
+    let result = client.get_freshness(&500u32, &1_700_000_000u64, &0u32).unwrap();
 
     assert!(result.contains_key(String::from_str(&env, "last_indexed_ledger")));
     assert!(result.contains_key(String::from_str(&env, "index_lag_seconds")));
@@ -34,7 +34,7 @@ fn test_get_freshness_zero_lag() {
     env.ledger().set_sequence_number(500);
     env.ledger().set_timestamp(1_700_000_000);
 
-    let result = client.get_freshness(&500u32, &1_700_000_000u64, &0u32);
+    let result = client.get_freshness(&500u32, &1_700_000_000u64, &0u32).unwrap();
 
     let lag = result
         .get(String::from_str(&env, "index_lag_seconds"))
@@ -48,7 +48,7 @@ fn test_get_freshness_positive_lag() {
     env.ledger().set_sequence_number(500);
     env.ledger().set_timestamp(1_700_000_060); // 60 s ahead of indexed
 
-    let result = client.get_freshness(&499u32, &1_700_000_000u64, &0u32);
+    let result = client.get_freshness(&499u32, &1_700_000_000u64, &0u32).unwrap();
 
     let lag = result
         .get(String::from_str(&env, "index_lag_seconds"))
@@ -62,7 +62,7 @@ fn test_get_freshness_cursor_encodes_seq_and_offset() {
     env.ledger().set_sequence_number(1000);
     env.ledger().set_timestamp(1_700_000_000);
 
-    let result = client.get_freshness(&1000u32, &1_700_000_000u64, &25u32);
+    let result = client.get_freshness(&1000u32, &1_700_000_000u64, &25u32).unwrap();
 
     let cursor = result.get(String::from_str(&env, "cursor")).unwrap();
     assert_eq!(cursor, String::from_str(&env, "1000_25"));
@@ -74,7 +74,7 @@ fn test_get_freshness_last_updated_at_is_iso8601() {
     env.ledger().set_sequence_number(1000);
     env.ledger().set_timestamp(1_700_000_000);
 
-    let result = client.get_freshness(&1000u32, &1_700_000_000u64, &0u32);
+    let result = client.get_freshness(&1000u32, &1_700_000_000u64, &0u32).unwrap();
 
     let ts = result
         .get(String::from_str(&env, "last_updated_at"))
@@ -90,7 +90,7 @@ fn test_get_freshness_no_topology_in_values() {
     env.ledger().set_sequence_number(1000);
     env.ledger().set_timestamp(1_700_000_000);
 
-    let result = client.get_freshness(&1000u32, &1_700_000_000u64, &0u32);
+    let result = client.get_freshness(&1000u32, &1_700_000_000u64, &0u32).unwrap();
 
     // Cursor must only contain digits and underscore.
     let cursor = result.get(String::from_str(&env, "cursor")).unwrap();

--- a/quicklendx-contracts/src/test_freshness_bounds.rs
+++ b/quicklendx-contracts/src/test_freshness_bounds.rs
@@ -19,7 +19,7 @@ fn index_lag_seconds(
 ) -> i64 {
     env.ledger().set_timestamp(current);
 
-    let result = client.get_freshness(&100u32, &indexed, &0u32);
+    let result = client.get_freshness(&100u32, &indexed, &0u32).unwrap();
     let lag = result
         .get(String::from_str(env, "index_lag_seconds"))
         .unwrap();

--- a/quicklendx-contracts/src/test_freshness_lag.rs
+++ b/quicklendx-contracts/src/test_freshness_lag.rs
@@ -63,7 +63,7 @@ mod test_freshness_lag {
         let now = 1_700_000_000u64;
         env.ledger().set_timestamp(now);
 
-        let result = client.get_freshness(&500u32, &now, &0u32);
+        let result = client.get_freshness(&500u32, &now, &0u32).unwrap();
         let lag = lag_from_response(&env, &result);
 
         assert_eq!(lag, 0, "lag must be exactly 0 when indexed == current");
@@ -76,7 +76,7 @@ mod test_freshness_lag {
         let now = 1_700_000_000u64;
         env.ledger().set_timestamp(now);
 
-        let result = client.get_freshness(&500u32, &now, &0u32);
+        let result = client.get_freshness(&500u32, &now, &0u32).unwrap();
         let lag = lag_from_response(&env, &result);
 
         assert!(
@@ -85,16 +85,39 @@ mod test_freshness_lag {
         );
     }
 
-    /// Zero lag holds at the Unix epoch boundary (timestamp = 0).
+    /// Zero lag holds at the Unix epoch boundary (timestamp = 0, ledger_seq = 1).
+    ///
+    /// Note: `indexed_ledger_seq = 0` is now rejected with
+    /// `InvalidLedgerSequence` (see issue #1485). This test verifies that
+    /// supplying the minimum valid sequence (1) at timestamp 0 still produces
+    /// zero lag, and that supplying 0 is correctly rejected.
     #[test]
     fn lag_is_zero_at_unix_epoch_when_indexed_equals_current() {
         let (env, client, _) = setup();
         env.ledger().set_timestamp(0);
+        env.ledger().set_sequence_number(1);
 
-        let result = client.get_freshness(&0u32, &0u64, &0u32);
+        // Minimum valid ledger sequence (1) at epoch boundary => zero lag.
+        let result = client.get_freshness(&1u32, &0u64, &0u32).unwrap();
         let lag = lag_from_response(&env, &result);
-
         assert_eq!(lag, 0, "lag must be 0 at epoch boundary when timestamps match");
+    }
+
+    /// Ledger sequence 0 is rejected: it is not a valid Soroban sequence number
+    /// and would allow callers to inject a sentinel that bypasses freshness
+    /// checks (see issue #1485).
+    #[test]
+    fn ledger_seq_zero_is_rejected() {
+        let (env, client, _) = setup();
+        env.ledger().set_timestamp(0);
+
+        let err = client.try_get_freshness(&0u32, &0u64, &0u32)
+            .expect_err("ledger_seq 0 must be rejected");
+        assert_eq!(
+            err,
+            Ok(crate::errors::QuickLendXError::InvalidLedgerSequence),
+            "expected InvalidLedgerSequence error for ledger_seq = 0"
+        );
     }
 
     // =========================================================================
@@ -110,7 +133,7 @@ mod test_freshness_lag {
         let elapsed = 60u64;
         env.ledger().set_timestamp(indexed + elapsed);
 
-        let result = client.get_freshness(&500u32, &indexed, &0u32);
+        let result = client.get_freshness(&500u32, &indexed, &0u32).unwrap();
         let lag = lag_from_response(&env, &result);
 
         assert_eq!(lag, elapsed as i64, "lag must equal elapsed seconds");
@@ -123,7 +146,7 @@ mod test_freshness_lag {
         let indexed = 1_700_000_000u64;
         env.ledger().set_timestamp(indexed + 1);
 
-        let result = client.get_freshness(&500u32, &indexed, &0u32);
+        let result = client.get_freshness(&500u32, &indexed, &0u32).unwrap();
         let lag = lag_from_response(&env, &result);
 
         assert_eq!(lag, 1);
@@ -141,7 +164,7 @@ mod test_freshness_lag {
         let indexed = 1_700_000_000u64;
         env.ledger().set_timestamp(indexed + bound);
 
-        let result = client.get_freshness(&500u32, &indexed, &0u32);
+        let result = client.get_freshness(&500u32, &indexed, &0u32).unwrap();
         let lag = lag_from_response(&env, &result);
 
         assert_eq!(lag, DEFAULT_MAX_FRESHNESS_DRIFT_SECS);
@@ -159,7 +182,7 @@ mod test_freshness_lag {
         let indexed = 1_700_000_000u64;
         env.ledger().set_timestamp(indexed + bound + 1);
 
-        let result = client.get_freshness(&500u32, &indexed, &0u32);
+        let result = client.get_freshness(&500u32, &indexed, &0u32).unwrap();
         let lag = lag_from_response(&env, &result);
 
         assert_eq!(lag, DEFAULT_MAX_FRESHNESS_DRIFT_SECS + 1);
@@ -179,7 +202,7 @@ mod test_freshness_lag {
 
         for &elapsed in &steps {
             env.ledger().set_timestamp(indexed + elapsed);
-            let result = client.get_freshness(&500u32, &indexed, &0u32);
+            let result = client.get_freshness(&500u32, &indexed, &0u32).unwrap();
             let lag = lag_from_response(&env, &result);
 
             assert!(
@@ -207,7 +230,7 @@ mod test_freshness_lag {
         let skew = 5u64;
         env.ledger().set_timestamp(now);
 
-        let result = client.get_freshness(&500u32, &(now + skew), &0u32);
+        let result = client.get_freshness(&500u32, &(now + skew), &0u32).unwrap();
         let lag = lag_from_response(&env, &result);
 
         assert_eq!(lag, -(skew as i64), "future indexed timestamp gives negative lag");
@@ -234,7 +257,7 @@ mod test_freshness_lag {
         client.pause(&admin);
 
         // get_freshness must still succeed — it is not gated by require_not_paused.
-        let result = client.get_freshness(&500u32, &indexed, &0u32);
+        let result = client.get_freshness(&500u32, &indexed, &0u32).unwrap();
         let lag = lag_from_response(&env, &result);
 
         assert_eq!(
@@ -253,7 +276,7 @@ mod test_freshness_lag {
 
         client.pause(&admin);
 
-        let result = client.get_freshness(&500u32, &now, &0u32);
+        let result = client.get_freshness(&500u32, &now, &0u32).unwrap();
         let lag = lag_from_response(&env, &result);
 
         assert_eq!(lag, 0, "zero lag must be reported correctly while paused");
@@ -274,7 +297,7 @@ mod test_freshness_lag {
         let elapsed_while_paused = 90u64;
         env.ledger().set_timestamp(indexed + 10 + elapsed_while_paused);
 
-        let result = client.get_freshness(&500u32, &indexed, &0u32);
+        let result = client.get_freshness(&500u32, &indexed, &0u32).unwrap();
         let lag = lag_from_response(&env, &result);
 
         assert_eq!(
@@ -297,7 +320,7 @@ mod test_freshness_lag {
         env.ledger().set_timestamp(indexed + 90);
         client.unpause(&admin);
 
-        let result = client.get_freshness(&500u32, &indexed, &0u32);
+        let result = client.get_freshness(&500u32, &indexed, &0u32).unwrap();
         let lag = lag_from_response(&env, &result);
 
         assert_eq!(


### PR DESCRIPTION
## Summary

- Adds `InvalidLedgerSequence = 2205` to `QuickLendXError` for a typed, ABI-stable error.
- Changes `get_freshness` return type to `Result<Map<String, String>, QuickLendXError>` and rejects `indexed_ledger_seq == 0` immediately at the entrypoint boundary.
- Updates all existing freshness tests to unwrap the now-`Result` return value.
- Adds `ledger_seq_zero_is_rejected` negative test that verifies the new guard.

## Threat model

Stellar/Soroban ledger sequences start at 1; a value of 0 is never a valid on-chain ledger sequence. Without this guard, a caller can supply `indexed_ledger_seq = 0`, receive a freshness response that looks structurally valid, and cause downstream consumers (off-chain indexers, dashboards, caches) to store a cursor of `"0_<offset>"`. Those consumers would then treat perpetually-unindexed state as fresh data, silently serving stale results with no error signal. The guard closes this gap with a single cheap integer comparison on a hot diagnostic path — negligible cost.

## Test plan

- [ ] `ledger_seq_zero_is_rejected` fails before the fix, passes after.
- [ ] All pre-existing freshness tests continue to pass (they use non-zero sequences).
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` clean.

Closes #1485

🤖 Generated with [Claude Code](https://claude.com/claude-code)