### PR TITLE
feat: add structured audit-log entries for every admin control action

### DIFF
--- a/backend/src/services/adminControlService.ts
+++ b/backend/src/services/adminControlService.ts
@@ -1,5 +1,13 @@
 import { AdminRole } from "../types/rbac";
 
+export interface AdminAuditEntry {
+  id: string;
+  action: string;
+  actor: AdminRole;
+  timestamp: string;
+  metadata: Record<string, unknown>;
+}
+
 export interface BackfillJob {
   id: string;
   scope: string;
@@ -26,6 +34,31 @@ class AdminControlService {
   private readonly maxJobs = 50;
   private backfillJobs: BackfillJob[] = [];
   private dangerousConfig: DangerousConfig = { ...DEFAULT_DANGEROUS_CONFIG };
+  private auditLog: AdminAuditEntry[] = [];
+  private readonly maxAuditEntries = 1000;
+
+  private recordAudit(
+    action: string,
+    actor: AdminRole,
+    metadata: Record<string, unknown> = {}
+  ): AdminAuditEntry {
+    const entry: AdminAuditEntry = {
+      id: `audit_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`,
+      action,
+      actor,
+      timestamp: new Date().toISOString(),
+      metadata,
+    };
+    this.auditLog.push(entry);
+    if (this.auditLog.length > this.maxAuditEntries) {
+      this.auditLog = this.auditLog.slice(-this.maxAuditEntries);
+    }
+    return entry;
+  }
+
+  public getAuditLog(): AdminAuditEntry[] {
+    return [...this.auditLog].reverse();
+  }
 
   public queueBackfill(requestedBy: AdminRole, scope: string): BackfillJob {
     const job: BackfillJob = {
@@ -41,6 +74,7 @@ class AdminControlService {
       this.backfillJobs = this.backfillJobs.slice(-this.maxJobs);
     }
 
+    this.recordAudit("queue_backfill", requestedBy, { jobId: job.id, scope });
     return job;
   }
 
@@ -59,18 +93,23 @@ class AdminControlService {
       "allowEmergencyConfigChanges" | "maintenanceWindowMinutes"
     >,
   ): DangerousConfig {
+    const prev = { ...this.dangerousConfig };
     this.dangerousConfig = {
       ...config,
       updatedAt: new Date().toISOString(),
       updatedBy: requestedBy,
     };
-
+    this.recordAudit("update_dangerous_config", requestedBy, {
+      previous: prev,
+      updated: config,
+    });
     return this.getDangerousConfig();
   }
 
   public reset(): void {
     this.backfillJobs = [];
     this.dangerousConfig = { ...DEFAULT_DANGEROUS_CONFIG };
+    this.auditLog = [];
   }
 }
 


### PR DESCRIPTION
Closes #1748

Adds AdminAuditEntry interface and recordAudit() private helper to AdminControlService. Emits an entry on queue_backfill and update_dangerous_config. Exposes getAuditLog() for monitoring; capped at 1000 entries.