### PR TITLE
feat: add get_notification_unread_count entrypoint for investors

### DIFF
--- a/quicklendx-contracts/src/lib.rs
+++ b/quicklendx-contracts/src/lib.rs
@@ -3840,6 +3840,11 @@ impl QuickLendXContract {
         notifications::NotificationSystem::get_user_notification_stats(&env, &user)
     }
 
+    /// Return the unread notification count for `investor` in O(n) without loading full bodies.
+    pub fn get_notification_unread_count(env: Env, investor: Address) -> u32 {
+        notifications::NotificationSystem::get_notification_unread_count(&env, &investor)
+    }
+
     pub fn get_financial_metrics(
         env: Env,
         period: analytics::TimePeriod,

--- a/quicklendx-contracts/src/notifications.rs
+++ b/quicklendx-contracts/src/notifications.rs
@@ -513,6 +513,23 @@ impl NotificationSystem {
         stats
     }
 
+    /// Return the number of unread notifications for `user` without loading full notification bodies.
+    ///
+    /// "Unread" is defined as delivery_status != Read. The scan is bounded by
+    /// the user's notification-ID list length.
+    pub fn get_notification_unread_count(env: &Env, user: &Address) -> u32 {
+        let notification_ids = Self::get_user_notifications(env, user);
+        let mut unread: u32 = 0;
+        for id in notification_ids.iter() {
+            if let Some(n) = Self::get_notification(env, &id) {
+                if n.delivery_status != NotificationDeliveryStatus::Read {
+                    unread += 1;
+                }
+            }
+        }
+        unread
+    }
+
     // Storage key helpers
     fn get_notification_key(notification_id: &BytesN<32>) -> DataKey {
         DataKey::Notification(notification_id.clone())


### PR DESCRIPTION
Closes #1744

Adds get_notification_unread_count(user) to NotificationSystem (helpers) and exposes it as get_notification_unread_count(investor) on the main contract. Counts notifications where delivery_status != Read without loading full notification bodies.