### PR TITLE
test: cover overdue scan limit boundaries

### DIFF
--- a/quicklendx-contracts/src/defaults.rs
+++ b/quicklendx-contracts/src/defaults.rs
@@ -212,6 +212,32 @@ fn resolve_scan_limit(limit: Option<u32>) -> u32 {
         .clamp(1, MAX_OVERDUE_SCAN_BATCH_LIMIT)
 }
 
+#[cfg(test)]
+mod scan_limit_tests {
+    use super::{resolve_scan_limit, MAX_OVERDUE_SCAN_BATCH_LIMIT};
+
+    #[test]
+    fn zero_scan_limit_is_clamped_to_one() {
+        assert_eq!(resolve_scan_limit(Some(0)), 1);
+    }
+
+    #[test]
+    fn maximum_scan_limit_is_accepted() {
+        assert_eq!(
+            resolve_scan_limit(Some(MAX_OVERDUE_SCAN_BATCH_LIMIT)),
+            MAX_OVERDUE_SCAN_BATCH_LIMIT
+        );
+    }
+
+    #[test]
+    fn scan_limit_above_maximum_is_clamped() {
+        assert_eq!(
+            resolve_scan_limit(Some(MAX_OVERDUE_SCAN_BATCH_LIMIT + 1)),
+            MAX_OVERDUE_SCAN_BATCH_LIMIT
+        );
+    }
+}
+
 /// @notice Scans funded invoices in a deterministic bounded window for overdue/default handling.
 /// @dev Uses a rotating cursor stored in instance storage so repeated calls eventually inspect
 ///      the full funded set without any single call walking every invoice. The function reads a


### PR DESCRIPTION
## Summary

- cover a zero scan limit being clamped to the minimum batch size
- verify the configured maximum remains accepted
- cover values above the maximum being clamped to the hard cap

The tests sit next to `resolve_scan_limit` because the guard is pure module-level logic and does not require a contract fixture.

## Verification

- `rustfmt --check quicklendx-contracts/src/defaults.rs`
- `git diff --check`

The repository CI currently stops in the unchanged `ethnum 1.5.0` dependency with `E0512` under the stable Rust toolchain, before compiling this crate. The current `main` branch also contains an unmatched closing brace in `quicklendx-contracts/src/storage.rs`; #1966 removes that parser error but is failing on the same dependency step. This PR deliberately leaves both unrelated fixes out of scope.

Closes #1852
