### PR TITLE
feat: add per-invoice settlement currency whitelist (defence-in-depth)

### DIFF
--- a/quicklendx-contracts/src/errors.rs
+++ b/quicklendx-contracts/src/errors.rs
@@ -214,6 +214,10 @@ pub enum QuickLendXError {
     BatchSizeExceeded = 2208,
     /// Account is frozen and cannot create invoices.
     AccountIsFrozen = 2209,
+    /// Settlement currency is not in the invoice's per-invoice settlement currency whitelist.
+    /// Defence-in-depth: the invoice's own `currency` field must be in `settlement_currencies`
+    /// at settlement time. See Issue #1908.
+    SettlementCurrencyNotAllowed = 2210,
 }
 
 impl From<QuickLendXError> for Symbol {
@@ -321,6 +325,7 @@ impl From<QuickLendXError> for Symbol {
             QuickLendXError::UnstableCursor => symbol_short!("STBL_CUR"),
             QuickLendXError::BatchSizeExceeded => symbol_short!("BAT_MAX"),
             QuickLendXError::AccountIsFrozen => symbol_short!("ACCT_FRZ"),
+            QuickLendXError::SettlementCurrencyNotAllowed => symbol_short!("STL_CR_NA"),
         }
     }
 }

--- a/quicklendx-contracts/src/lib.rs
+++ b/quicklendx-contracts/src/lib.rs
@@ -239,6 +239,10 @@ mod test_reentrancy;
 mod test_reentrancy_fault_injection;
 #[cfg(test)]
 mod test_settlement_accounting_identity;
+// Issue #1908 — per-invoice settlement currency whitelist (defence-in-depth).
+// Negative test: settlement blocked when whitelist does not match invoice currency.
+#[cfg(test)]
+mod test_settlement_currency_whitelist;
 #[cfg(test)]
 mod test_settle_during_dispute;
 #[cfg(test)]
@@ -1149,6 +1153,15 @@ impl QuickLendXContract {
         // Store the invoice
         InvoiceStorage::store_invoice(&env, &invoice);
 
+        // Per-invoice settlement currency whitelist (defence-in-depth)
+        let mut settlement_currencies: Vec<Address> = Vec::new(&env);
+        settlement_currencies.push_back(currency.clone());
+        crate::settlement::store_settlement_currencies(
+            &env,
+            &invoice.id,
+            &settlement_currencies,
+        );
+
         // Emit event
         env.events().publish(
             (symbol_short!("created"),),
@@ -1212,6 +1225,16 @@ impl QuickLendXContract {
             origination_fee_bps,
         )?;
         InvoiceStorage::store_invoice(&env, &invoice);
+
+        // Per-invoice settlement currency whitelist (defence-in-depth)
+        let mut settlement_currencies: Vec<Address> = Vec::new(&env);
+        settlement_currencies.push_back(currency.clone());
+        crate::settlement::store_settlement_currencies(
+            &env,
+            &invoice.id,
+            &settlement_currencies,
+        );
+
         emit_invoice_uploaded(&env, &invoice);
 
         Ok(invoice.id)
@@ -1321,6 +1344,16 @@ impl QuickLendXContract {
             )?;
             let id = invoice.id.clone();
             InvoiceStorage::store_invoice(&env, &invoice);
+
+            // Per-invoice settlement currency whitelist (defence-in-depth)
+            let mut settlement_currencies: Vec<Address> = Vec::new(&env);
+            settlement_currencies.push_back(input.currency.clone());
+            crate::settlement::store_settlement_currencies(
+                &env,
+                &invoice.id,
+                &settlement_currencies,
+            );
+
             emit_invoice_uploaded(&env, &invoice);
             ids.push_back(id);
         }

--- a/quicklendx-contracts/src/settlement.rs
+++ b/quicklendx-contracts/src/settlement.rs
@@ -118,6 +118,9 @@ enum SettlementDataKey {
     PaymentNonce(BytesN<32>, String),
     /// Marks an invoice as finalized to guard against double-settlement.
     Finalized(BytesN<32>),
+    /// Per-invoice settlement currency whitelist (defence-in-depth).
+    /// Stored at invoice creation; checked at settlement time.
+    SettlementCurrencies(BytesN<32>),
 }
 
 /// Durable payment record stored per invoice/payment-index.
@@ -563,6 +566,55 @@ pub fn max_settlement_batch_size_soft_cap() -> u32 {
     MAX_SETTLEMENT_BATCH_SIZE_SOFT_CAP
 }
 
+/// Store the per-invoice settlement currency whitelist.
+///
+/// Called at invoice creation time to record the currencies that may be used
+/// to settle this invoice.  By default the whitelist contains only the
+/// invoice's own `currency`, providing defence-in-depth against storage-level
+/// corruption of `invoice.currency`.
+///
+/// When the stored whitelist is empty, no restriction is enforced (backward
+/// compatible fallback for invoices created before this feature).
+///
+/// # Arguments
+/// * `env` — The contract environment.
+/// * `invoice_id` — The invoice whose whitelist to set.
+/// * `currencies` — Allowed settlement currencies for this invoice.
+pub fn store_settlement_currencies(
+    env: &Env,
+    invoice_id: &BytesN<32>,
+    currencies: &soroban_sdk::Vec<Address>,
+) {
+    env.storage()
+        .persistent()
+        .set(&SettlementDataKey::SettlementCurrencies(invoice_id.clone()), currencies);
+}
+
+/// Check that `invoice_currency` is in the per-invoice settlement currency
+/// whitelist.  When no whitelist is stored (backward compat) the check passes.
+fn require_settlement_currency_allowed(
+    env: &Env,
+    invoice_id: &BytesN<32>,
+    invoice_currency: &Address,
+) -> Result<(), QuickLendXError> {
+    let stored: Option<soroban_sdk::Vec<Address>> = env
+        .storage()
+        .persistent()
+        .get(&SettlementDataKey::SettlementCurrencies(invoice_id.clone()));
+    if let Some(allowed) = stored {
+        if allowed.is_empty() {
+            return Ok(());
+        }
+        for c in allowed.iter() {
+            if c == *invoice_currency {
+                return Ok(());
+            }
+        }
+        return Err(QuickLendXError::SettlementCurrencyNotAllowed);
+    }
+    Ok(())
+}
+
 // ---------------------------------------------------------------------------
 // Internal helpers
 // ---------------------------------------------------------------------------
@@ -607,6 +659,13 @@ fn settle_invoice_internal(env: &Env, invoice_id: &BytesN<32>) -> Result<(), Qui
     ) {
         return Err(QuickLendXError::DisputeActive);
     }
+
+    // ── Settlement currency whitelist (defence-in-depth) ─────────────────
+    // Threat: if `invoice.currency` were corrupted in storage (or if a
+    // future refactor allowed a caller-supplied settlement currency), the
+    // per-invoice whitelist captured at creation time provides an independent
+    // check that the settlement currency is what the invoice intended.
+    require_settlement_currency_allowed(env, invoice_id, &invoice.currency)?;
 
     let investment = InvestmentStorage::get_investment_by_invoice(env, invoice_id).unwrap();
 

--- a/quicklendx-contracts/src/test_settlement_currency_whitelist.rs
+++ b/quicklendx-contracts/src/test_settlement_currency_whitelist.rs
@@ -1,0 +1,191 @@
+//! Negative regression tests: settlement is blocked when the per-invoice
+//! settlement currency whitelist does not include `invoice.currency`.
+//!
+//! # Security gap being closed (defence-in-depth)
+//!
+//! `settle_invoice_internal()` previously had no check on the settlement
+//! currency — it used `invoice.currency` unconditionally.  This meant that
+//! if `invoice.currency` were corrupted in stored state (or if a future
+//! refactor introduced a caller-supplied settlement currency), an invoice
+//! could be settled in an unexpected token.
+//!
+//! ## Threat model
+//!
+//! An attacker who can manipulate stored invoice state (or a future code
+//! path that accepts a caller-specified settlement currency) could cause an
+//! invoice funded in Token A to be settled in Token B, potentially at a
+//! different valuation, enabling:
+//!
+//! 1. **Value extraction** — settle a high-value invoice with a low-value
+//!    token, defrauding the investor of the expected return.
+//! 2. **Compliance bypass** — settle in a token that was deliberately
+//!    excluded (e.g. a sanctioned or frozen token).
+//! 3. **Accounting drift** — create an inconsistency between the funded
+//!    currency and the settlement currency that off-chain reconciliation
+//!    cannot resolve.
+//!
+//! ## Fix
+//!
+//! `settle_invoice_internal()` now checks a per-invoice settlement currency
+//! whitelist stored at invoice creation time.  If the whitelist is non-empty
+//! and does not contain `invoice.currency`, settlement is rejected with
+//! `SettlementCurrencyNotAllowed`.
+//!
+//! ## Test matrix
+//!
+//! | Test                                                           | Whitelist contains invoice currency | Expected                     |
+//! |----------------------------------------------------------------|--------------------------------------|------------------------------|
+//! | `test_settlement_blocked_when_whitelist_does_not_match`        | No                                   | `SettlementCurrencyNotAllowed` |
+//! | `test_settlement_succeeds_with_default_whitelist`              | Yes (default)                        | `Ok(())`                     |
+
+use super::*;
+
+use crate::errors::QuickLendXError;
+use crate::types::InvoiceCategory;
+use soroban_sdk::{testutils::Address as _, token, Address, BytesN, Env, String, Vec};
+
+/// Boot a full contract instance and return a `Funded` invoice.
+fn setup_funded_invoice(
+    env: &Env,
+) -> (
+    QuickLendXContractClient,
+    BytesN<32>,
+    Address,
+    Address,
+    Address,
+) {
+    let contract_id = env.register(QuickLendXContract, ());
+    let client = QuickLendXContractClient::new(env, &contract_id);
+
+    let admin = Address::generate(env);
+    let business = Address::generate(env);
+    let investor = Address::generate(env);
+
+    client.set_admin(&admin);
+    client.initialize_fee_system(&admin);
+
+    // Create a real Stellar Asset Contract so token transfers succeed.
+    let token_admin = Address::generate(env);
+    let currency = env
+        .register_stellar_asset_contract_v2(token_admin.clone())
+        .address();
+    let token_client = token::Client::new(env, &currency);
+    let sac = token::StellarAssetClient::new(env, &currency);
+
+    let balance: i128 = 500_000;
+    sac.mint(&business, &balance);
+    sac.mint(&investor, &balance);
+
+    let expiry = env.ledger().sequence() + 10_000;
+    token_client.approve(&business, &contract_id, &balance, &expiry);
+    token_client.approve(&investor, &contract_id, &balance, &expiry);
+
+    // KYC — both parties must be verified.
+    client.submit_kyc_application(&business, &String::from_str(env, "business-kyc"));
+    client.verify_business(&admin, &business);
+    client.submit_investor_kyc(&investor, &String::from_str(env, "investor-kyc"));
+    client.verify_investor(&investor, &balance);
+
+    // Create invoice → verify → bid → accept (funds escrowed, invoice = Funded).
+    let amount: i128 = 100_000;
+    let due_date = env.ledger().timestamp() + 86_400;
+    let invoice_id = client.store_invoice(
+        &business,
+        &amount,
+        &currency,
+        &due_date,
+        &String::from_str(env, "Settlement currency whitelist test invoice"),
+        &InvoiceCategory::Services,
+        &Vec::new(env),
+    );
+    client.verify_invoice(&invoice_id);
+    let bid_id = client.place_bid(&investor, &invoice_id, &amount, &amount);
+    client.accept_bid(&invoice_id, &bid_id);
+
+    (client, invoice_id, business, investor, contract_id)
+}
+
+/// Settlement MUST be blocked when the per-invoice settlement currency
+/// whitelist has been replaced with a list that does NOT include the
+/// invoice's own currency.
+///
+/// Before the fix: there was no check, so settlement would succeed.
+/// After the fix: `settle_invoice_internal` verifies the whitelist and
+/// returns `Err(SettlementCurrencyNotAllowed)`.
+#[test]
+fn test_settlement_blocked_when_whitelist_does_not_match() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, invoice_id, _business, _investor, contract_id) = setup_funded_invoice(&env);
+
+    // Verify pre-condition: invoice is Funded and ready to settle.
+    let inv = client.get_invoice(&invoice_id);
+    assert_eq!(
+        inv.status,
+        crate::types::InvoiceStatus::Funded,
+        "pre-condition: invoice must be Funded"
+    );
+
+    // ── Override settlement currencies whitelist ──────────────────────────
+    // Create a different dummy token and set it as the ONLY allowed
+    // settlement currency.  The invoice was created with `currency`, so
+    // this whitelist does NOT include it.
+    let other_token = Address::generate(&env);
+    let mut bad_whitelist: Vec<Address> = Vec::new(&env);
+    bad_whitelist.push_back(other_token);
+    crate::settlement::store_settlement_currencies(&env, &invoice_id, &bad_whitelist);
+
+    // Attempt full settlement — MUST FAIL.
+    let result = client.try_settle_invoice(&invoice_id, &100_000i128);
+
+    assert_eq!(
+        result.unwrap_err().unwrap(),
+        QuickLendXError::SettlementCurrencyNotAllowed,
+        "settle_invoice must return SettlementCurrencyNotAllowed when the \
+         whitelist does not include invoice.currency"
+    );
+
+    // Invoice must still be Funded — no funds moved, no terminal state.
+    let inv_after = client.get_invoice(&invoice_id);
+    assert_eq!(
+        inv_after.status,
+        crate::types::InvoiceStatus::Funded,
+        "invoice must remain Funded after failed settlement"
+    );
+}
+
+/// Settlement MUST succeed when the default whitelist (set at invoice
+/// creation) contains the invoice's own currency.
+#[test]
+fn test_settlement_succeeds_with_default_whitelist() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, invoice_id, _business, _investor, _contract_id) = setup_funded_invoice(&env);
+
+    // Verify pre-condition: invoice is Funded.
+    let inv = client.get_invoice(&invoice_id);
+    assert_eq!(
+        inv.status,
+        crate::types::InvoiceStatus::Funded,
+        "pre-condition: invoice must be Funded"
+    );
+
+    // Full settlement with default whitelist — MUST SUCCEED.
+    let result = client.try_settle_invoice(&invoice_id, &100_000i128);
+
+    assert!(
+        result.is_ok(),
+        "settle_invoice must succeed with default whitelist: {:?}",
+        result.err()
+    );
+
+    // Invoice must now be Paid.
+    let inv_after = client.get_invoice(&invoice_id);
+    assert_eq!(
+        inv_after.status,
+        crate::types::InvoiceStatus::Paid,
+        "invoice must transition to Paid after successful settlement"
+    );
+}


### PR DESCRIPTION
## Summary

Adds a per-invoice settlement currency whitelist that constrains what tokens can be used to settle a given invoice. This is a defence-in-depth fix: even though `settle_invoice` currently always uses `invoice.currency`, the whitelist provides an independent check at settlement time that protects against storage-level corruption of `invoice.currency` or future code paths that could accept a caller-supplied settlement currency.

## Threat model

If `invoice.currency` were corrupted in storage (or if a future refactor introduced a caller-supplied settlement currency), an invoice funded in Token A could be settled in Token B, enabling:

1. **Value extraction** — settle a high-value invoice with a low-value token, defrauding the investor.
2. **Compliance bypass** — settle in a token that was deliberately excluded (e.g. sanctioned or frozen).
3. **Accounting drift** — create an inconsistency between funded and settlement currency.

The per-invoice whitelist captures the intended settlement currencies at invoice creation time and independently validates at settlement, regardless of the current value of `invoice.currency`.

## What changed

| File | Change |
|---|---|
| `src/errors.rs` | Added `SettlementCurrencyNotAllowed = 2210` error variant |
| `src/settlement.rs` | Added `SettlementCurrencies(BytesN<32>)` data key, `store_settlement_currencies()` public function, `require_settlement_currency_allowed()` internal check, and validation call in `settle_invoice_internal()` |
| `src/lib.rs` | Store settlement currencies whitelist after invoice creation in all three paths: `store_invoice()`, `upload_invoice()`, `store_invoices_batch()` |
| `src/test_settlement_currency_whitelist.rs` | New: negative test (`test_settlement_blocked_when_whitelist_does_not_match`) and happy-path test (`test_settlement_succeeds_with_default_whitelist`) |

## Acceptance criteria

- [x] Change constrains what tokens can settle a given invoice (per-invoice whitelist)
- [x] Negative test exercises the new check (`SettlementCurrencyNotAllowed`)
- [x] PR description names the threat being mitigated (see Threat model above)
- [x] PR references Closes #1908

## Security note

The codebase has pre-existing compilation errors in other modules unrelated to this change (see previous PR commentary). This PR only:
- Adds a new error variant
- Adds storage + check logic in settlement.rs
- Writes the whitelist at invoice creation time
- Adds tests

## Cost impact

Negligible — the check is a single storage read + iteration over a small Vec (typically 1 element). No new storage is written on the settlement hot path; the whitelist is written once at invoice creation.

## Follow-ups

None — scope is strictly the defence-in-depth whitelist check.