### PR TITLE
feat(search): add paged invoice search

### DIFF
--- a/quicklendx-contracts/docs/invoice-search-ranking.md
+++ b/quicklendx-contracts/docs/invoice-search-ranking.md
@@ -41,4 +41,5 @@ graph TD
 
 - **Case-Insensitive UI**: The contract automatically sanitizes queries and converts them to lowercase. UI elements do not need to convert queries before invoking the contract search.
 - **ID Formatting**: If a user is searching by invoice ID, supply the full 64-character hex string of the `BytesN<32>` ID. This triggers the `ExactId` tier and guarantees that specific invoice surfaces first.
-- **Result Limits**: The result vector is capped at 50 elements by the contract to ensure predictable WASM memory usage and low gas consumption.
+- **Result Limits**: `search_invoices` returns the first page capped at 50 elements by the contract to ensure predictable WASM memory usage and low gas consumption.
+- **Paged Search**: Use `search_invoices_paged(query, offset, limit)` for deterministic pagination. `limit` is clamped to 50, `limit = 0` returns an empty page, offsets beyond the current result set return an empty page, and offsets above the protocol sanity cap are rejected.

--- a/quicklendx-contracts/scripts/check-wasm-size.sh
+++ b/quicklendx-contracts/scripts/check-wasm-size.sh
@@ -53,7 +53,7 @@ if [[ "$CHECK_ONLY" == false ]]; then
     [[ -f "$HOME/.cargo/env" ]] && source "$HOME/.cargo/env"
     rustup target add wasm32v1-none 2>/dev/null || true
     cargo build --target wasm32v1-none --release --lib
-    WASM_PATH="target/wasm32v1-none/release/$WASM_NAME"
+    WASM_PATH="$(find target/wasm32v1-none/release -maxdepth 1 -type f -name '*.wasm' | sort | head -n 1)"
   fi
 else
   # --check-only: probe both target directories for an existing artifact

--- a/quicklendx-contracts/scripts/check-wasm-size.sh
+++ b/quicklendx-contracts/scripts/check-wasm-size.sh
@@ -49,11 +49,11 @@ if [[ "$CHECK_ONLY" == false ]]; then
     stellar contract build --verbose
     WASM_PATH="target/wasm32v1-none/release/$WASM_NAME"
   else
-    echo "Stellar CLI not found; using cargo wasm32-unknown-unknown."
+    echo "Stellar CLI not found; using cargo wasm32v1-none."
     [[ -f "$HOME/.cargo/env" ]] && source "$HOME/.cargo/env"
-    rustup target add wasm32-unknown-unknown 2>/dev/null || true
-    cargo build --target wasm32-unknown-unknown --release --lib
-    WASM_PATH="target/wasm32-unknown-unknown/release/$WASM_NAME"
+    rustup target add wasm32v1-none 2>/dev/null || true
+    cargo build --target wasm32v1-none --release --lib
+    WASM_PATH="target/wasm32v1-none/release/$WASM_NAME"
   fi
 else
   # --check-only: probe both target directories for an existing artifact

--- a/quicklendx-contracts/scripts/check-wasm-size.sh
+++ b/quicklendx-contracts/scripts/check-wasm-size.sh
@@ -53,7 +53,11 @@ if [[ "$CHECK_ONLY" == false ]]; then
     [[ -f "$HOME/.cargo/env" ]] && source "$HOME/.cargo/env"
     rustup target add wasm32v1-none 2>/dev/null || true
     cargo build --target wasm32v1-none --release --lib
-    WASM_PATH="$(find target/wasm32v1-none/release -maxdepth 1 -type f -name '*.wasm' | sort | head -n 1)"
+    WASM_PATH="$(
+      for dir in target/wasm32v1-none/release ../target/wasm32v1-none/release; do
+        [[ -d "$dir" ]] && find "$dir" -maxdepth 1 -type f -name '*.wasm'
+      done | sort | head -n 1
+    )"
   fi
 else
   # --check-only: probe both target directories for an existing artifact

--- a/quicklendx-contracts/src/errors.rs
+++ b/quicklendx-contracts/src/errors.rs
@@ -258,6 +258,7 @@ impl From<QuickLendXError> for Symbol {
             QuickLendXError::RotationNotFound => symbol_short!("ROT_NF"),
             QuickLendXError::RotationExpired => symbol_short!("ROT_EXP"),
             QuickLendXError::RotationTimelockNotElapsed => symbol_short!("ROT_TLK"),
+            QuickLendXError::NoPendingTreasuryRotation => symbol_short!("NO_TRSROT"),
             // Dispute
             QuickLendXError::DisputeNotFound => symbol_short!("DSP_NF"),
             QuickLendXError::DisputeAlreadyExists => symbol_short!("DSP_EX"),
@@ -285,7 +286,8 @@ impl From<QuickLendXError> for Symbol {
             QuickLendXError::MaintenanceModeActive => symbol_short!("MAINT"),
             QuickLendXError::ArithmeticOverflow => symbol_short!("ARITH_OF"),
             QuickLendXError::DuplicateDefaultTransition => symbol_short!("DEF_DUP"),
-            QuickLendXError::BackupVersionUnsupported => symbol_short!("BKP_VER")
+            QuickLendXError::BackupVersionUnsupported => symbol_short!("BKP_VER"),
+            QuickLendXError::InvalidLedgerSequence => symbol_short!("INV_LEDGR"),
         }
     }
 }

--- a/quicklendx-contracts/src/events.rs
+++ b/quicklendx-contracts/src/events.rs
@@ -1525,7 +1525,7 @@ pub fn emit_admin_initialized(env: &Env, admin: &Address) {
 
 pub fn treasury_rotation_cancelled(env: &Env, admin: &Address) {
     env.events().publish(
-        (symbol_short!("tr_rot_cncl"), admin.clone()),
+        (symbol_short!("tr_cnl"), admin.clone()),
         (),
     );
 }

--- a/quicklendx-contracts/src/idempotency.rs
+++ b/quicklendx-contracts/src/idempotency.rs
@@ -1,4 +1,6 @@
-use crate::storage::{bump_persistent, extend_persistent_ttl};
+use soroban_sdk::{symbol_short, Address, Bytes, BytesN, Env, Symbol};
+
+use crate::storage::extend_persistent_ttl;
 
 /// Storage key for the idempotency map.
 pub const IDEMPOTENCY_MAP_KEY: Symbol = symbol_short!("idem_map");

--- a/quicklendx-contracts/src/invoice_search.rs
+++ b/quicklendx-contracts/src/invoice_search.rs
@@ -6,6 +6,8 @@ use crate::types::{Invoice, InvoiceStatus, SearchRank, SearchResult};
 
 /// Maximum number of search results to return
 pub const MAX_SEARCH_RESULTS: u32 = 50;
+/// Maximum allowed page offset for ranked invoice searches.
+pub const MAX_SEARCH_OFFSET: u32 = 10_000;
 
 /// Invoice search functionality with safe query semantics and relevance ranking
 pub struct InvoiceSearch;
@@ -46,14 +48,24 @@ impl InvoiceSearch {
         Ok(String::from_str(query.env(), trimmed_str))
     }
 
-    /// Search invoices with relevance ranking
+    /// Search invoices with relevance ranking.
+    ///
+    /// Compatibility wrapper for the first result page. New callers that need
+    /// deterministic pagination should use `search_invoices_paged`.
+    pub fn search_invoices(env: &Env, query: String) -> Result<Vec<SearchResult>, QuickLendXError> {
+        Self::search_invoices_paged(env, query, 0, MAX_SEARCH_RESULTS)
+    }
+
+    /// Search invoices with relevance ranking, offset pagination, and a clamped page size.
     ///
     /// # Arguments
     /// * `env` - Soroban environment
     /// * `query` - Search query string (will be sanitized)
+    /// * `offset` - Number of ranked matches to skip before returning a page
+    /// * `limit` - Requested page size, clamped to MAX_SEARCH_RESULTS
     ///
     /// # Returns
-    /// * `Vec<SearchResult>` - Ranked search results, limited to MAX_SEARCH_RESULTS
+    /// * `Vec<SearchResult>` - Ranked search results for the requested page
     ///
     /// # Ranking Logic
     /// 1. Exact matches on invoice_id (highest priority)
@@ -62,10 +74,24 @@ impl InvoiceSearch {
     ///
     /// # Security Notes
     /// - Input sanitization prevents injection attacks
-    /// - Memory-safe: bounded result set prevents DoS
+    /// - Memory-safe: returned pages are bounded by MAX_SEARCH_RESULTS
+    /// - Rejects offsets above MAX_SEARCH_OFFSET to avoid absurd page walks
     /// - Case-insensitive search
-    pub fn search_invoices(env: &Env, query: String) -> Result<Vec<SearchResult>, QuickLendXError> {
+    pub fn search_invoices_paged(
+        env: &Env,
+        query: String,
+        offset: u32,
+        limit: u32,
+    ) -> Result<Vec<SearchResult>, QuickLendXError> {
+        if offset > MAX_SEARCH_OFFSET {
+            return Err(QuickLendXError::InvalidAmount);
+        }
+
         let sanitized_query = Self::sanitize_query(&query)?;
+        let page_limit = limit.min(MAX_SEARCH_RESULTS);
+        if page_limit == 0 {
+            return Ok(Vec::new(env));
+        }
 
         // Get all invoices (in a real implementation, this might be paginated or indexed)
         // For now, we'll search through all invoices
@@ -89,16 +115,30 @@ impl InvoiceSearch {
         // Sort by rank (descending) then by created_at (descending)
         Self::sort_results(&mut results);
 
-        // Limit results
-        let mut limited_results = Vec::new(env);
-        let max_results = MAX_SEARCH_RESULTS.min(results.len());
-        for i in 0..max_results {
+        Ok(Self::page_results(env, &results, offset, page_limit))
+    }
+
+    /// Return a bounded result page after ranking has been applied.
+    fn page_results(
+        env: &Env,
+        results: &Vec<SearchResult>,
+        offset: u32,
+        limit: u32,
+    ) -> Vec<SearchResult> {
+        let mut page = Vec::new(env);
+        let len = results.len();
+        if offset >= len {
+            return page;
+        }
+
+        let end = offset.saturating_add(limit).min(len);
+        for i in offset..end {
             if let Some(result) = results.get(i) {
-                limited_results.push_back(result);
+                page.push_back(result);
             }
         }
 
-        Ok(limited_results)
+        page
     }
 
     /// Calculate search relevance rank for an invoice
@@ -260,12 +300,18 @@ mod tests {
     use soroban_sdk::testutils::Address as _;
     use soroban_sdk::{Address, Env, String, Vec};
 
+    use crate::storage::InvoiceStorage;
     use crate::types::{Invoice, InvoiceCategory, InvoiceStatus, SearchRank};
 
     fn setup_test_env() -> Env {
         let env = Env::default();
         env.mock_all_auths();
         env
+    }
+
+    fn with_contract<T>(env: &Env, f: impl FnOnce() -> T) -> T {
+        let contract_id = env.register(crate::QuickLendXContract, ());
+        env.as_contract(&contract_id, f)
     }
 
     fn create_test_invoice(
@@ -387,5 +433,99 @@ mod tests {
                 "1234abcd00000000000000000000000000000000000000000000000000000000"
             )
         );
+    }
+
+    #[test]
+    fn test_search_invoices_paged_clamps_limit_and_keeps_order() {
+        let env = setup_test_env();
+        let business = Address::generate(&env);
+
+        let results = with_contract(&env, || {
+            for i in 0..60 {
+                let mut invoice = create_test_invoice(&env, &business, "service", None);
+                invoice.created_at = 1_000 + i;
+                InvoiceStorage::store_invoice(&env, &invoice);
+            }
+
+            InvoiceSearch::search_invoices_paged(
+                &env,
+                String::from_str(&env, "service"),
+                0,
+                MAX_SEARCH_RESULTS + 25,
+            )
+            .unwrap()
+        });
+
+        assert_eq!(results.len(), MAX_SEARCH_RESULTS);
+        assert_eq!(results.get(0).unwrap().created_at, 1_059);
+        assert_eq!(results.get(49).unwrap().created_at, 1_010);
+    }
+
+    #[test]
+    fn test_search_invoices_paged_offset_and_limit() {
+        let env = setup_test_env();
+        let business = Address::generate(&env);
+
+        let page = with_contract(&env, || {
+            for i in 0..5 {
+                let mut invoice = create_test_invoice(&env, &business, "service", None);
+                invoice.created_at = 10 + i;
+                InvoiceStorage::store_invoice(&env, &invoice);
+            }
+
+            InvoiceSearch::search_invoices_paged(&env, String::from_str(&env, "service"), 2, 2)
+                .unwrap()
+        });
+
+        assert_eq!(page.len(), 2);
+        assert_eq!(page.get(0).unwrap().created_at, 12);
+        assert_eq!(page.get(1).unwrap().created_at, 11);
+    }
+
+    #[test]
+    fn test_search_invoices_paged_limit_zero_returns_empty_page() {
+        let env = setup_test_env();
+        let business = Address::generate(&env);
+
+        let page = with_contract(&env, || {
+            let invoice = create_test_invoice(&env, &business, "service", None);
+            InvoiceStorage::store_invoice(&env, &invoice);
+
+            InvoiceSearch::search_invoices_paged(&env, String::from_str(&env, "service"), 0, 0)
+                .unwrap()
+        });
+
+        assert!(page.is_empty());
+    }
+
+    #[test]
+    fn test_search_invoices_paged_offset_past_end_returns_empty_page() {
+        let env = setup_test_env();
+        let business = Address::generate(&env);
+
+        let page = with_contract(&env, || {
+            let invoice = create_test_invoice(&env, &business, "service", None);
+            InvoiceStorage::store_invoice(&env, &invoice);
+
+            InvoiceSearch::search_invoices_paged(&env, String::from_str(&env, "service"), 10, 5)
+                .unwrap()
+        });
+
+        assert!(page.is_empty());
+    }
+
+    #[test]
+    fn test_search_invoices_paged_absurd_offset_rejected() {
+        let env = setup_test_env();
+
+        let err = InvoiceSearch::search_invoices_paged(
+            &env,
+            String::from_str(&env, "service"),
+            MAX_SEARCH_OFFSET + 1,
+            5,
+        )
+        .unwrap_err();
+
+        assert_eq!(err, QuickLendXError::InvalidAmount);
     }
 }

--- a/quicklendx-contracts/src/lib.rs
+++ b/quicklendx-contracts/src/lib.rs
@@ -1307,6 +1307,19 @@ impl QuickLendXContract {
         InvoiceSearch::search_invoices(&env, query)
     }
 
+    /// Search invoices with relevance ranking and deterministic offset pagination
+    ///
+    /// `limit` is clamped to the protocol maximum page size, `limit = 0`
+    /// returns an empty page, and absurdly large offsets are rejected.
+    pub fn search_invoices_paged(
+        env: Env,
+        query: String,
+        offset: u32,
+        limit: u32,
+    ) -> Result<Vec<SearchResult>, QuickLendXError> {
+        InvoiceSearch::search_invoices_paged(&env, query, offset, limit)
+    }
+
     /// Get all invoices by status
     pub fn get_invoices_by_status(env: Env, status: InvoiceStatus) -> Vec<BytesN<32>> {
         InvoiceStorage::get_invoices_by_status(&env, status)

--- a/quicklendx-contracts/src/profits.rs
+++ b/quicklendx-contracts/src/profits.rs
@@ -547,36 +547,6 @@ pub fn compute_yield(amount: i128, rate_bps: i128, duration_days: i128) -> i128 
         / denominator
 }
 
-/// Compute the simple interest yield on a principal amount.
-///
-/// # Formula
-/// ```text
-/// yield = amount * rate_bps * duration_days / (BPS_DENOMINATOR * 365)
-/// ```
-pub fn compute_yield(amount: i128, rate_bps: u32, duration_days: u32) -> i128 {
-    let safe_amount = amount.max(0);
-    let safe_rate = rate_bps as i128;
-    let safe_days = duration_days as i128;
-
-    let numerator = safe_amount
-        .saturating_mul(safe_rate)
-        .saturating_mul(safe_days);
-    let denominator = BPS_DENOMINATOR.saturating_mul(365);
-    numerator / denominator
-}
-///
-/// All arithmetic uses `saturating_mul` / integer division to stay within
-/// `i128` bounds without panicking and to preserve `#![no_std]` discipline.
-///
-/// # Arguments
-/// * `amount`        — Principal (must be >= 0; negative input returns 0)
-/// * `rate_bps`      — Annual rate in basis points, e.g. 500 = 5 %
-/// * `duration_days` — Holding period in days
-///
-/// # Monotonicity invariant
-/// For fixed `rate_bps` and `duration_days`, `yield` is non-decreasing in `amount`.
-/// For fixed `amount` and `duration_days`, `yield` is non-decreasing in `rate_bps`.
-/// For fixed `amount` and `rate_bps`, `yield` is non-decreasing in `duration_days`.
 /// Compute the expected return on a principal amount.
 ///
 /// # Returns
@@ -584,35 +554,6 @@ pub fn compute_yield(amount: i128, rate_bps: u32, duration_days: u32) -> i128 {
 pub fn compute_expected_return(amount: i128, rate_bps: u32, duration_days: u32) -> i128 {
     let yield_amount = compute_yield(amount, rate_bps.into(), duration_days.into());
     amount.max(0).saturating_add(yield_amount)
-}
-
-/// Compute the simple interest yield on a principal amount.
-///
-/// # Formula
-/// ```text
-/// yield = amount * rate_bps * duration_days / (BPS_DENOMINATOR * 365)
-/// ```
-///
-/// All arithmetic uses `saturating_mul` / integer division to stay within
-/// `i128` bounds without panicking and to preserve `#![no_std]` discipline.
-///
-/// # Arguments
-/// * `amount`        — Principal (must be >= 0; negative input returns 0)
-/// * `rate_bps`      — Annual rate in basis points, e.g. 500 = 5 %
-/// * `duration_days` — Holding period in days
-///
-/// # Returns
-/// Simple interest yield (non-negative).
-pub fn compute_yield(amount: i128, rate_bps: i128, duration_days: i128) -> i128 {
-    if amount <= 0 || rate_bps <= 0 || duration_days <= 0 {
-        return 0;
-    }
-    // amount * rate_bps * duration_days / (10_000 * 365)
-    let numerator = amount
-        .saturating_mul(rate_bps)
-        .saturating_mul(duration_days);
-    let denominator: i128 = BPS_DENOMINATOR.saturating_mul(365);
-    numerator / denominator
 }
 
 /// A single ledger-delta entry for time-weighted average calculations.

--- a/quicklendx-contracts/src/storage.rs
+++ b/quicklendx-contracts/src/storage.rs
@@ -32,7 +32,7 @@ where
 /// Storage key for the pending treasury address during a rotation.
 pub const PENDING_TREASURY_KEY: Symbol = symbol_short!("pnd_trs");
 /// Storage key for the pending treasury execution timestamp.
-pub const PENDING_TREASURY_TS_KEY: Symbol = symbol_short!("pnd_trs_ts");
+pub const PENDING_TREASURY_TS_KEY: Symbol = symbol_short!("pnd_trts");
 
 /// Counter and configuration keys for the contract.
 ///

--- a/quicklendx-contracts/src/storage.rs
+++ b/quicklendx-contracts/src/storage.rs
@@ -33,7 +33,6 @@ where
 pub const PENDING_TREASURY_KEY: Symbol = symbol_short!("pnd_trs");
 /// Storage key for the pending treasury execution timestamp.
 pub const PENDING_TREASURY_TS_KEY: Symbol = symbol_short!("pnd_trs_ts");
-}
 
 /// Counter and configuration keys for the contract.
 ///

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,4 @@
 [toolchain]
-# Use a platform-agnostic channel so CI runners pick the correct host-specific
-# toolchain (e.g., x86_64-unknown-linux-gnu on Ubuntu, x86_64-pc-windows-msvc on Windows).
-channel = "stable"
+# Pin below Rust 1.97 until the current ethnum dependency is compatible with it.
+channel = "1.96.1"
 components = ["rustfmt"]


### PR DESCRIPTION
Closes #1726

## Summary
- add `search_invoices_paged(query, offset, limit)` with clamped page size and an offset sanity cap
- keep `search_invoices` as the compatibility wrapper for the first page
- document paged search behavior for integrators
- add focused tests for limit clamping, offset paging, `limit = 0`, offset past end, and absurd offset rejection
- pin Rust to 1.96.1 because CI's Rust 1.97.0 update currently fails while compiling the existing `ethnum v1.5.0` dependency before reaching project code
- unblock existing contract compile errors surfaced by CI: stray storage delimiter, duplicate `compute_yield`, missing idempotency imports, too-long storage symbol, and missing error-symbol mappings

## Validation
- `git diff --check`
- GitHub Actions: rerun after latest compile fixes is pending
- Not run locally: `cargo fmt -p quicklendx-contracts` and `cargo test -p quicklendx-contracts search_invoices_paged -- --nocapture` because Cargo is not installed in this Windows environment (`cargo` is not recognized in PATH).

/claim #1726