### PR TITLE
test: add BackfillService resumability test for last persisted cursor

### DIFF
--- a/backend/src/tests/backfill.service.test.ts
+++ b/backend/src/tests/backfill.service.test.ts
@@ -365,4 +365,38 @@ describe("BackfillService – drift backfill (resumable)", () => {
       .get() as { cnt: number };
     expect(rows.cnt).toBe(1); // exactly one row, no duplicates
   });
+
+  it("resumes from the last persisted progress cursor after a mid-run interruption", async () => {
+    // Process 2 of 5 items — simulates an interrupted run
+    const report = makeDriftReport(5, 11000);
+    await backfillService.triggerDriftBackfill(report, 2);
+
+    const midProgress = mockDb
+      .prepare("SELECT * FROM backfill_progress WHERE run_id = 'drift_11000'")
+      .get() as any;
+    expect(midProgress.last_processed_id).toBe("invoice_2");
+    expect(midProgress.status).toBe("running");
+
+    // Second call must resume from last_processed_id, not restart from invoice_1
+    await backfillService.triggerDriftBackfill(report, 2);
+    const resumedProgress = mockDb
+      .prepare("SELECT * FROM backfill_progress WHERE run_id = 'drift_11000'")
+      .get() as any;
+    expect(resumedProgress.last_processed_id).toBe("invoice_4");
+
+    // Complete remaining
+    await backfillService.triggerDriftBackfill(report, 10);
+    const final = mockDb
+      .prepare("SELECT * FROM backfill_progress WHERE run_id = 'drift_11000'")
+      .get() as any;
+    expect(final.status).toBe("completed");
+    // Audit log should contain exactly 5 distinct invoice IDs
+    const auditRows = mockDb
+      .prepare("SELECT DISTINCT invoice_id FROM backfill_audit WHERE event_type = 'completed'")
+      .all() as any[];
+    const ids = auditRows.map((r) => r.invoice_id);
+    for (let i = 1; i <= 5; i++) {
+      expect(ids).toContain(`invoice_${i}`);
+    }
+  });
 });


### PR DESCRIPTION
Closes #1746

Adds a test that simulates a mid-run interruption after 2/5 items, verifies last_processed_id is persisted, resumes and advances the cursor by exactly the batch size, and confirms all 5 items are in the audit log after full completion.