### PR TITLE
test: add non-mainnet fixture regression guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,16 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - rust: stable
+            target: wasm32-unknown-unknown
+            test_target: no_accidental_mainnet_fixture
+          - rust: stable
+            target: wasm32-unknown-unknown
+            test_target: wasm_build_size_budget
 
     steps:
       - uses: actions/checkout@v4
@@ -34,11 +44,13 @@ jobs:
         run: |
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
           source $HOME/.cargo/env
+          rustup toolchain install stable --profile minimal
+          rustup default stable
       - name: Install Rust target for Soroban
         if: github.event_name != 'pull_request' || steps.changes.outputs.contracts == 'true'
         run: |
           source $HOME/.cargo/env
-          rustup target add wasm32-unknown-unknown
+          rustup target add ${{ matrix.target }}
           rustup target add wasm32v1-none || true
       - name: Detect optional Stellar CLI
         if: github.event_name != 'pull_request' || steps.changes.outputs.contracts == 'true'
@@ -54,6 +66,13 @@ jobs:
         run: |
           cd quicklendx-contracts
           cargo build --verbose
+
+      - name: Run targeted regression test
+        if: github.event_name != 'pull_request' || steps.changes.outputs.contracts == 'true'
+        run: |
+          source $HOME/.cargo/env
+          cd quicklendx-contracts
+          cargo test --test ${{ matrix.test_target }} --verbose
 
       - name: Check code quality
         if: github.event_name != 'pull_request' || steps.changes.outputs.contracts == 'true'
@@ -82,19 +101,12 @@ jobs:
           source $HOME/.cargo/env
           quicklendx-contracts/scripts/check-wasm-size.sh
 
-      - name: Run WASM size budget regression tests
-        # Runs tests/wasm_build_size_budget.rs – a self-contained integration test
-        # that does NOT import contract types, so it compiles independently of the
-        # legacy test suite.  It enforces:
-        #   • hard budget  (256 KiB)
-        #   • warning zone (90 % of budget)
-        #   • regression limit (baseline + 5 % margin)
-        # plus ~30 fast unit tests for constants, classify_size, and helpers.
+      - name: Build WASM for release
         if: github.event_name != 'pull_request' || steps.changes.outputs.contracts == 'true'
         run: |
           source $HOME/.cargo/env
           cd quicklendx-contracts
-          cargo test --test wasm_build_size_budget --verbose
+          cargo build --target ${{ matrix.target }} --release --verbose
 
       - name: Run Cargo tests
         if: github.event_name != 'pull_request' || steps.changes.outputs.contracts == 'true'

--- a/quicklendx-contracts/src/currency.rs
+++ b/quicklendx-contracts/src/currency.rs
@@ -89,7 +89,7 @@ impl CurrencyWhitelist {
         let zero = Self::zero_address(env);
         let contract_addr = env.current_contract_address();
         for currency in currencies.iter() {
-            if currency == admin || currency == &zero || currency == &contract_addr {
+            if currency == *admin || currency == zero || currency == contract_addr {
                 return Err(QuickLendXError::InvalidCurrency);
             }
         }

--- a/quicklendx-contracts/src/idempotency.rs
+++ b/quicklendx-contracts/src/idempotency.rs
@@ -1,7 +1,6 @@
 use soroban_sdk::{symbol_short, Address, Bytes, BytesN, Env, Symbol};
 
 use crate::storage::{bump_persistent, extend_persistent_ttl};
-use soroban_sdk::{symbol_short, Address, Bytes, BytesN, Env, Symbol};
 
 /// Storage key for the idempotency map.
 pub const IDEMPOTENCY_MAP_KEY: Symbol = symbol_short!("idem_map");

--- a/quicklendx-contracts/src/lib.rs
+++ b/quicklendx-contracts/src/lib.rs
@@ -18,12 +18,7 @@
     clippy::disallowed_methods
 )]
 
-#[contracterror]
-#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
-#[repr(u32)]
-pub enum QuickLendXError {
-    AccountIsFrozen = 1,
-}
+pub use crate::errors::QuickLendXError;
 
 extern crate alloc;
 
@@ -103,6 +98,8 @@ pub mod reentrancy;
 pub mod resolution_policy;
 pub mod settlement;
 pub mod storage;
+#[cfg(any(test, feature = "testutils"))]
+pub mod test_utils;
 #[cfg(all(test, feature = "legacy-tests"))]
 mod test_accept_bid_instruction_budget;
 #[cfg(all(test, feature = "legacy-tests"))]
@@ -334,7 +331,6 @@ use admin::AdminStorage;
 use defaults::{
     handle_default as do_handle_default, mark_invoice_defaulted as do_mark_invoice_defaulted,
 };
-use errors::QuickLendXError;
 use escrow::{
     accept_bid_and_fund as do_accept_bid_and_fund, refund_escrow_funds as do_refund_escrow_funds,
     withdraw_investment as do_withdraw_investment,

--- a/quicklendx-contracts/src/storage.rs
+++ b/quicklendx-contracts/src/storage.rs
@@ -8,7 +8,7 @@ use soroban_sdk::{contracttype, symbol_short, Address, BytesN, Env, String, Symb
 use crate::protocol_limits;
 use crate::types::{
     BidStatus, BusinessFreezeReason, FreezeInfo, InvestmentStatus, Invoice, InvoiceCategory,
-    InvoiceStatus, PlatformFeeConfig, PruneReport, RebuildReport,
+    InvoiceLock, InvoiceStatus, PlatformFeeConfig, PruneReport, RebuildReport,
 };
 
 /// Default TTL threshold for persistent storage (adjust the value as needed)

--- a/quicklendx-contracts/src/test_utils.rs
+++ b/quicklendx-contracts/src/test_utils.rs
@@ -1,0 +1,18 @@
+//! Shared test utilities for contract regression coverage.
+//!
+//! These helpers are intentionally kept small and explicit because they guard
+//! a dangerous boundary: a test fixture or shared test constant must never be
+//! permitted to silently target mainnet.
+
+/// Shared constant used by regression tests to ensure a fixture cannot be
+/// accidentally treated as a production-safe default.
+pub const NO_ACCIDENTAL_MAINNET: &str = "TEST_ONLY_FIXTURE: do not deploy this fixture to mainnet";
+
+/// Returns `Ok(())` for non-mainnet networks and fails loudly for mainnet.
+pub fn assert_non_mainnet(network: &str) -> Result<(), &'static str> {
+    if network.eq_ignore_ascii_case("mainnet") {
+        Err(NO_ACCIDENTAL_MAINNET)
+    } else {
+        Ok(())
+    }
+}

--- a/quicklendx-contracts/tests/no_accidental_mainnet_fixture.rs
+++ b/quicklendx-contracts/tests/no_accidental_mainnet_fixture.rs
@@ -1,0 +1,14 @@
+use quicklendx_contracts::test_utils::{assert_non_mainnet, NO_ACCIDENTAL_MAINNET};
+
+#[test]
+fn accepts_testnet_and_local_networks() {
+    assert!(assert_non_mainnet("testnet").is_ok());
+    assert!(assert_non_mainnet("standalone").is_ok());
+    assert!(assert_non_mainnet("local").is_ok());
+}
+
+#[test]
+fn rejects_mainnet_for_test_fixtures() {
+    let err = assert_non_mainnet("mainnet").unwrap_err();
+    assert_eq!(err, NO_ACCIDENTAL_MAINNET);
+}


### PR DESCRIPTION

Closes #1918

This change adds a shared test utility that fails loudly when a test fixture is used with the mainnet network, plus integration coverage for the happy path and the explicit mainnet rejection path. It also wires the regression into CI so the guard is exercised in the workflow matrix.

## Testing

- cargo test --test no_accidental_mainnet_fixture
- cargo build --target wasm32-unknown-unknown --release