### PR TITLE
test: add below-boundary cases for classify_size tier thresholds

### DIFF
--- a/quicklendx-contracts/tests/wasm_build_size_budget.rs
+++ b/quicklendx-contracts/tests/wasm_build_size_budget.rs
@@ -352,6 +352,15 @@ fn classify_at_warning_threshold_is_ok() {
     assert_eq!(classify_size(WASM_SIZE_WARNING_BYTES), SizeTier::Ok);
 }
 
+/// One byte below the warning threshold is also `Ok`.
+#[test]
+fn classify_one_below_warning_is_ok() {
+    assert_eq!(
+        classify_size(WASM_SIZE_WARNING_BYTES.saturating_sub(1)),
+        SizeTier::Ok
+    );
+}
+
 /// One byte above the warning threshold enters the `Warning` tier.
 #[test]
 fn classify_one_above_warning_is_warning() {
@@ -372,6 +381,15 @@ fn classify_midpoint_warning_to_budget_is_warning() {
 #[test]
 fn classify_at_hard_budget_is_warning() {
     assert_eq!(classify_size(WASM_SIZE_BUDGET_BYTES), SizeTier::Warning);
+}
+
+/// One byte below the hard budget is also `Warning`.
+#[test]
+fn classify_one_below_budget_is_warning() {
+    assert_eq!(
+        classify_size(WASM_SIZE_BUDGET_BYTES.saturating_sub(1)),
+        SizeTier::Warning
+    );
 }
 
 /// One byte above the hard budget is `Over` (CI must fail).


### PR DESCRIPTION
## Summary

Closes #1827

Adds the two missing **below** boundary tests for the `classify_size` / `SizeTier` logic in the WASM build size budget suite. Each threshold now has a complete **at / below / above** triplet, locking in the documented semantics.

## Changes

`quicklendx-contracts/tests/wasm_build_size_budget.rs`

| Test | Input | Expected |
|------|-------|----------|
| `classify_one_below_warning_is_ok` | `WASM_SIZE_WARNING_BYTES - 1` | `SizeTier::Ok` |
| `classify_one_below_budget_is_warning` | `WASM_SIZE_BUDGET_BYTES - 1` | `SizeTier::Warning` |

Both use `saturating_sub` to remain safe even if the thresholds were set to 0.

## Testing

- [ ] `cargo build --target wasm32-unknown-unknown --release` — builds for WASM
- [ ] `cargo test -p quicklendx-contracts` — all existing + new tests pass
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` — no new warnings

## Related

- Issue #1827 — `At tier, above tier, below tier`