### PR TITLE
test(verification): confirm require_regulatory_ok is a no-op by default

### DIFF
--- a/quicklendx-contracts/src/lib.rs
+++ b/quicklendx-contracts/src/lib.rs
@@ -59,6 +59,9 @@ mod test_maintenance_write_matrix;
 mod test_settlement_history_reconstruction;
 #[cfg(test)]
 mod test_settlement_capacity_stress;
+// Issue #1920 — confirm require_regulatory_ok is truly a no-op by default.
+#[cfg(test)]
+mod test_regulatory_gate;
 use soroban_sdk::{contract, contractimpl, symbol_short, Address, BytesN, Env, Map, String, Vec};
 use crate::idempotency::{idempotency_key, idempotency_exists, store_idempotency};
 

--- a/quicklendx-contracts/src/test_regulatory_gate.rs
+++ b/quicklendx-contracts/src/test_regulatory_gate.rs
@@ -1,0 +1,102 @@
+//! Tests confirming `verification::require_regulatory_ok` is truly a no-op
+//! by default (issue #1920).
+//!
+//! `require_regulatory_ok` is a placeholder hook reserved for future
+//! jurisdiction/sanctions-list checks. No such checks are implemented yet,
+//! so every call must unconditionally succeed regardless of the address
+//! passed in or any KYC/verification state already recorded for it. These
+//! run on every CI matrix entry (plain `#[cfg(test)]`, no feature gate).
+
+#![cfg(test)]
+
+use crate::verification::require_regulatory_ok;
+use crate::{QuickLendXContract, QuickLendXContractClient};
+use soroban_sdk::{testutils::Address as _, Address, Env, String};
+
+fn setup(env: &Env) -> (QuickLendXContractClient<'static>, Address) {
+    env.mock_all_auths();
+    let contract_id = env.register(QuickLendXContract, ());
+    let client = QuickLendXContractClient::new(env, &contract_id);
+    let admin = Address::generate(env);
+    client.set_admin(&admin);
+    (client, admin)
+}
+
+#[test]
+fn returns_ok_for_an_address_with_no_recorded_state() {
+    let env = Env::default();
+    let address = Address::generate(&env);
+
+    assert!(
+        require_regulatory_ok(&env, &address).is_ok(),
+        "the gate must succeed by default for an address with no history at all"
+    );
+}
+
+#[test]
+fn returns_ok_without_requiring_authorization() {
+    // Deliberately skip `env.mock_all_auths()`. A true no-op never calls
+    // `require_auth()`; if it ever started doing so, this would panic
+    // instead of returning `Ok`.
+    let env = Env::default();
+    let address = Address::generate(&env);
+
+    require_regulatory_ok(&env, &address).unwrap();
+}
+
+#[test]
+fn returns_ok_for_a_business_with_pending_kyc() {
+    let env = Env::default();
+    let (client, _admin) = setup(&env);
+    let business = Address::generate(&env);
+    client.submit_kyc_application(&business, &String::from_str(&env, "pending kyc"));
+
+    assert!(
+        require_regulatory_ok(&env, &business).is_ok(),
+        "gate must stay a no-op even for a business stuck in KYC-pending state"
+    );
+}
+
+#[test]
+fn returns_ok_for_a_rejected_business() {
+    let env = Env::default();
+    let (client, admin) = setup(&env);
+    let business = Address::generate(&env);
+    client.submit_kyc_application(&business, &String::from_str(&env, "will be rejected"));
+    client.reject_business(&admin, &business, &String::from_str(&env, "not eligible"));
+
+    assert!(
+        require_regulatory_ok(&env, &business).is_ok(),
+        "gate must stay a no-op even for a rejected business"
+    );
+}
+
+#[test]
+fn returns_ok_for_a_verified_business() {
+    let env = Env::default();
+    let (client, admin) = setup(&env);
+    let business = Address::generate(&env);
+    client.submit_kyc_application(&business, &String::from_str(&env, "verified kyc"));
+    client.verify_business(&admin, &business);
+
+    assert!(require_regulatory_ok(&env, &business).is_ok());
+}
+
+#[test]
+fn returns_ok_for_many_distinct_addresses() {
+    let env = Env::default();
+    for _ in 0..100 {
+        let address = Address::generate(&env);
+        assert!(require_regulatory_ok(&env, &address).is_ok());
+    }
+}
+
+#[test]
+fn is_idempotent_across_repeated_calls() {
+    let env = Env::default();
+    let address = Address::generate(&env);
+
+    for _ in 0..10 {
+        assert!(require_regulatory_ok(&env, &address).is_ok());
+    }
+}

--- a/quicklendx-contracts/src/verification.rs
+++ b/quicklendx-contracts/src/verification.rs
@@ -995,6 +995,17 @@ pub fn require_investor_not_pending(env: &Env, investor: &Address) -> Result<(),
     }
 }
 
+/// Regulatory compliance gate, reserved for future jurisdiction/sanctions-list
+/// checks (see `docs/contracts/currency-whitelist.md` "Regulatory Compliance").
+///
+/// No such checks exist yet: this is intentionally a no-op by default and
+/// unconditionally returns `Ok(())` for any address and any ledger/storage
+/// state. Call sites can be wired in ahead of the actual regulatory logic
+/// landing so they don't need to change again once it does.
+pub fn require_regulatory_ok(_env: &Env, _address: &Address) -> Result<(), QuickLendXError> {
+    Ok(())
+}
+
 // Keep the existing invoice verification function
 pub fn verify_invoice_data(
     env: &Env,


### PR DESCRIPTION
## Summary
Adds `verification::require_regulatory_ok`, a placeholder regulatory/jurisdiction-compliance gate reserved for future sanctions/jurisdiction checks. No such checks exist yet, so it must unconditionally return `Ok(())`. This PR locks that no-op behavior in with tests so a future change can't silently turn it into a real gate without a test failing first.

## Changes
- `quicklendx-contracts/src/verification.rs`: add `require_regulatory_ok(env, address) -> Result<(), QuickLendXError>`, always `Ok(())`.
- `quicklendx-contracts/src/test_regulatory_gate.rs` (new): asserts the gate returns `Ok` for:
  - an address with no recorded state at all
  - a call made with no mocked auth (proves it never calls `require_auth`)
  - a business with pending KYC
  - a rejected business
  - a verified business
  - 100 distinct freshly generated addresses
  - repeated calls against the same address (idempotency)
- `quicklendx-contracts/src/lib.rs`: register the new `#[cfg(test)]` test module (no feature gate, so it runs on every CI matrix entry).

## Testing
- Could not run `cargo test` / `cargo build --target wasm32-unknown-unknown --release` / `cargo clippy` locally in this environment — the local Windows toolchain is missing the Windows SDK (`kernel32.lib` and friends aren't installed alongside VS Build Tools), which blocks linking for *any* native Rust build here, unrelated to this change. Relying on the repo's CI matrix to compile and run these tests.

Closes #1920