### PR TITLE
test: add overbid boundary and rejection coverage

### DIFF
--- a/quicklendx-contracts/tests/invoice_lifecycle_e2e.rs
+++ b/quicklendx-contracts/tests/invoice_lifecycle_e2e.rs
@@ -13,6 +13,8 @@
 //! | `test_partial_then_full_settle`       | Upload → Verify → Bid → Fund → Multiple partials → Final settle |
 
 use quicklendx_contracts::{
+    errors::QuickLendXError,
+    payments::EscrowStatus,
     types::{BidStatus, InvestmentStatus, InvoiceCategory, InvoiceStatus},
     QuickLendXContract, QuickLendXContractClient,
 };
@@ -101,6 +103,51 @@ fn setup_contract(env: &Env) -> Fixture {
         currency,
         contract_id,
     }
+}
+
+fn upload_verified_invoice(fx: &Fixture, amount: i128, description: &str) -> BytesN<32> {
+    let due_date = fx.client.env.ledger().timestamp() + 86_400;
+    let invoice_id = fx.client.upload_invoice(
+        &fx.business,
+        &amount,
+        &fx.currency,
+        &due_date,
+        &String::from_str(&fx.client.env, description),
+        &InvoiceCategory::Goods,
+        &Vec::new(&fx.client.env),
+    );
+
+    fx.client.verify_invoice(&invoice_id);
+
+    invoice_id
+}
+
+fn assert_invoice_still_verified_and_unfunded(
+    fx: &Fixture,
+    invoice_id: &BytesN<32>,
+    amount: i128,
+) {
+    let invoice = fx.client.get_invoice(invoice_id);
+
+    assert_eq!(invoice.amount, amount);
+    assert_eq!(invoice.status, InvoiceStatus::Verified);
+    assert_eq!(invoice.funded_amount, 0);
+    assert_eq!(invoice.total_paid, 0);
+    assert!(invoice.investor.is_none());
+    assert_eq!(invoice.payment_history.len(), 0);
+}
+
+fn assert_no_bid_or_escrow_created(fx: &Fixture, invoice_id: &BytesN<32>) {
+    assert_eq!(fx.client.get_bids_for_invoice(invoice_id).len(), 0);
+
+    let escrow_result = fx.client.try_get_escrow_details(invoice_id);
+    assert!(
+        matches!(
+            escrow_result,
+            Err(Ok(QuickLendXError::StorageKeyNotFound))
+        ),
+        "expected no escrow"
+    );
 }
 
 // ============================================================================
@@ -356,6 +403,132 @@ fn test_invoice_lifecycle_happy_path() {
         paid_ids.iter().any(|id| id == invoice_id),
         "Stage 6: invoice must appear in Paid bucket"
     );
+}
+
+// ============================================================================
+// Issue #1937: Overbid refund path boundaries
+// ============================================================================
+
+#[test]
+fn test_boundary_bid_equal_to_invoice_amount_accepts_and_funds_exactly() {
+    let env = Env::default();
+    let fx = setup_contract(&env);
+    let tok = token::Client::new(&env, &fx.currency);
+
+    let invoice_amount: i128 = 10_000;
+    let invoice_id = upload_verified_invoice(
+        &fx,
+        invoice_amount,
+        "Boundary bid equal to invoice amount",
+    );
+    let bid_salt = BytesN::from_array(&env, &[11u8; 32]);
+
+    let investor_balance_before = tok.balance(&fx.investor);
+    let contract_balance_before = tok.balance(&fx.contract_id);
+
+    let bid_id = fx.client.place_bid(
+        &fx.investor,
+        &invoice_id,
+        &invoice_amount,
+        &(invoice_amount + 1_000),
+        &bid_salt,
+    );
+
+    let bid = fx.client.get_bid(&bid_id).unwrap();
+    assert_eq!(bid.status, BidStatus::Placed);
+    assert_eq!(bid.bid_amount, invoice_amount);
+    assert_eq!(fx.client.get_bids_for_invoice(&invoice_id).len(), 1);
+
+    fx.client.accept_bid_and_fund(&invoice_id, &bid_id);
+
+    let escrow = fx.client.get_escrow_details(&invoice_id);
+    assert!(matches!(escrow.status, EscrowStatus::Held));
+    assert_eq!(escrow.amount, invoice_amount);
+    assert_eq!(escrow.investor, fx.investor);
+
+    let invoice = fx.client.get_invoice(&invoice_id);
+    assert_eq!(invoice.status, InvoiceStatus::Funded);
+    assert_eq!(invoice.funded_amount, invoice_amount);
+    assert_eq!(invoice.investor, Some(fx.investor.clone()));
+
+    assert_eq!(
+        tok.balance(&fx.investor),
+        investor_balance_before - invoice_amount
+    );
+    assert_eq!(
+        tok.balance(&fx.contract_id),
+        contract_balance_before + invoice_amount
+    );
+}
+
+#[test]
+fn test_single_overbid_rejected_without_balance_or_state_changes() {
+    let env = Env::default();
+    let fx = setup_contract(&env);
+    let tok = token::Client::new(&env, &fx.currency);
+
+    let invoice_amount: i128 = 10_000;
+    let invoice_id = upload_verified_invoice(&fx, invoice_amount, "Single overbid rejected");
+    let overbid_amount = invoice_amount + 1;
+    let bid_salt = BytesN::from_array(&env, &[12u8; 32]);
+
+    let investor_balance_before = tok.balance(&fx.investor);
+    let contract_balance_before = tok.balance(&fx.contract_id);
+
+    let result = fx.client.try_place_bid(
+        &fx.investor,
+        &invoice_id,
+        &overbid_amount,
+        &(overbid_amount + 1_000),
+        &bid_salt,
+    );
+
+    assert!(
+        matches!(
+            result,
+            Err(Ok(QuickLendXError::InvoiceAmountInvalid))
+        ),
+        "expected InvoiceAmountInvalid for overbid"
+    );
+    assert_eq!(tok.balance(&fx.investor), investor_balance_before);
+    assert_eq!(tok.balance(&fx.contract_id), contract_balance_before);
+    assert_no_bid_or_escrow_created(&fx, &invoice_id);
+    assert_invoice_still_verified_and_unfunded(&fx, &invoice_id, invoice_amount);
+}
+
+#[test]
+fn test_multiple_overbids_rejected_independently_without_side_effects() {
+    let env = Env::default();
+    let fx = setup_contract(&env);
+    let tok = token::Client::new(&env, &fx.currency);
+
+    let invoice_amount: i128 = 10_000;
+    let invoice_id = upload_verified_invoice(&fx, invoice_amount, "Multiple overbids rejected");
+    let investor_balance_before = tok.balance(&fx.investor);
+    let contract_balance_before = tok.balance(&fx.contract_id);
+
+    for (salt_byte, overbid_amount) in [(21u8, 10_001i128), (22, 10_500), (23, 14_999)] {
+        let bid_salt = BytesN::from_array(&env, &[salt_byte; 32]);
+        let result = fx.client.try_place_bid(
+            &fx.investor,
+            &invoice_id,
+            &overbid_amount,
+            &(overbid_amount + 1),
+            &bid_salt,
+        );
+
+        assert!(
+            matches!(
+                result,
+                Err(Ok(QuickLendXError::InvoiceAmountInvalid))
+            ),
+            "expected InvoiceAmountInvalid for overbid {overbid_amount}"
+        );
+        assert_eq!(tok.balance(&fx.investor), investor_balance_before);
+        assert_eq!(tok.balance(&fx.contract_id), contract_balance_before);
+        assert_no_bid_or_escrow_created(&fx, &invoice_id);
+        assert_invoice_still_verified_and_unfunded(&fx, &invoice_id, invoice_amount);
+    }
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

Adds integration-test coverage for issue #1937.

- Tests a bid exactly equal to the invoice amount.
- Tests rejection of a single overbid.
- Tests multiple overbids being rejected independently.
- Verifies that rejected overbids do not change balances, create bids, create escrow records, or alter invoice funding state.
- Verifies that an exact-boundary bid funds only the invoice amount.

## Testing

Local compilation was blocked because the Windows MSVC linker was unavailable. Cargo dependencies were fetched successfully, and the full test suite will be validated by GitHub Actions.

Closes #1937