### PR TITLE
fix: replace Math.random/substr correlation ID fallback with randomUUID (#1066)

### DIFF
--- a/quicklendx-frontend/app/components/ErrorToast.tsx
+++ b/quicklendx-frontend/app/components/ErrorToast.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { randomUUID } from "crypto";
 import toast from "react-hot-toast";
 import { AppError, ErrorCategory, ErrorSeverity } from "../lib/errors";
 
@@ -218,7 +219,7 @@ export class ErrorToastManager {
         | "bottom-left";
     }
   ): string {
-    const toastId = `error-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
+    const toastId = `error-${randomUUID()}`;
 
     // Auto-dismiss timing per severity (docs/ux/toasts.md). Critical errors
     // persist until manually dismissed so they cannot be missed.

--- a/quicklendx-frontend/app/lib/api-client.ts
+++ b/quicklendx-frontend/app/lib/api-client.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "crypto";
 import axios, {
   AxiosInstance,
   AxiosRequestConfig,
@@ -228,7 +229,7 @@ class ApiClient {
   }
 
   private generateRequestId(): string {
-    return `req_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
+    return `req_${randomUUID()}`;
   }
 
   private getRequestKey(config: AxiosRequestConfig): string {

--- a/quicklendx-frontend/eslint.config.cjs
+++ b/quicklendx-frontend/eslint.config.cjs
@@ -1,0 +1,11 @@
+const { FlatCompat } = require("@eslint/eslintrc");
+const path = require("path");
+
+const compat = new FlatCompat({
+  baseDirectory: __dirname,
+});
+
+/** @type {import("eslint").Linter.Config[]} */
+const config = [...compat.extends("next/core-web-vitals")];
+
+module.exports = config;


### PR DESCRIPTION
## Summary

Pr Closes #1066 

## Changes
Two frontend files used `Math.random().toString(36).substr(2, 9)` as a fallback ID source, which has two problems:

1. **Collision risk** — `Math.random()` has only ~53 bits of entropy. Under high request volume from clients that don't send a correlation header, two concurrent requests landing in the same millisecond can be assigned the same fallback ID, silently corrupting log traces.
2. **Deprecated API** — `.substr()` is a legacy method deprecated in favour of `.slice()`.

| File | Change |
|---|---|
| `app/lib/api-client.ts` | `generateRequestId()` now returns `req_${randomUUID()}` |
| `app/components/ErrorToast.tsx` | `toastId` now uses `error-${randomUUID()}` |
| `eslint.config.cjs` *(new)* | Migrates to ESLint 9 flat config so `npm run lint` passes in CI |

`randomUUID()` is imported from Node's built-in `crypto` module — already used in `app/lib/webhook/dispatcher.ts` in this codebase — and provides 122 bits of cryptographically random entropy, making collisions astronomically unlikely.

## CI checks (verified locally)

- ✅ `tsc --noEmit` — no type errors
- ✅ `npm run lint` — no lint errors
- ✅ `npx prettier --check .` — all files formatted correctly