### PR TITLE
Persist reconciliation drift snapshots with trend query

### DIFF
--- a/backend/src/migrations/v013_reconciliation_snapshots.ts
+++ b/backend/src/migrations/v013_reconciliation_snapshots.ts
@@ -1,0 +1,58 @@
+/**
+ * v013_reconciliation_snapshots
+ *
+ * Author: QuickLendX Engineering
+ * Created: 2026-07-09
+ *
+ * Adds persisted reconciliation drift snapshots so operators can inspect
+ * whether detected drift is a one-off event or a worsening trend.
+ */
+
+import type {
+  MigrationDefinition,
+  MigrationContext,
+} from "../lib/migrations/types";
+
+export default {
+  version: 13,
+  name: "reconciliation_snapshots",
+  authoredAt: "2026-07-09",
+  author: "QuickLendX Engineering",
+
+  up: async (ctx: MigrationContext): Promise<void> => {
+    await ctx.db.exec(`
+      CREATE TABLE IF NOT EXISTS reconciliation_snapshots (
+        id            INTEGER PRIMARY KEY AUTOINCREMENT,
+        run_at        TEXT    NOT NULL,
+        checked_count INTEGER NOT NULL CHECK(checked_count >= 0),
+        drift_count   INTEGER NOT NULL CHECK(drift_count >= 0),
+        severity      TEXT    NOT NULL CHECK(severity IN ('LOW', 'MEDIUM', 'HIGH'))
+      )
+    `);
+
+    await ctx.db.exec(`
+      CREATE INDEX IF NOT EXISTS idx_reconciliation_snapshots_run_at
+        ON reconciliation_snapshots(run_at DESC)
+    `);
+  },
+
+  down: async (ctx: MigrationContext): Promise<void> => {
+    await ctx.db.exec(
+      `DROP INDEX IF EXISTS idx_reconciliation_snapshots_run_at`
+    );
+    await ctx.db.exec(`DROP TABLE IF EXISTS reconciliation_snapshots`);
+  },
+
+  validate: async (ctx: MigrationContext): Promise<string[]> => {
+    const warnings: string[] = [];
+    const existing = await ctx.db.get<{ name: string }>(
+      "SELECT name FROM sqlite_master WHERE type='table' AND name = 'reconciliation_snapshots'"
+    );
+    if (existing) {
+      warnings.push(
+        "Table reconciliation_snapshots already exists - migration is idempotent."
+      );
+    }
+    return warnings;
+  },
+} satisfies MigrationDefinition;

--- a/backend/src/routes/v1/monitoring.ts
+++ b/backend/src/routes/v1/monitoring.ts
@@ -224,6 +224,17 @@ router.get("/reconciliation", async (_req: AuthenticatedRequest, res: Response) 
   }
 });
 
+router.get("/reconciliation/trend", async (req: AuthenticatedRequest, res: Response) => {
+  try {
+    const rawLimit = Number((req.query as Record<string, unknown>).limit);
+    const trend = ReconciliationWorker.getDriftTrend(rawLimit);
+    res.json({ trend });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Failed to read reconciliation trend";
+    res.status(500).json({ error: { message, code: "RECONCILIATION_TREND_READ_ERROR" } });
+  }
+});
+
 /**
  * GET /api/v1/admin/monitoring/latency
  *

--- a/backend/src/services/reconciliationWorker.ts
+++ b/backend/src/services/reconciliationWorker.ts
@@ -2,6 +2,8 @@ import {
   DriftReport,
   DriftItem,
   BackfillResult,
+  ReconciliationSnapshot,
+  Severity,
 } from "../types/reconciliation";
 import { Invoice } from "../types/contract";
 import { rpcClient } from "./rpcClient";
@@ -9,12 +11,15 @@ import { derivedTableStore } from "./replayService";
 import { MockDataProviders } from "./mockDataProviders";
 import { backfillService } from "./backfillService";
 import { withSpan } from "../lib/tracing";
+import { getPreparedStatement } from "../lib/database";
 
 export class ReconciliationWorker {
   private static reports: DriftReport[] = [];
   private static isRunning: boolean = false;
   private static backfillBatchSize: number = 10;
   public static failBackfill: boolean = false;
+  private static readonly defaultTrendLimit: number = 10;
+  private static readonly maxTrendLimit: number = 100;
 
   static async runReconciliation(): Promise<DriftReport> {
     return withSpan("reconciliation.runReconciliation", {}, async () => {
@@ -52,8 +57,7 @@ export class ReconciliationWorker {
               error: rpcErr instanceof Error ? rpcErr.message : String(rpcErr),
             } as any;
 
-            this.reports.push(report);
-            return report;
+            return this.finalizeReport(report);
           }
         }
         const drifts: DriftItem[] = [];
@@ -86,8 +90,7 @@ export class ReconciliationWorker {
           drifts,
         };
 
-        this.reports.push(report);
-        return report;
+        return this.finalizeReport(report);
       } finally {
         this.isRunning = false;
       }
@@ -126,11 +129,75 @@ export class ReconciliationWorker {
     );
   }
 
+  static getDriftTrend(
+    limit = ReconciliationWorker.defaultTrendLimit,
+  ): ReconciliationSnapshot[] {
+    return withSpan(
+      "reconciliation.getDriftTrend",
+      { limit },
+      () => {
+        const safeLimit = this.clampTrendLimit(limit);
+        const rows = getPreparedStatement(
+          `SELECT run_at, checked_count, drift_count, severity
+           FROM reconciliation_snapshots
+           ORDER BY run_at DESC, id DESC
+           LIMIT ?`
+        ).all(safeLimit) as Array<{
+          run_at: string;
+          checked_count: number;
+          drift_count: number;
+          severity: Severity;
+        }>;
+
+        return rows.map((row) => ({
+          runAt: row.run_at,
+          checkedCount: row.checked_count,
+          driftCount: row.drift_count,
+          severity: row.severity,
+        }));
+      },
+    );
+  }
+
   static isReconciliationRunning(): boolean {
     return withSpan(
       "reconciliation.isReconciliationRunning",
       {},
       () => this.isRunning,
     );
+  }
+
+  private static finalizeReport(report: DriftReport): DriftReport {
+    this.reports.push(report);
+    this.persistSnapshot(report);
+    return report;
+  }
+
+  private static persistSnapshot(report: DriftReport): void {
+    getPreparedStatement(
+      `INSERT INTO reconciliation_snapshots
+         (run_at, checked_count, drift_count, severity)
+       VALUES (?, ?, ?, ?)`
+    ).run(
+      new Date(report.timestamp * 1000).toISOString(),
+      Math.max(0, report.totalRecordsChecked),
+      Math.max(0, report.driftCount),
+      this.classifySnapshotSeverity(report.driftCount)
+    );
+  }
+
+  private static classifySnapshotSeverity(driftCount: number): Severity {
+    if (driftCount > 100) return Severity.HIGH;
+    if (driftCount >= 2) return Severity.MEDIUM;
+    return Severity.LOW;
+  }
+
+  private static clampTrendLimit(limit: number): number {
+    if (!Number.isFinite(limit)) {
+      return this.defaultTrendLimit;
+    }
+
+    const integerLimit = Math.floor(limit);
+    return Math.min(Math.max(integerLimit, 1), this.maxTrendLimit);
   }
 }

--- a/backend/src/tests/reconciliation.real.test.ts
+++ b/backend/src/tests/reconciliation.real.test.ts
@@ -2,15 +2,32 @@ import { ReconciliationWorker } from "../services/reconciliationWorker";
 import { derivedTableStore } from "../services/replayService";
 import { rpcClient } from "../services/rpcClient";
 import { InvoiceStatus } from "../types/contract";
+import { closeDatabase, getDatabase } from "../lib/database";
 
 describe("ReconciliationWorker (real)", () => {
   beforeEach(async () => {
+    process.env.DATABASE_PATH = ":memory:";
+    closeDatabase();
+    getDatabase().exec(`
+      CREATE TABLE IF NOT EXISTS reconciliation_snapshots (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        run_at TEXT NOT NULL,
+        checked_count INTEGER NOT NULL CHECK(checked_count >= 0),
+        drift_count INTEGER NOT NULL CHECK(drift_count >= 0),
+        severity TEXT NOT NULL CHECK(severity IN ('LOW', 'MEDIUM', 'HIGH'))
+      );
+    `);
+
     (ReconciliationWorker as any).reports = [];
     (ReconciliationWorker as any).isRunning = false;
     // Reset derived store
     try {
       await derivedTableStore.clearDerivedTables();
     } catch {}
+  });
+
+  afterEach(() => {
+    closeDatabase();
   });
 
   test("detects missing and status mismatch using indexed store + rpc", async () => {

--- a/backend/src/tests/reconciliation.test.ts
+++ b/backend/src/tests/reconciliation.test.ts
@@ -8,6 +8,20 @@ let mockDb: any;
 
 const statementCache = new Map<string, any>();
 
+const createSnapshotTable = () => {
+  mockDb.exec(`
+    CREATE TABLE IF NOT EXISTS reconciliation_snapshots (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      run_at TEXT NOT NULL,
+      checked_count INTEGER NOT NULL CHECK(checked_count >= 0),
+      drift_count INTEGER NOT NULL CHECK(drift_count >= 0),
+      severity TEXT NOT NULL CHECK(severity IN ('LOW', 'MEDIUM', 'HIGH'))
+    );
+    CREATE INDEX IF NOT EXISTS idx_reconciliation_snapshots_run_at
+      ON reconciliation_snapshots(run_at DESC);
+  `);
+};
+
 jest.mock("../lib/database", () => ({
   getDatabase: () => mockDb,
   closeDatabase: jest.fn(),
@@ -54,6 +68,8 @@ describe("ReconciliationWorker", () => {
         invoice_id TEXT
       );
     `);
+    createSnapshotTable();
+
     // Reset internal state if needed (static members are shared)
     (ReconciliationWorker as any).reports = [];
     (ReconciliationWorker as any).isRunning = false;
@@ -144,5 +160,63 @@ describe("ReconciliationWorker", () => {
     
     const reports = ReconciliationWorker.getAllReports();
     expect(reports.length).toBeGreaterThan(0);
+  });
+
+  test("should return an empty drift trend before snapshots exist", () => {
+    expect(ReconciliationWorker.getDriftTrend()).toEqual([]);
+  });
+
+  test("should persist a reconciliation snapshot per run", async () => {
+    const report = await ReconciliationWorker.runReconciliation();
+
+    const trend = ReconciliationWorker.getDriftTrend(10);
+
+    expect(trend).toHaveLength(1);
+    expect(trend[0]).toEqual({
+      runAt: new Date(report.timestamp * 1000).toISOString(),
+      checkedCount: 3,
+      driftCount: 2,
+      severity: "MEDIUM",
+    });
+  });
+
+  test("should order trend by most recent run and clamp limits", () => {
+    const insert = mockDb.prepare(
+      `INSERT INTO reconciliation_snapshots
+         (run_at, checked_count, drift_count, severity)
+       VALUES (?, ?, ?, ?)`
+    );
+    insert.run("2026-07-09T00:00:00.000Z", 10, 0, "LOW");
+    insert.run("2026-07-09T00:01:00.000Z", 10, 2, "MEDIUM");
+    insert.run("2026-07-09T00:02:00.000Z", 10, 101, "HIGH");
+
+    expect(ReconciliationWorker.getDriftTrend(0)).toEqual([
+      {
+        runAt: "2026-07-09T00:02:00.000Z",
+        checkedCount: 10,
+        driftCount: 101,
+        severity: "HIGH",
+      },
+    ]);
+
+    expect(ReconciliationWorker.getDriftTrend(999)).toHaveLength(3);
+  });
+
+  test("should classify snapshot severity at drift-count boundaries", async () => {
+    (rpcClient.call as jest.Mock).mockResolvedValueOnce([
+      { id: "invoice_2", status: "Funded" },
+    ]);
+
+    await ReconciliationWorker.runReconciliation();
+    expect(ReconciliationWorker.getDriftTrend(1)[0].severity).toBe("LOW");
+
+    const highDriftInvoices = Array.from({ length: 101 }, (_, index) => ({
+      id: `missing_invoice_${index}`,
+      status: "Funded",
+    }));
+    (rpcClient.call as jest.Mock).mockResolvedValueOnce(highDriftInvoices);
+
+    await ReconciliationWorker.runReconciliation();
+    expect(ReconciliationWorker.getDriftTrend(1)[0].severity).toBe("HIGH");
   });
 });

--- a/backend/src/types/reconciliation.ts
+++ b/backend/src/types/reconciliation.ts
@@ -5,6 +5,13 @@ export interface DriftReport {
   drifts: DriftItem[];
 }
 
+export interface ReconciliationSnapshot {
+  runAt: string;
+  checkedCount: number;
+  driftCount: number;
+  severity: Severity;
+}
+
 export interface DriftItem {
   id: string;
   type: "Invoice" | "Bid" | "Settlement";


### PR DESCRIPTION
Closes #1713.

## Summary

- add `v013_reconciliation_snapshots` with durable `run_at`, `checked_count`, `drift_count`, and `severity` fields plus a `run_at` index
- persist a snapshot at the end of each `ReconciliationWorker` run, including RPC-error reports
- add `ReconciliationWorker.getDriftTrend(limit)` with limit clamping and most-recent-first ordering
- expose the trend via `GET /api/v1/admin/monitoring/reconciliation/trend?limit=...`
- add focused Jest coverage for empty trends, persistence, ordering, limit clamping, and severity boundaries

## Validation

- `node .\node_modules\jest\bin\jest.js src\tests\reconciliation.test.ts --runInBand --forceExit`
- direct v013 SQLite migration smoke: `up` creates the table/index, accepts a snapshot row, and `down` drops the table
- `git diff --check`

## Notes

- I attempted the suggested migration dry-run, but the current migration runner fails before this migration with `db.get is not a function` because the runner adapter calls `db.get()` on a better-sqlite3 database instance. I left that shared runner behavior unchanged to keep this PR scoped to the reconciliation history feature.
- Full `tsc --noEmit --pretty false` is currently blocked by an existing syntax error in `src/index.ts`; the focused Jest coverage above passes.
