### PR TITLE
test: register invoice batch create boundary tests and fix missing origination_fee_bps

### DIFF
--- a/quicklendx-contracts/src/lib.rs
+++ b/quicklendx-contracts/src/lib.rs
@@ -343,6 +343,10 @@ mod test_volume_tier_props;
 mod test_cannot_withdraw_more_than_deposited;
 #[cfg(test)]
 mod test_store_invoice_auth;
+// Issue #1880 — batch-create boundary tests; no feature gate (runs on every CI matrix entry).
+// Covers 0, 1, MAX_BATCH, MAX_BATCH+1, active-invoice cap, KYC gating, and atomicity.
+#[cfg(test)]
+mod test_store_invoices_batch;
 #[cfg(test)]
 mod test_tier_boundary;
 #[cfg(test)]
@@ -1318,6 +1322,7 @@ impl QuickLendXContract {
                 input.description.clone(),
                 input.category,
                 input.tags.clone(),
+                None, // origination_fee_bps
             )?;
             let id = invoice.id.clone();
             InvoiceStorage::store_invoice(&env, &invoice);


### PR DESCRIPTION
## Summary

Registers the existing but unregistered `test_store_invoices_batch` module (src/test_store_invoices_batch.rs), which was dead code — never compiled or run. Also fixes a missing `origination_fee_bps` parameter in the `Invoice::new` call inside `store_invoices_batch` (introduced when `origination_fee_bps` was added to `Invoice::new` but the batch path was not updated).

## What changed

**quicklendx-contracts/src/lib.rs**
1. Added `#[cfg(test)] mod test_store_invoices_batch;` — no feature gate, runs on every CI matrix entry.
2. Fixed `Invoice::new` call in `store_invoices_batch` to pass `origination_fee_bps: None`.

## Tests covered (all in existing test_store_invoices_batch.rs)

| Boundary | Test | Expected |
|---|---|---|
| 0 (empty) | `test_batch_empty_rejected` | `Err(BatchSizeExceeded)` |
| 1 | `test_batch_single_invoice` | `Ok(1 ID)` |
| MAX_BATCH (10) | `test_batch_max_size_succeeds` | `Ok(10 IDs)` |
| MAX_BATCH+1 (11) | `test_batch_oversized_rejected` | `Err(BatchSizeExceeded)` |
| Active-invoice cap | `test_batch_respects_active_invoice_cap` | Rejected when over limit |
| KYC unverified | `test_batch_unverified_business_rejected` | `Err(BusinessNotVerified)` |
| KYC pending | `test_batch_pending_business_rejected` | `Err(KYCAlreadyPending)` |
| Atomicity | `test_batch_bad_input_aborts_entirely` | No partial writes |

## Acceptance criteria

- [x] Change matches the summary (0, 1, MAX_BATCH, MAX_BATCH+1 boundaries)
- [x] Tests were dead code on main (unregistered module); now enabled
- [x] No feature gate — runs on every CI matrix entry
- [x] PR references Closes #1880

## Security note

The codebase has pre-existing compilation errors in other modules (unrelated to this change). CI will show those failures, but they are not introduced by this PR. This PR only:
- Registers an existing test module  
- Fixes a missing parameter in one function call within `store_invoices_batch`

## Follow-ups

None — scope is strictly the boundary test registration and the one-line fix to make them compile.