### PR TITLE
feat(admin): add rating_override entrypoint with audit trail

### DIFF
--- a/quicklendx-contracts/src/audit.rs
+++ b/quicklendx-contracts/src/audit.rs
@@ -69,6 +69,8 @@ pub enum AuditOperation {
     ConfigFeeStructureChanged,
     /// Admin reconfigured revenue-distribution shares.
     ConfigRevenueDistributionChanged,
+    /// Admin manually overrode an invoice's computed average rating.
+    RatingOverridden,
 }
 
 /// Typed operation types used by audit-log emission.
@@ -100,6 +102,7 @@ pub enum OpType {
     ConfigTreasuryChanged,
     ConfigFeeStructureChanged,
     ConfigRevenueDistributionChanged,
+    RatingOverridden,
 }
 
 impl OpType {
@@ -127,6 +130,7 @@ impl OpType {
             OpType::ConfigTreasuryChanged => symbol_short!("cfg_trs"),
             OpType::ConfigFeeStructureChanged => symbol_short!("cfg_fstr"),
             OpType::ConfigRevenueDistributionChanged => symbol_short!("cfg_rev"),
+            OpType::RatingOverridden => symbol_short!("rt_over"),
         }
     }
 
@@ -154,6 +158,7 @@ impl OpType {
             OpType::ConfigTreasuryChanged => 18,
             OpType::ConfigFeeStructureChanged => 19,
             OpType::ConfigRevenueDistributionChanged => 20,
+            OpType::RatingOverridden => 21,
         }
     }
 }
@@ -184,6 +189,7 @@ impl From<AuditOperation> for OpType {
             AuditOperation::ConfigRevenueDistributionChanged => {
                 OpType::ConfigRevenueDistributionChanged
             }
+            AuditOperation::RatingOverridden => OpType::RatingOverridden,
         }
     }
 }
@@ -423,6 +429,7 @@ fn operation_tag(operation: &AuditOperation) -> u8 {
         AuditOperation::ConfigTreasuryChanged => 18,
         AuditOperation::ConfigFeeStructureChanged => 19,
         AuditOperation::ConfigRevenueDistributionChanged => 20,
+        AuditOperation::RatingOverridden => 21,
     }
 }
 

--- a/quicklendx-contracts/src/errors.rs
+++ b/quicklendx-contracts/src/errors.rs
@@ -90,6 +90,9 @@ pub enum QuickLendXError {
     AlreadyRated = 1502,
     /// BREAKING: Do not renumber this variant. public ABI consumption.
     NotRater = 1503,
+    /// Admin rating override was requested without a non-empty, bounded-length audit reason.
+    /// BREAKING: Do not renumber this variant. public ABI consumption.
+    InvalidRatingOverrideReason = 1504,
 
     // KYC / verification (1600-1604)
     /// BREAKING: Do not renumber this variant. public ABI consumption.
@@ -235,6 +238,7 @@ impl From<QuickLendXError> for Symbol {
             QuickLendXError::NotFunded => symbol_short!("NOT_FD"),
             QuickLendXError::AlreadyRated => symbol_short!("ALR_RT"),
             QuickLendXError::NotRater => symbol_short!("NOT_RT"),
+            QuickLendXError::InvalidRatingOverrideReason => symbol_short!("RT_OV_RSN"),
             // KYC / verification
             QuickLendXError::BusinessNotVerified => symbol_short!("BUS_NV"),
             QuickLendXError::KYCAlreadyPending => symbol_short!("KYC_PD"),

--- a/quicklendx-contracts/src/invoice.rs
+++ b/quicklendx-contracts/src/invoice.rs
@@ -334,6 +334,24 @@ impl Invoice {
         Ok(())
     }
 
+    /// Admin override of the invoice's computed average rating.
+    ///
+    /// A one-off manual correction (e.g. for a fraudulent or erroneous rating
+    /// discovered off-chain). Callers are responsible for authorization and
+    /// for recording the mandatory audit reason; this method only validates
+    /// and applies the new score.
+    ///
+    /// Note: a subsequent [`Self::add_rating`] call recomputes `average_rating`
+    /// purely from the underlying `ratings` vector, which silently replaces
+    /// this override — it is a one-off correction, not a persistent pin.
+    pub fn override_rating(&mut self, new_rating: u32) -> Result<(), QuickLendXError> {
+        if new_rating == 0 || new_rating > 5 {
+            return Err(QuickLendXError::InvalidRating);
+        }
+        self.average_rating = Some(new_rating);
+        Ok(())
+    }
+
     pub fn get_highest_rating(&self) -> Option<u32> {
         let mut highest: Option<u32> = None;
         for entry in self.ratings.iter() {

--- a/quicklendx-contracts/src/lib.rs
+++ b/quicklendx-contracts/src/lib.rs
@@ -128,6 +128,8 @@ mod test_admin_two_step;
 mod test_audit;
 #[cfg(test)]
 mod test_audit_config;
+#[cfg(test)]
+mod test_rating_override;
 #[cfg(all(test, feature = "legacy-tests"))]
 mod test_backup;
 #[cfg(all(test, feature = "legacy-tests"))]
@@ -354,6 +356,13 @@ use verification::{
 };
 
 use crate::storage::{BidStorage, InvoiceStorage};
+
+/// Render a 1-5 rating score as a decimal `String` for audit-log serialization.
+fn fmt_rating(env: &Env, value: u32) -> String {
+    let mut buf = [0u8; 10];
+    let len = audit::write_u64_to_buf(&mut buf, value as u64);
+    String::from_str(env, core::str::from_utf8(&buf[..len]).unwrap_or("0"))
+}
 
 #[contract]
 pub struct QuickLendXContract;
@@ -3448,6 +3457,64 @@ impl QuickLendXContract {
         let ts = env.ledger().timestamp();
         invoice.add_rating(rating, feedback, rater, ts)?;
         InvoiceStorage::update_invoice(&env, &invoice);
+        Ok(())
+    }
+
+    /// Admin-only: override an invoice's computed average rating.
+    ///
+    /// A one-off manual override for correcting a fraudulent or erroneous
+    /// rating discovered off-chain. Every use is recorded in the append-only
+    /// audit trail together with the caller-supplied `reason`.
+    ///
+    /// # Threat model
+    /// Without a mandatory, logged reason, an admin could silently rewrite an
+    /// invoice's displayed rating — e.g. to bury a legitimate bad-faith
+    /// complaint or inflate a business's track record — leaving investors who
+    /// rely on that score with no way to detect or attribute the change after
+    /// the fact. Requiring a non-empty, length-bounded reason and routing the
+    /// mutation through the tamper-evident audit trail (see `audit.rs`) closes
+    /// that accountability gap; the reason check happens before the storage
+    /// write so an override can never be applied without a corresponding
+    /// audit entry.
+    ///
+    /// # Errors
+    /// * `NotAdmin` / `OperationNotAllowed` — caller is not the current admin.
+    /// * `InvalidRatingOverrideReason` — `reason` is empty or exceeds
+    ///   `protocol_limits::MAX_RATING_OVERRIDE_REASON_LENGTH`.
+    /// * `InvoiceNotFound` — `invoice_id` does not exist.
+    /// * `InvalidRating` — `new_rating` is not in `1..=5`.
+    pub fn rating_override(
+        env: Env,
+        admin: Address,
+        invoice_id: BytesN<32>,
+        new_rating: u32,
+        reason: String,
+    ) -> Result<(), QuickLendXError> {
+        AdminStorage::require_admin_auth(&env, &admin)?;
+
+        if reason.is_empty() || reason.len() > protocol_limits::MAX_RATING_OVERRIDE_REASON_LENGTH {
+            return Err(QuickLendXError::InvalidRatingOverrideReason);
+        }
+
+        let mut invoice = InvoiceStorage::get_invoice(&env, &invoice_id)
+            .ok_or(QuickLendXError::InvoiceNotFound)?;
+
+        let old_value = invoice.average_rating.map(|r| fmt_rating(&env, r));
+
+        invoice.override_rating(new_rating)?;
+        InvoiceStorage::update_invoice(&env, &invoice);
+
+        audit::log_operation(
+            &env,
+            invoice_id,
+            audit::AuditOperation::RatingOverridden,
+            admin,
+            old_value,
+            Some(fmt_rating(&env, new_rating)),
+            None,
+            Some(reason),
+        );
+
         Ok(())
     }
 

--- a/quicklendx-contracts/src/protocol_limits.rs
+++ b/quicklendx-contracts/src/protocol_limits.rs
@@ -77,6 +77,8 @@ pub const MAX_KYC_DATA_LENGTH: u32 = 5000;
 pub const MAX_REJECTION_REASON_LENGTH: u32 = 500;
 /// Maximum length for invoice feedback (1000 bytes)
 pub const MAX_FEEDBACK_LENGTH: u32 = 1000;
+/// Maximum length for the mandatory reason on an admin rating override (500 bytes)
+pub const MAX_RATING_OVERRIDE_REASON_LENGTH: u32 = 500;
 
 pub fn check_string_length(s: &String, max_len: u32) -> Result<(), QuickLendXError> {
     if s.len() > max_len {

--- a/quicklendx-contracts/src/test_rating_override.rs
+++ b/quicklendx-contracts/src/test_rating_override.rs
@@ -1,0 +1,155 @@
+#![cfg(test)]
+
+//! Tests for the admin `rating_override` entrypoint (issue #1876).
+//!
+//! ## Threat model
+//! Without a mandatory, logged reason, an admin could silently rewrite an
+//! invoice's displayed rating — e.g. to bury a legitimate bad-faith
+//! complaint or inflate a business's track record — leaving investors who
+//! rely on that score with no way to detect or attribute the change after
+//! the fact. These tests confirm:
+//! - a missing/empty reason is rejected with a typed error (not a panic),
+//! - non-admin callers cannot invoke the override,
+//! - out-of-range ratings are rejected,
+//! - every successful override mutates the invoice AND produces exactly one
+//!   audit-trail entry recording the actor and reason.
+
+use soroban_sdk::{testutils::Address as _, Address, BytesN, Env, String, Vec};
+
+use crate::admin::AdminStorage;
+use crate::audit::AuditOperation;
+use crate::errors::QuickLendXError;
+use crate::invoice::Invoice;
+use crate::storage::InvoiceStorage;
+use crate::types::InvoiceCategory;
+use crate::{QuickLendXContract, QuickLendXContractClient};
+
+fn setup() -> (Env, QuickLendXContractClient<'static>, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(QuickLendXContract, ());
+    let client = QuickLendXContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    env.as_contract(&contract_id, || {
+        AdminStorage::initialize(&env, &admin).unwrap();
+    });
+    (env, client, admin)
+}
+
+/// Store a bare invoice directly, bypassing `store_invoice`'s currency
+/// whitelist / KYC checks (irrelevant to rating-override logic), and
+/// return its id.
+fn seed_invoice(env: &Env, contract_id: &Address) -> BytesN<32> {
+    env.as_contract(contract_id, || {
+        let business = Address::generate(env);
+        let currency = Address::generate(env);
+        let invoice = Invoice::new(
+            env,
+            business,
+            1_000i128,
+            currency,
+            env.ledger().timestamp() + 86_400,
+            String::from_str(env, "Test invoice"),
+            InvoiceCategory::Services,
+            Vec::new(env),
+        )
+        .unwrap();
+        let id = invoice.id.clone();
+        InvoiceStorage::store_invoice(env, &invoice);
+        id
+    })
+}
+
+#[test]
+fn test_rating_override_requires_non_empty_reason() {
+    let (env, client, admin) = setup();
+    let invoice_id = seed_invoice(&env, &client.address);
+
+    let result =
+        client.try_rating_override(&admin, &invoice_id, &4u32, &String::from_str(&env, ""));
+
+    assert_eq!(
+        result,
+        Err(Ok(QuickLendXError::InvalidRatingOverrideReason))
+    );
+
+    // Rejected calls must not mutate state or leave an audit trace.
+    let trail = client.get_invoice_audit_trail(&invoice_id);
+    assert_eq!(trail.len(), 0);
+    let invoice = client.get_invoice(&invoice_id);
+    assert_eq!(invoice.average_rating, None);
+}
+
+#[test]
+fn test_rating_override_rejects_non_admin_caller() {
+    let (env, client, _admin) = setup();
+    let invoice_id = seed_invoice(&env, &client.address);
+    let attacker = Address::generate(&env);
+
+    let result = client.try_rating_override(
+        &attacker,
+        &invoice_id,
+        &4u32,
+        &String::from_str(&env, "correcting a fraudulent rating"),
+    );
+
+    assert!(result.is_err());
+
+    let invoice = client.get_invoice(&invoice_id);
+    assert_eq!(invoice.average_rating, None);
+}
+
+#[test]
+fn test_rating_override_rejects_out_of_range_rating() {
+    let (env, client, admin) = setup();
+    let invoice_id = seed_invoice(&env, &client.address);
+
+    let result = client.try_rating_override(
+        &admin,
+        &invoice_id,
+        &6u32,
+        &String::from_str(&env, "correcting a fraudulent rating"),
+    );
+
+    assert_eq!(result, Err(Ok(QuickLendXError::InvalidRating)));
+}
+
+#[test]
+fn test_rating_override_unknown_invoice_returns_not_found() {
+    let (env, client, admin) = setup();
+    let bogus_id = BytesN::from_array(&env, &[7u8; 32]);
+
+    let result = client.try_rating_override(
+        &admin,
+        &bogus_id,
+        &4u32,
+        &String::from_str(&env, "correcting a fraudulent rating"),
+    );
+
+    assert_eq!(result, Err(Ok(QuickLendXError::InvoiceNotFound)));
+}
+
+#[test]
+fn test_rating_override_success_updates_rating_and_logs_audit_entry() {
+    let (env, client, admin) = setup();
+    let invoice_id = seed_invoice(&env, &client.address);
+    let reason = String::from_str(
+        &env,
+        "Investor rating found to be retaliatory; correcting to neutral score.",
+    );
+
+    client.rating_override(&admin, &invoice_id, &3u32, &reason);
+
+    let invoice = client.get_invoice(&invoice_id);
+    assert_eq!(invoice.average_rating, Some(3));
+
+    let trail = client.get_invoice_audit_trail(&invoice_id);
+    assert_eq!(trail.len(), 1);
+
+    let entry = client.get_audit_entry(&trail.get(0).unwrap()).unwrap();
+    assert_eq!(entry.operation, AuditOperation::RatingOverridden);
+    assert_eq!(entry.actor, admin);
+    assert_eq!(entry.invoice_id, invoice_id);
+    assert_eq!(entry.old_value, None);
+    assert_eq!(entry.additional_data, Some(reason));
+}


### PR DESCRIPTION
## Summary

Closes #1876

Adds a one-off admin `rating_override` entrypoint that lets the admin manually correct an invoice's computed `average_rating` (e.g. a fraudulent or retaliatory investor rating discovered off-chain), with every call captured in the append-only audit trail.

## Threat being mitigated

Before this change there was no supported way to correct a bad rating short of a raw storage patch outside the contract's audited surface. If such a path were ever added without safeguards, an admin could silently rewrite an invoice's displayed rating — e.g. to bury a legitimate bad-faith complaint from an investor, or to inflate a business's track record — with no way for anyone to detect or attribute the change after the fact. Investors and businesses rely on `average_rating` as a trust signal, so an unaccountable override is a direct integrity/trust attack on the protocol, even without a public exploit report.

The fix closes this gap defensively:
- `reason` is mandatory (non-empty) and length-bounded (`protocol_limits::MAX_RATING_OVERRIDE_REASON_LENGTH` = 500 bytes). A missing/empty reason returns the typed error `QuickLendXError::InvalidRatingOverrideReason` instead of silently succeeding or panicking.
- The reason check runs **before** any storage write, so an override can never be applied without a corresponding audit entry — there is no path to a "silent" override.
- Every successful call appends exactly one entry to the existing append-only, hash-chained audit trail (`audit.rs`) via a new `AuditOperation::RatingOverridden` operation, recording the admin's address, the old/new rating, and the reason.
- Only the current admin can call it (`AdminStorage::require_admin_auth`), consistent with every other privileged entrypoint in the contract.

## Changes

- `quicklendx-contracts/src/lib.rs`: new `rating_override(env, admin, invoice_id, new_rating, reason)` entrypoint on `QuickLendXContract`, plus a small `fmt_rating` helper for audit-log serialization.
- `quicklendx-contracts/src/invoice.rs`: `Invoice::override_rating` — validates `new_rating` is in `1..=5` and applies it (mirrors the existing `add_rating` validation).
- `quicklendx-contracts/src/audit.rs`: new `AuditOperation::RatingOverridden` / `OpType::RatingOverridden` variants wired through all existing match sites (symbol, tag, `From` impl).
- `quicklendx-contracts/src/errors.rs`: new typed error `QuickLendXError::InvalidRatingOverrideReason = 1504`.
- `quicklendx-contracts/src/protocol_limits.rs`: new `MAX_RATING_OVERRIDE_REASON_LENGTH` constant (500 bytes), following the existing `MAX_*_REASON_LENGTH` convention used by disputes.
- `quicklendx-contracts/src/test_rating_override.rs` (new): negative + positive coverage.

## Negative test (fails before the fix, passes after)

`test_rating_override_requires_non_empty_reason` in `quicklendx-contracts/src/test_rating_override.rs` calls the entrypoint with an empty reason and asserts it returns `Err(QuickLendXError::InvalidRatingOverrideReason)` with no state mutation and no audit entry. The entrypoint (and the error variant) do not exist before this diff, so this test cannot pass on `main`.

Additional tests in the same file cover: non-admin caller rejection, out-of-range rating rejection, unknown-invoice rejection, and the success path (asserts `average_rating` is updated **and** exactly one `AuditOperation::RatingOverridden` entry is appended with the correct actor/reason).

## Cost

Not on a hot path — this is a rare, manual admin action, not part of any invoice/bid/settlement flow. Its cost is one `InvoiceStorage` read/write plus one audit-log append, identical in shape to the existing `set_fee_config`/`set_treasury` admin entrypoints already in the contract.

## Verification note

I was unable to run `cargo build --target wasm32-unknown-unknown --release`, `cargo test -p quicklendx-contracts`, or `cargo clippy --workspace --all-targets -- -D warnings` locally: this machine's MSVC Build Tools install is missing the Windows SDK (`link.exe` cannot resolve `kernel32.lib`), and the alternate GNU toolchain's linker fails on the space in the local user profile path. I manually re-verified every changed signature, import, and match arm against the existing codebase conventions (mirrored closely on the existing `set_fee_config`/`cancel_treasury_rotation`/`add_invoice_rating` entrypoints and the `test_audit_config.rs`/`test_invoice_metadata.rs` test patterns). Please confirm green CI before merge.

## Checklist

- [x] Change matches the issue summary (one-off manual override; every use logged with reason)
- [x] Negative test exercises the new check
- [x] PR description names the threat being mitigated
- [ ] Lint, type-check, and tests all pass locally — **could not verify locally, see note above; relying on CI**
- [x] PR description references the issue with `Closes #`