### PR TITLE
test: add replay guard tests

### DIFF
--- a/quicklendx-contracts/src/test/test_invoice_status.rs
+++ b/quicklendx-contracts/src/test/test_invoice_status.rs
@@ -1,0 +1,125 @@
+// quicklendx-contracts/src/test/test_invoice_status.rs
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use soroban_sdk::{Env, Address, BytesN, String, Vec};
+    use crate::invoice::Invoice;
+    use crate::types::{InvoiceStatus, InvoiceCategory};
+    use crate::errors::QuickLendXError;
+
+    fn dummy_env() -> Env {
+        Env::default()
+    }
+
+    fn dummy_address() -> Address {
+        // Zero address for simplicity
+        Address::from_str(&Env::default(), "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF").unwrap()
+    }
+
+    fn create_invoice(env: &Env, status: InvoiceStatus) -> Invoice {
+        // Minimal fields for new invoice
+        let business = dummy_address();
+        let amount: i128 = 1_000_000; // 1 unit
+        let currency = dummy_address();
+        let due_date = env.ledger().timestamp() + 86400; // 1 day later
+        let description = String::from_str(env, "test invoice");
+        let category = InvoiceCategory::Services;
+        let tags = Vec::new(env);
+        let mut inv = Invoice::new(
+            env,
+            business,
+            amount,
+            currency,
+            due_date,
+            description,
+            category,
+            tags,
+        ).expect("invoice creation should succeed");
+        // Manually set status to the desired variant for testing
+        inv.status = status;
+        inv
+    }
+
+    #[test]
+    fn test_invoice_status_is_terminal() {
+        assert!(!InvoiceStatus::Pending.is_terminal());
+        assert!(!InvoiceStatus::Verified.is_terminal());
+        assert!(!InvoiceStatus::Funded.is_terminal());
+        assert!(InvoiceStatus::Paid.is_terminal());
+        assert!(InvoiceStatus::Defaulted.is_terminal());
+        assert!(InvoiceStatus::Cancelled.is_terminal());
+        assert!(InvoiceStatus::Refunded.is_terminal());
+    }
+
+    #[test]
+    fn test_is_available_for_funding_logic() {
+        let env = dummy_env();
+        // Pending should not be available for funding
+        let pending = create_invoice(&env, InvoiceStatus::Pending);
+        assert!(!pending.is_available_for_funding());
+
+        // Verified and no funding yet should be available
+        let verified = create_invoice(&env, InvoiceStatus::Verified);
+        assert!(verified.is_available_for_funding());
+
+        // Funded should not be available
+        let mut funded = create_invoice(&env, InvoiceStatus::Funded);
+        funded.funded_amount = 500_000;
+        funded.funded_at = Some(env.ledger().timestamp());
+        funded.investor = Some(dummy_address());
+        assert!(!funded.is_available_for_funding());
+    }
+
+    #[test]
+    fn test_mark_as_funded_transitions_status() {
+        let env = dummy_env();
+        let mut inv = create_invoice(&env, InvoiceStatus::Verified);
+        let investor = dummy_address();
+        let amount: i128 = 500_000;
+        let timestamp = env.ledger().timestamp();
+        inv.mark_as_funded(&env, investor.clone(), amount, timestamp);
+        assert_eq!(inv.status, InvoiceStatus::Funded);
+        assert_eq!(inv.funded_amount, amount);
+        assert_eq!(inv.funded_at, Some(timestamp));
+        assert_eq!(inv.investor, Some(investor));
+    }
+
+    #[test]
+    fn test_mark_as_paid_transitions_status() {
+        let env = dummy_env();
+        let mut inv = create_invoice(&env, InvoiceStatus::Funded);
+        let timestamp = env.ledger().timestamp();
+        inv.mark_as_paid(&env, dummy_address(), timestamp);
+        assert_eq!(inv.status, InvoiceStatus::Paid);
+        assert_eq!(inv.total_paid, inv.amount);
+        assert_eq!(inv.settled_at, Some(timestamp));
+    }
+
+    #[test]
+    fn test_mark_as_defaulted_transitions_status() {
+        let env = dummy_env();
+        let mut inv = create_invoice(&env, InvoiceStatus::Funded);
+        inv.mark_as_defaulted(&mut inv);
+        assert_eq!(inv.status, InvoiceStatus::Defaulted);
+    }
+
+    #[test]
+    fn test_mark_as_refunded_resets_funding() {
+        let env = dummy_env();
+        let mut inv = create_invoice(&env, InvoiceStatus::Funded);
+        // Simulate funded state first
+        inv.funded_amount = 500_000;
+        inv.funded_at = Some(env.ledger().timestamp());
+        inv.investor = Some(dummy_address());
+        inv.total_paid = 300_000;
+        // Now refund
+        inv.mark_as_refunded(&env, dummy_address());
+        assert_eq!(inv.status, InvoiceStatus::Refunded);
+        assert_eq!(inv.funded_amount, 0);
+        assert_eq!(inv.funded_at, None);
+        assert_eq!(inv.investor, None);
+        assert_eq!(inv.total_paid, 0);
+        assert!(inv.payment_history.is_empty());
+    }
+}

--- a/quicklendx-contracts/src/test_replay_guard.rs
+++ b/quicklendx-contracts/src/test_replay_guard.rs
@@ -1,0 +1,107 @@
+// Tests for replay guard (nonce handling) in settlement.
+
+use super::*;
+use soroban_sdk::{Address, BytesN, Env, String, Vec};
+
+/// Helper to initialize a token for testing.
+fn init_currency_for_test(
+    env: &Env,
+    contract_id: &Address,
+    business: &Address,
+    investor: &Address,
+) -> Address {
+    let token_admin = Address::generate(env);
+    let currency = env.register_stellar_asset_contract_v2(token_admin.clone()).address();
+    let token_client = token::Client::new(env, &currency);
+    let sac_client = token::StellarAssetClient::new(env, &currency);
+    let initial_balance = 10_000i128;
+    sac_client.mint(business, &initial_balance);
+    sac_client.mint(investor, &initial_balance);
+    sac_client.mint(contract_id, &1i128);
+    let expiration = env.ledger().sequence() + 1_000;
+    token_client.approve(business, contract_id, &initial_balance, &expiration);
+    token_client.approve(investor, contract_id, &initial_balance, &expiration);
+    currency
+}
+
+/// Helper to set up a funded invoice.
+fn setup_funded_invoice(
+    env: &Env,
+    client: &QuickLendXContractClient,
+    business: &Address,
+    investor: &Address,
+    currency: &Address,
+    invoice_amount: i128,
+    investment_amount: i128,
+) -> BytesN<32> {
+    let admin = Address::generate(env);
+    client.set_admin(&admin);
+    client.submit_kyc_application(business, &String::from_str(env, "KYC data"));
+    client.verify_business(&admin, business);
+    let due_date = env.ledger().timestamp() + 86_400;
+    let invoice_id = client.store_invoice(
+        business,
+        &invoice_amount,
+        currency,
+        &due_date,
+        &String::from_str(env, "Test invoice"),
+        &InvoiceCategory::Services,
+        &Vec::new(env),
+    );
+    client.verify_invoice(&invoice_id);
+    // Investor KYC and investment.
+    client.submit_investor_kyc(investor, &String::from_str(env, "Investor KYC"));
+    client.verify_investor(investor, &10_000i128);
+    let bid_id = client.place_bid(investor, &invoice_id, &investment_amount, &invoice_amount);
+    client.accept_bid(&invoice_id, &bid_id);
+    invoice_id
+}
+
+#[test]
+fn test_replay_guard_fresh_and_duplicate_nonce() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(QuickLendXContract, ());
+    let client = QuickLendXContractClient::new(&env, &contract_id);
+    let business = Address::generate(&env);
+    let investor = Address::generate(&env);
+    let currency = init_currency_for_test(&env, &contract_id, &business, &investor);
+    let invoice_id = setup_funded_invoice(&env, &client, &business, &investor, &currency, 1_000, 900);
+
+    // First partial payment with a fresh nonce.
+    let nonce = String::from_str(&env, "nonce-1");
+    client.process_partial_payment(&invoice_id, 400, &nonce);
+    let count_after_first = get_payment_count(&env, &invoice_id).unwrap();
+    assert_eq!(count_after_first, 1);
+
+    // Duplicate nonce should not create a new record.
+    client.process_partial_payment(&invoice_id, 400, &nonce);
+    let count_after_dup = get_payment_count(&env, &invoice_id).unwrap();
+    assert_eq!(count_after_dup, 1, "Duplicate nonce should not increase count");
+}
+
+#[test]
+fn test_replay_guard_cross_domain_nonce() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(QuickLendXContract, ());
+    let client = QuickLendXContractClient::new(&env, &contract_id);
+    let business1 = Address::generate(&env);
+    let investor1 = Address::generate(&env);
+    let currency1 = init_currency_for_test(&env, &contract_id, &business1, &investor1);
+    let invoice_id1 = setup_funded_invoice(&env, &client, &business1, &investor1, &currency1, 1_000, 900);
+
+    let business2 = Address::generate(&env);
+    let investor2 = Address::generate(&env);
+    let currency2 = init_currency_for_test(&env, &contract_id, &business2, &investor2);
+    let invoice_id2 = setup_funded_invoice(&env, &client, &business2, &investor2, &currency2, 1_500, 1_200);
+
+    let shared_nonce = String::from_str(&env, "shared-nonce");
+    client.process_partial_payment(&invoice_id1, 300, &shared_nonce);
+    client.process_partial_payment(&invoice_id2, 400, &shared_nonce);
+
+    let count1 = get_payment_count(&env, &invoice_id1).unwrap();
+    let count2 = get_payment_count(&env, &invoice_id2).unwrap();
+    assert_eq!(count1, 1, "First invoice should have one payment record");
+    assert_eq!(count2, 1, "Second invoice should also have one payment record with same nonce string");
+}


### PR DESCRIPTION
Closes #1893   `test: add replay guard tests`


Add unit tests validating the replay‑guard nonce logic (fresh, duplicate, and cross‑domain cases) and close #1893.