### PR TITLE
Fix/kyc tier

### DIFF
--- a/quicklendx-contracts/src/admin.rs
+++ b/quicklendx-contracts/src/admin.rs
@@ -424,9 +424,7 @@ pub fn require_not_reserved(
 
     let admin_addr = match admin {
         Some(a) => a,
-        None => {
-            AdminStorage::get_admin(env).ok_or(QuickLendXError::InvalidCurrency)?
-        }
+        None => AdminStorage::get_admin(env).ok_or(QuickLendXError::InvalidCurrency)?,
     };
     if *address == admin_addr {
         return Err(QuickLendXError::InvalidCurrency);

--- a/quicklendx-contracts/src/errors.rs
+++ b/quicklendx-contracts/src/errors.rs
@@ -80,6 +80,8 @@ pub enum QuickLendXError {
     MaxInvoicesPerBusinessExceeded = 1408,
     /// BREAKING: Do not renumber this variant. public ABI consumption.
     InvalidBidTtl = 1409,
+    /// BREAKING: Do not renumber this variant. public ABI consumption.
+    InsufficientKYCTier = 1410,
 
     // Rating (1500-1503)
     /// BREAKING: Do not renumber this variant. public ABI consumption.
@@ -283,6 +285,7 @@ impl From<QuickLendXError> for Symbol {
             QuickLendXError::MaxActiveBidsPerInvestorExceeded => symbol_short!("MAX_ACT"),
             QuickLendXError::MaxInvoicesPerBusinessExceeded => symbol_short!("MAX_INV"),
             QuickLendXError::InvalidBidTtl => symbol_short!("INV_TTL"),
+            QuickLendXError::InsufficientKYCTier => symbol_short!("TIER_LOW"),
             QuickLendXError::ContractPaused => symbol_short!("PAUSED"),
             QuickLendXError::EmergencyWithdrawNotFound => symbol_short!("EMG_NF"),
             QuickLendXError::EmergencyWithdrawTimelockNotElapsed => symbol_short!("EMG_TLK"),

--- a/quicklendx-contracts/src/events.rs
+++ b/quicklendx-contracts/src/events.rs
@@ -1548,3 +1548,27 @@ pub fn treasury_rotation_cancelled(env: &Env, admin: &Address) {
     env.events()
         .publish((symbol_short!("tr_rot_cn"), admin.clone()), ());
 }
+
+pub fn emit_treasury_rotation_initiated(
+    env: &Env,
+    new_address: &Address,
+    initiated_by: &Address,
+    confirmation_deadline: u64,
+) {
+    TreasuryRotationInitiated {
+        new_address: new_address.clone(),
+        initiated_by: initiated_by.clone(),
+        confirmation_deadline,
+        timestamp: env.ledger().timestamp(),
+    }
+    .publish(env);
+}
+
+pub fn emit_treasury_rotation_confirmed(env: &Env, old_address: &Address, new_address: &Address) {
+    TreasuryRotationConfirmed {
+        old_address: old_address.clone(),
+        new_address: new_address.clone(),
+        timestamp: env.ledger().timestamp(),
+    }
+    .publish(env);
+}

--- a/quicklendx-contracts/src/fees.rs
+++ b/quicklendx-contracts/src/fees.rs
@@ -1172,14 +1172,14 @@ impl FeeManager {
         };
 
         env.storage().instance().set(&ROTATION_KEY, &request);
-        
+
         crate::events::emit_treasury_rotation_initiated(
             env,
             &new_address,
             admin,
             request.confirmation_deadline,
         );
-        
+
         Ok(request)
     }
 
@@ -1222,7 +1222,7 @@ impl FeeManager {
 
         let mut platform_config = Self::get_platform_fee_config(env)?;
         let old_treasury = platform_config.treasury_address.clone();
-        
+
         platform_config.treasury_address = Some(new_address.clone());
         platform_config.updated_at = now;
         platform_config.updated_by = new_address.clone();

--- a/quicklendx-contracts/src/lib.rs
+++ b/quicklendx-contracts/src/lib.rs
@@ -272,6 +272,8 @@ mod test_fuzz_distribute_revenue;
 mod test_fuzz_invoice_metadata;
 #[cfg(all(test, feature = "fuzz-tests"))]
 mod test_fuzz_partial_payment;
+#[cfg(all(test, feature = "fuzz-tests"))]
+mod test_fuzz_tier_boundary;
 #[cfg(all(test, feature = "legacy-tests"))]
 mod test_incident;
 #[cfg(test)]

--- a/quicklendx-contracts/src/lib.rs
+++ b/quicklendx-contracts/src/lib.rs
@@ -282,8 +282,12 @@ mod test_init_debug;
 mod test_init_invariants;
 #[cfg(test)]
 mod test_input_matrix;
+#[cfg(test)]
+mod test_investment_active_guard;
 #[cfg(all(test, feature = "legacy-tests"))]
 mod test_investment_transitions;
+#[cfg(test)]
+mod test_investment_withdrawal;
 #[cfg(all(test, feature = "legacy-tests"))]
 mod test_investment_withdrawal;
 #[cfg(all(test, feature = "legacy-tests"))]
@@ -1391,8 +1395,7 @@ impl QuickLendXContract {
     ) -> Result<(), QuickLendXError> {
         AdminStorage::require_admin(&env, &admin)?;
         // Validate that the invoice exists before freezing.
-        InvoiceStorage::get_invoice(&env, &invoice_id)
-            .ok_or(QuickLendXError::InvoiceNotFound)?;
+        InvoiceStorage::get_invoice(&env, &invoice_id).ok_or(QuickLendXError::InvoiceNotFound)?;
 
         let info = FreezeInfo {
             reason,
@@ -1425,10 +1428,7 @@ impl QuickLendXContract {
     /// Return the stored freeze info for an invoice, if any.
     ///
     /// Returns `None` when the invoice is not frozen or does not exist.
-    pub fn get_invoice_freeze_info(
-        env: Env,
-        invoice_id: BytesN<32>,
-    ) -> Option<FreezeInfo> {
+    pub fn get_invoice_freeze_info(env: Env, invoice_id: BytesN<32>) -> Option<FreezeInfo> {
         InvoiceStorage::get_freeze_info(&env, &invoice_id)
     }
 
@@ -2418,6 +2418,7 @@ impl QuickLendXContract {
             max_due_date_days,
             grace_period_seconds,
             existing.max_invoices_per_business,
+            existing.min_investor_tier,
         )
     }
 
@@ -2445,6 +2446,7 @@ impl QuickLendXContract {
             max_due_date_days,
             grace_period_seconds,
             existing.max_invoices_per_business,
+            existing.min_investor_tier,
         )
     }
 
@@ -2472,6 +2474,7 @@ impl QuickLendXContract {
             max_due_date_days,
             grace_period_seconds,
             existing.max_invoices_per_business,
+            existing.min_investor_tier,
         )
     }
 
@@ -2499,6 +2502,7 @@ impl QuickLendXContract {
             max_due_date_days,
             grace_period_seconds,
             max_invoices_per_business,
+            existing.min_investor_tier,
         )
     }
 
@@ -2534,6 +2538,7 @@ impl QuickLendXContract {
         max_due_date_days: u64,
         grace_period_seconds: u64,
         max_invoices_per_business: u32,
+        min_investor_tier: crate::verification::InvestorTier,
     ) -> Result<(), QuickLendXError> {
         pause::PauseControl::require_not_paused(&env)?;
         protocol_limits::ProtocolLimitsContract::set_protocol_limits(
@@ -2545,6 +2550,7 @@ impl QuickLendXContract {
             max_due_date_days,
             grace_period_seconds,
             max_invoices_per_business,
+            min_investor_tier,
         )
     }
 

--- a/quicklendx-contracts/src/protocol_limits.rs
+++ b/quicklendx-contracts/src/protocol_limits.rs
@@ -22,6 +22,8 @@ pub struct ProtocolLimits {
     pub grace_period_seconds: u64,
     /// Max invoices per business. **Inclusivity**: Inclusive (active_count < limit), 0 = unlimited.
     pub max_invoices_per_business: u32,
+    /// Minimum KYC tier required for placing a bid.
+    pub min_investor_tier: crate::verification::InvestorTier,
 }
 
 #[allow(dead_code)]
@@ -148,6 +150,7 @@ impl ProtocolLimitsContract {
             max_due_date_days: DEFAULT_MAX_DUE_DAYS,
             grace_period_seconds: DEFAULT_GRACE_PERIOD,
             max_invoices_per_business: DEFAULT_MAX_INVOICES_PER_BUSINESS,
+            min_investor_tier: crate::verification::InvestorTier::Basic,
         };
 
         env.storage().instance().set(&LIMITS_KEY, &limits);
@@ -165,6 +168,7 @@ impl ProtocolLimitsContract {
         max_due_date_days: u64,
         grace_period_seconds: u64,
         max_invoices_per_business: u32,
+        min_investor_tier: crate::verification::InvestorTier,
     ) -> Result<(), QuickLendXError> {
         admin.require_auth();
         Self::set_protocol_limits_authed(
@@ -176,6 +180,7 @@ impl ProtocolLimitsContract {
             max_due_date_days,
             grace_period_seconds,
             max_invoices_per_business,
+            min_investor_tier,
         )
     }
 
@@ -191,6 +196,7 @@ impl ProtocolLimitsContract {
         max_due_date_days: u64,
         grace_period_seconds: u64,
         max_invoices_per_business: u32,
+        min_investor_tier: crate::verification::InvestorTier,
     ) -> Result<(), QuickLendXError> {
         AdminStorage::require_admin(env, admin)?;
         validate_protocol_limits_params(
@@ -208,6 +214,7 @@ impl ProtocolLimitsContract {
             max_due_date_days,
             grace_period_seconds,
             max_invoices_per_business,
+            min_investor_tier,
         };
 
         env.storage().instance().set(&LIMITS_KEY, &limits);
@@ -227,6 +234,7 @@ impl ProtocolLimitsContract {
                 max_due_date_days: DEFAULT_MAX_DUE_DAYS,
                 grace_period_seconds: DEFAULT_GRACE_PERIOD,
                 max_invoices_per_business: DEFAULT_MAX_INVOICES_PER_BUSINESS,
+                min_investor_tier: crate::verification::InvestorTier::Basic,
             })
     }
 

--- a/quicklendx-contracts/src/storage.rs
+++ b/quicklendx-contracts/src/storage.rs
@@ -295,11 +295,7 @@ impl InvoiceStorage {
         }
     }
 
-    pub fn set_freeze_info(
-        env: &Env,
-        invoice_id: &BytesN<32>,
-        info: &FreezeInfo,
-    ) {
+    pub fn set_freeze_info(env: &Env, invoice_id: &BytesN<32>, info: &FreezeInfo) {
         let key = DataKey::FreezeInfo(invoice_id.clone());
         env.storage().persistent().set(&key, info);
         extend_persistent_ttl(env, &key);

--- a/quicklendx-contracts/src/test_admin.rs
+++ b/quicklendx-contracts/src/test_admin.rs
@@ -1250,7 +1250,15 @@ mod access_control_matrix {
         // Non-admin cannot set protocol limits
         let result = env.as_contract(&contract_id, || {
             ProtocolLimitsContract::set_protocol_limits(
-                &env, &non_admin, 1000, 10, 100, 365, 86400, 100,
+                &env,
+                &non_admin,
+                1000,
+                10,
+                100,
+                365,
+                86400,
+                100,
+                crate::verification::InvestorTier::Basic,
             )
         });
         assert_eq!(result, Err(QuickLendXError::NotAdmin));
@@ -1258,7 +1266,15 @@ mod access_control_matrix {
         // Admin can set protocol limits
         let result = env.as_contract(&contract_id, || {
             ProtocolLimitsContract::set_protocol_limits(
-                &env, &admin, 1000, 10, 100, 365, 86400, 100,
+                &env,
+                &admin,
+                1000,
+                10,
+                100,
+                365,
+                86400,
+                100,
+                crate::verification::InvestorTier::Basic,
             )
         });
         assert_eq!(result, Ok(()));
@@ -1790,7 +1806,15 @@ mod access_control_matrix {
             }),
             env.as_contract(&contract_id, || {
                 ProtocolLimitsContract::set_protocol_limits(
-                    &env, &admin_1, 1000, 10, 100, 365, 86400, 100,
+                    &env,
+                    &admin_1,
+                    1000,
+                    10,
+                    100,
+                    365,
+                    86400,
+                    100,
+                    crate::verification::InvestorTier::Basic,
                 )
             }),
         ];
@@ -2692,6 +2716,7 @@ mod access_control_matrix_extended {
                         365,
                         86400,
                         100,
+                        crate::verification::InvestorTier::Basic,
                     )
                 })
             }),

--- a/quicklendx-contracts/src/test_business_freeze_reason.rs
+++ b/quicklendx-contracts/src/test_business_freeze_reason.rs
@@ -15,22 +15,14 @@ fn setup_env() -> (Env, crate::QuickLendXContractClient<'static>, Address) {
     (env, client, admin)
 }
 
-fn setup_business(
-    env: &Env,
-    client: &crate::QuickLendXContractClient,
-    admin: &Address,
-) -> Address {
+fn setup_business(env: &Env, client: &crate::QuickLendXContractClient, admin: &Address) -> Address {
     let business = Address::generate(env);
     client.submit_kyc_application(&business, &String::from_str(env, "Business KYC"));
     client.verify_business(admin, &business);
     business
 }
 
-fn setup_investor(
-    env: &Env,
-    client: &crate::QuickLendXContractClient,
-    limit: i128,
-) -> Address {
+fn setup_investor(env: &Env, client: &crate::QuickLendXContractClient, limit: i128) -> Address {
     let investor = Address::generate(env);
     client.submit_investor_kyc(&investor, &String::from_str(env, "Investor KYC"));
     client.verify_investor(&investor, &limit);
@@ -126,7 +118,11 @@ fn test_freeze_compliance_violation() {
     let business = setup_business(&env, &client, &admin);
     let (invoice_id, _) = setup_invoice(&env, &client, &admin, &business);
 
-    client.freeze_invoice(&admin, &invoice_id, &BusinessFreezeReason::ComplianceViolation);
+    client.freeze_invoice(
+        &admin,
+        &invoice_id,
+        &BusinessFreezeReason::ComplianceViolation,
+    );
 
     let info = client.get_invoice_freeze_info(&invoice_id).unwrap();
     assert_eq!(info.reason, BusinessFreezeReason::ComplianceViolation);
@@ -138,7 +134,11 @@ fn test_freeze_suspicious_activity() {
     let business = setup_business(&env, &client, &admin);
     let (invoice_id, _) = setup_invoice(&env, &client, &admin, &business);
 
-    client.freeze_invoice(&admin, &invoice_id, &BusinessFreezeReason::SuspiciousActivity);
+    client.freeze_invoice(
+        &admin,
+        &invoice_id,
+        &BusinessFreezeReason::SuspiciousActivity,
+    );
 
     let info = client.get_invoice_freeze_info(&invoice_id).unwrap();
     assert_eq!(info.reason, BusinessFreezeReason::SuspiciousActivity);
@@ -178,10 +178,7 @@ fn test_freeze_blocks_place_bid() {
         &BytesN::from_array(&env, &[0u8; 32]),
     );
     assert!(result.is_err());
-    assert_eq!(
-        result.unwrap_err().unwrap(),
-        QuickLendXError::InvoiceFrozen
-    );
+    assert_eq!(result.unwrap_err().unwrap(), QuickLendXError::InvoiceFrozen);
 }
 
 #[test]
@@ -206,10 +203,7 @@ fn test_freeze_blocks_accept_bid() {
 
     let result = client.try_accept_bid(&invoice_id, &bid_id);
     assert!(result.is_err());
-    assert_eq!(
-        result.unwrap_err().unwrap(),
-        QuickLendXError::InvoiceFrozen
-    );
+    assert_eq!(result.unwrap_err().unwrap(), QuickLendXError::InvoiceFrozen);
 }
 
 #[test]
@@ -239,10 +233,7 @@ fn test_freeze_blocks_partial_payment() {
         &String::from_str(&env, "tx-freeze-block"),
     );
     assert!(result.is_err());
-    assert_eq!(
-        result.unwrap_err().unwrap(),
-        QuickLendXError::InvoiceFrozen
-    );
+    assert_eq!(result.unwrap_err().unwrap(), QuickLendXError::InvoiceFrozen);
 }
 
 // ============================================================================
@@ -314,11 +305,8 @@ fn test_freeze_requires_admin() {
     let (invoice_id, _) = setup_invoice(&env, &client, &admin, &business);
 
     let non_admin = Address::generate(&env);
-    let result = client.try_freeze_invoice(
-        &non_admin,
-        &invoice_id,
-        &BusinessFreezeReason::AdminAction,
-    );
+    let result =
+        client.try_freeze_invoice(&non_admin, &invoice_id, &BusinessFreezeReason::AdminAction);
     assert!(result.is_err());
 }
 
@@ -331,11 +319,7 @@ fn test_freeze_nonexistent_invoice() {
     let (env, client, admin) = setup_env();
     let fake_id = BytesN::from_array(&env, &[0u8; 32]);
 
-    let result = client.try_freeze_invoice(
-        &admin,
-        &fake_id,
-        &BusinessFreezeReason::AdminAction,
-    );
+    let result = client.try_freeze_invoice(&admin, &fake_id, &BusinessFreezeReason::AdminAction);
     assert!(result.is_err());
     assert_eq!(
         result.unwrap_err().unwrap(),
@@ -381,7 +365,11 @@ fn test_freeze_info_includes_timestamp() {
     let (invoice_id, _) = setup_invoice(&env, &client, &admin, &business);
     let now = env.ledger().timestamp();
 
-    client.freeze_invoice(&admin, &invoice_id, &BusinessFreezeReason::SuspiciousActivity);
+    client.freeze_invoice(
+        &admin,
+        &invoice_id,
+        &BusinessFreezeReason::SuspiciousActivity,
+    );
 
     let info = client.get_invoice_freeze_info(&invoice_id).unwrap();
     assert_eq!(info.frozen_by, admin);

--- a/quicklendx-contracts/src/test_fuzz_tier_boundary.rs
+++ b/quicklendx-contracts/src/test_fuzz_tier_boundary.rs
@@ -1,0 +1,69 @@
+#![cfg(feature = "fuzz-tests")]
+
+use proptest::prelude::*;
+use crate::verification::{compute_investor_tier_from_stats, InvestorTier};
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(5000))]
+
+    #[test]
+    fn test_compute_investor_tier_properties(
+        total_invested in 0i128..10_000_000i128,
+        successful_investments in 0u32..200u32,
+        defaulted_investments in 0u32..50u32,
+        risk_score in 0u32..=100u32,
+    ) {
+        let result = compute_investor_tier_from_stats(
+            total_invested,
+            successful_investments,
+            defaulted_investments,
+            risk_score,
+        ).expect("compute_investor_tier_from_stats should not fail for risk_score <= 100");
+
+        let total_active_or_completed = successful_investments.saturating_add(defaulted_investments);
+        let default_rate_pct = if total_active_or_completed > 0 {
+            (defaulted_investments as u64)
+                .saturating_mul(100)
+                .checked_div(total_active_or_completed as u64)
+                .unwrap_or(0) as u32
+        } else {
+            0
+        };
+
+        // Assert strictly the same tier promotion thresholds defined in verification.rs
+        let expected = if risk_score <= 10
+            && total_invested >= 5_000_000
+            && successful_investments >= 50
+            && default_rate_pct <= 5
+        {
+            InvestorTier::VIP
+        } else if risk_score <= 20
+            && total_invested >= 1_000_000
+            && successful_investments >= 20
+            && default_rate_pct <= 10
+        {
+            InvestorTier::Platinum
+        } else if risk_score <= 40
+            && total_invested >= 100_000
+            && successful_investments >= 10
+            && default_rate_pct <= 15
+        {
+            InvestorTier::Gold
+        } else if risk_score <= 60
+            && total_invested >= 10_000
+            && successful_investments >= 3
+            && default_rate_pct <= 25
+        {
+            InvestorTier::Silver
+        } else {
+            InvestorTier::Basic
+        };
+
+        prop_assert_eq!(
+            result,
+            expected,
+            "Investor tier calculation mismatch: total_invested={}, successful={}, defaulted={}, default_rate_pct={}, risk_score={}",
+            total_invested, successful_investments, defaulted_investments, default_rate_pct, risk_score
+        );
+    }
+}

--- a/quicklendx-contracts/src/test_fuzz_tier_boundary.rs
+++ b/quicklendx-contracts/src/test_fuzz_tier_boundary.rs
@@ -1,7 +1,7 @@
 #![cfg(feature = "fuzz-tests")]
 
-use proptest::prelude::*;
 use crate::verification::{compute_investor_tier_from_stats, InvestorTier};
+use proptest::prelude::*;
 
 proptest! {
     #![proptest_config(ProptestConfig::with_cases(5000))]

--- a/quicklendx-contracts/src/test_init_debug.rs
+++ b/quicklendx-contracts/src/test_init_debug.rs
@@ -14,7 +14,11 @@ fn setup() -> (Env, QuickLendXContractClient<'static>) {
     (env, client)
 }
 
-fn base_params(admin: Address, treasury: Address, currencies: Vec<Address>) -> InitializationParams {
+fn base_params(
+    admin: Address,
+    treasury: Address,
+    currencies: Vec<Address>,
+) -> InitializationParams {
     InitializationParams {
         admin,
         treasury,
@@ -142,7 +146,14 @@ fn test_require_not_reserved_allows_regular_without_explicit_admin() {
     let regular = Address::generate(&env);
     // Pass None for admin/treasury - should fetch from storage
     let contract_id = contract_addr.clone();
-    let result = call_require_not_reserved(&env, &contract_id, &regular, None, None, Some(contract_addr));
+    let result = call_require_not_reserved(
+        &env,
+        &contract_id,
+        &regular,
+        None,
+        None,
+        Some(contract_addr),
+    );
     assert_eq!(result, Ok(()));
 }
 
@@ -150,7 +161,8 @@ fn test_require_not_reserved_allows_regular_without_explicit_admin() {
 fn test_require_not_reserved_rejects_admin_without_explicit_admin() {
     let (env, admin, treasury, contract_addr) = setup_initialized();
     let contract_id = contract_addr.clone();
-    let err = call_require_not_reserved(&env, &contract_id, &admin, None, None, Some(contract_addr));
+    let err =
+        call_require_not_reserved(&env, &contract_id, &admin, None, None, Some(contract_addr));
     assert_eq!(err, Err(QuickLendXError::InvalidCurrency));
 }
 

--- a/quicklendx-contracts/src/test_investment_active_guard.rs
+++ b/quicklendx-contracts/src/test_investment_active_guard.rs
@@ -101,10 +101,18 @@ fn test_add_insurance_succeeds_when_investment_is_active() {
     let sac = token::StellarAssetClient::new(&env, &currency);
     sac.mint(&provider, &100_000i128);
     let tok = token::Client::new(&env, &currency);
-    tok.approve(&provider, &contract_id, &400_000i128, &(env.ledger().sequence() + 50_000));
+    tok.approve(
+        &provider,
+        &contract_id,
+        &400_000i128,
+        &(env.ledger().sequence() + 50_000),
+    );
 
     let res = client.try_add_investment_insurance(&investment.investment_id, &provider, &50u32);
-    assert!(res.is_ok(), "Should succeed in adding insurance when Active");
+    assert!(
+        res.is_ok(),
+        "Should succeed in adding insurance when Active"
+    );
 }
 
 /// Sad Path: Adding insurance on a Completed investment fails.
@@ -120,7 +128,12 @@ fn test_add_insurance_fails_when_investment_is_completed() {
     let sac = token::StellarAssetClient::new(&env, &currency);
     sac.mint(&business, &2_000i128);
     let tok = token::Client::new(&env, &currency);
-    tok.approve(&business, &contract_id, &400_000i128, &(env.ledger().sequence() + 50_000));
+    tok.approve(
+        &business,
+        &contract_id,
+        &400_000i128,
+        &(env.ledger().sequence() + 50_000),
+    );
 
     client.settle_invoice(&invoice_id, &1000);
 
@@ -147,7 +160,8 @@ fn test_add_insurance_fails_when_investment_is_defaulted() {
     );
 
     // Advance time past due date + grace period
-    env.ledger().set_timestamp(env.ledger().timestamp() + 86_400 * 40);
+    env.ledger()
+        .set_timestamp(env.ledger().timestamp() + 86_400 * 40);
     client.handle_overdue_invoices(&100u32);
 
     let investment = env.as_contract(&contract_id, || {
@@ -223,7 +237,10 @@ fn test_withdraw_succeeds_when_investment_is_active() {
     );
 
     let res = client.try_withdraw_investment(&invoice_id, &investor);
-    assert!(res.is_ok(), "Should succeed in withdrawing active investment");
+    assert!(
+        res.is_ok(),
+        "Should succeed in withdrawing active investment"
+    );
 }
 
 /// Sad Path: Withdrawing a Completed investment fails.
@@ -239,7 +256,12 @@ fn test_withdraw_fails_when_investment_is_completed() {
     let sac = token::StellarAssetClient::new(&env, &currency);
     sac.mint(&business, &2_000i128);
     let tok = token::Client::new(&env, &currency);
-    tok.approve(&business, &contract_id, &400_000i128, &(env.ledger().sequence() + 50_000));
+    tok.approve(
+        &business,
+        &contract_id,
+        &400_000i128,
+        &(env.ledger().sequence() + 50_000),
+    );
 
     client.settle_invoice(&invoice_id, &1000);
 
@@ -260,7 +282,8 @@ fn test_withdraw_fails_when_investment_is_defaulted() {
     );
 
     // Advance time past due date + grace period
-    env.ledger().set_timestamp(env.ledger().timestamp() + 86_400 * 40);
+    env.ledger()
+        .set_timestamp(env.ledger().timestamp() + 86_400 * 40);
     client.handle_overdue_invoices(&100u32);
 
     let err = client

--- a/quicklendx-contracts/src/test_investor_kyc.rs
+++ b/quicklendx-contracts/src/test_investor_kyc.rs
@@ -1220,6 +1220,41 @@ mod test_investor_kyc {
         assert_eq!(err, QuickLendXError::BusinessNotVerified);
     }
 
+    #[test]
+    fn unverified_investor_fails_kyc_tier_check() {
+        let (env, client, admin) = setup();
+        let investor = Address::generate(&env);
+        let business = Address::generate(&env);
+        let kyc_data = String::from_str(&env, "Valid KYC data");
+
+        // Verify the investor so they are active but with Basic tier
+        let _ = client.try_submit_investor_kyc(&investor, &kyc_data);
+        let _ = client.try_verify_investor(&investor, &100_000i128);
+
+        // Update protocol limits to require Silver tier
+        client.set_protocol_limits_full(
+            &admin,
+            &1000,
+            &10,
+            &100,
+            &365,
+            &86400,
+            &100,
+            &crate::verification::InvestorTier::Silver,
+        );
+
+        let invoice_id = create_verified_invoice(&env, &client, &business, 50_000);
+        let err = client
+            .try_place_bid(&investor, &invoice_id, &10_000i128, &12_000i128)
+            .unwrap_err()
+            .unwrap();
+        assert_eq!(
+            err,
+            QuickLendXError::InsufficientKYCTier,
+            "Investor must have the minimum KYC tier to place a bid"
+        );
+    }
+
     // ============================================================================
     // Category: Admin revoke investor KYC (#1550)
     // ============================================================================

--- a/quicklendx-contracts/src/test_protocol_limits.rs
+++ b/quicklendx-contracts/src/test_protocol_limits.rs
@@ -231,6 +231,7 @@ fn test_internal_protocol_limit_updates_reject_invalid_bid_constraints() {
                 365,
                 0,
                 100,
+                crate::verification::InvestorTier::Basic,
             )
         }),
         Err(QuickLendXError::InvalidAmount)
@@ -247,6 +248,7 @@ fn test_internal_protocol_limit_updates_reject_invalid_bid_constraints() {
                 365,
                 0,
                 100,
+                crate::verification::InvestorTier::Basic,
             )
         }),
         Err(QuickLendXError::InvalidAmount)

--- a/quicklendx-contracts/src/test_protocol_limits_boundary.rs
+++ b/quicklendx-contracts/src/test_protocol_limits_boundary.rs
@@ -32,6 +32,7 @@ mod test_protocol_limits_boundary {
             max_due_date_days: 90,
             grace_period_seconds: 86_400,
             max_invoices_per_business: 5,
+            min_investor_tier: crate::verification::InvestorTier::Basic,
         };
         env.as_contract(&contract_id, || {
             env.storage().instance().set(&"protocol_limits", &limits);
@@ -104,6 +105,7 @@ mod test_protocol_limits_boundary {
                 90,
                 86_400,
                 5,
+                crate::verification::InvestorTier::Basic,
             )
         });
         assert_eq!(result, Err(QuickLendXError::InvalidAmount));

--- a/quicklendx-contracts/src/test_store_invoices_batch.rs
+++ b/quicklendx-contracts/src/test_store_invoices_batch.rs
@@ -164,7 +164,7 @@ fn test_batch_respects_active_invoice_cap() {
 
     // Lower the per-business limit to something small.
     // Default is 100; set it to 3 so we can test the cap easily.
-    client.set_protocol_limits(
+    client.set_protocol_limits_full(
         &admin,
         &10,    // min_invoice_amount
         &10,    // min_bid_amount
@@ -172,6 +172,7 @@ fn test_batch_respects_active_invoice_cap() {
         &365,   // max_due_date_days
         &604800, // grace_period_seconds (7 days)
         &3,     // max_invoices_per_business
+        &crate::verification::InvestorTier::Basic, // min_investor_tier
     );
 
     // First batch: 2 invoices — should succeed (2 < 3).

--- a/quicklendx-contracts/src/verification.rs
+++ b/quicklendx-contracts/src/verification.rs
@@ -36,7 +36,7 @@ pub struct BusinessVerification {
 }
 
 #[contracttype]
-#[derive(Clone, PartialEq, Debug)]
+#[derive(Clone, PartialEq, Debug, PartialOrd, Ord)]
 pub enum InvestorTier {
     Basic,
     Silver,
@@ -1623,7 +1623,13 @@ pub fn validate_investor_investment(
     investor: &Address,
     investment_amount: i128,
 ) -> Result<(), QuickLendXError> {
+    let limits = ProtocolLimitsContract::get_protocol_limits(env.clone());
+
     if let Some(verification) = InvestorVerificationStorage::get(env, investor) {
+        if verification.tier < limits.min_investor_tier {
+            return Err(QuickLendXError::InsufficientKYCTier);
+        }
+
         // 1. Verification status check
         if !matches!(verification.status, BusinessVerificationStatus::Verified) {
             return Err(QuickLendXError::BusinessNotVerified);

--- a/quicklendx-contracts/tests/pagination_match_over_under.rs
+++ b/quicklendx-contracts/tests/pagination_match_over_under.rs
@@ -2,15 +2,11 @@
 #[cfg(test)]
 mod pagination_match_over_under {
     use super::super::*; // import pagination module
-    use quicklendx_contracts::pagination::{
-        cap_query_limit,
-        validate_query_params,
-        validate_pagination_params,
-        calculate_safe_bounds,
-        paginate_slice,
-        MAX_QUERY_LIMIT,
-    };
     use quicklendx_contracts::errors::QuickLendXError;
+    use quicklendx_contracts::pagination::{
+        calculate_safe_bounds, cap_query_limit, paginate_slice, validate_pagination_params,
+        validate_query_params, MAX_QUERY_LIMIT,
+    };
 
     #[test]
     fn test_validate_query_params_overflow() {


### PR DESCRIPTION
Closes #2075 

**Summary**
Reject bids from investors without the required KYC tier.

**Background**
This is a defence-in-depth fix. Even though we have no public report of exploitation, this gap is the kind of thing a careful auditor would flag and that we want closed before any external review. The change is implemented as part of the security baseline rather than as a reaction to an incident.

**Threat Mitigated**
By bypassing minimum KYC tier requirements, low-tier or unverified investors could gain access to higher-risk or restricted investment opportunities, circumventing protocol risk controls designed to limit exposure for less-verified participants.

**Acceptance criteria**
- [x] The change matches the summary above.
- [x] A negative test exercises the new check (`unverified_investor_fails_kyc_tier_check`).
- [x] The PR description names the threat being mitigated.
- [x] Lint, type-check, and tests all pass locally.

