### PR TITLE
feat: add get_total_locked_escrow entrypoint with bounded scan

### DIFF
--- a/quicklendx-contracts/src/lib.rs
+++ b/quicklendx-contracts/src/lib.rs
@@ -4022,6 +4022,18 @@ impl QuickLendXContract {
         AdminStorage::require_admin(&env, &admin)?;
         EscrowStorage::repair_held_reserve_page(&env, &currency, offset, limit)
     }
+
+    /// Query the total locked escrow value across a caller-supplied bounded list of currencies.
+    ///
+    /// At most `max_currencies` entries from `currencies` are aggregated in one call.
+    /// Use this to stay within Soroban resource limits when many currencies exist.
+    pub fn get_total_locked_escrow(
+        env: Env,
+        currencies: Vec<Address>,
+        max_currencies: u32,
+    ) -> i128 {
+        EscrowStorage::get_total_locked_escrow_bounded(&env, &currencies, max_currencies)
+    }
 }
 
 // =============================================================================

--- a/quicklendx-contracts/src/payments.rs
+++ b/quicklendx-contracts/src/payments.rs
@@ -370,6 +370,36 @@ impl EscrowStorage {
 
         BytesN::from_array(env, &id_bytes)
     }
+
+    /// Return the total locked escrow value for `currency` across all held escrows.
+    ///
+    /// Uses the pre-computed `HeldEscrowReserve` accumulator stored by
+    /// `store_escrow`/`update_escrow`, so this is an O(1) read — no unbounded scan.
+    /// Returns 0 if no escrows have been created for this currency.
+    pub fn get_total_locked_escrow_for_currency(env: &Env, currency: &Address) -> i128 {
+        Self::get_held_reserve(env, currency)
+    }
+
+    /// Return the total locked escrow value summed across up to `max_currencies`
+    /// currencies found in the held-reserve index.
+    ///
+    /// `currencies` is a caller-supplied bounded list of currency addresses to
+    /// aggregate. Callers should obtain the list from `get_whitelisted_currencies`
+    /// or an off-chain index and paginate to stay within resource limits.
+    pub fn get_total_locked_escrow_bounded(
+        env: &Env,
+        currencies: &Vec<Address>,
+        max_currencies: u32,
+    ) -> i128 {
+        let mut total: i128 = 0;
+        let limit = currencies.len().min(max_currencies);
+        for i in 0..limit {
+            let currency = currencies.get_unchecked(i);
+            let held = Self::get_held_reserve(env, &currency);
+            total = total.saturating_add(held);
+        }
+        total
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Closes #1749

Adds get_total_locked_escrow_bounded() to EscrowStorage (O(n) over caller-supplied currency list, bounded by max_currencies) and exposes it as get_total_locked_escrow(currencies, max_currencies) on the main contract. Uses the pre-computed HeldEscrowReserve accumulator — no unbounded iteration.