### PR TITLE
feat: auto-pause contract when upgrade is pending

### DIFF
--- a/quicklendx-contracts/src/errors.rs
+++ b/quicklendx-contracts/src/errors.rs
@@ -214,6 +214,9 @@ pub enum QuickLendXError {
     BatchSizeExceeded = 2208,
     /// Account is frozen and cannot create invoices.
     AccountIsFrozen = 2209,
+    /// A contract upgrade is pending (scheduled but not yet executed or cancelled).
+    /// All writable entrypoints are blocked until the upgrade is resolved.
+    UpgradePending = 2211,
 }
 
 impl From<QuickLendXError> for Symbol {
@@ -321,6 +324,7 @@ impl From<QuickLendXError> for Symbol {
             QuickLendXError::UnstableCursor => symbol_short!("STBL_CUR"),
             QuickLendXError::BatchSizeExceeded => symbol_short!("BAT_MAX"),
             QuickLendXError::AccountIsFrozen => symbol_short!("ACCT_FRZ"),
+            QuickLendXError::UpgradePending => symbol_short!("UPG_PND"),
         }
     }
 }

--- a/quicklendx-contracts/src/events.rs
+++ b/quicklendx-contracts/src/events.rs
@@ -1553,3 +1553,29 @@ pub fn treasury_rotation_cancelled(env: &Env, admin: &Address) {
         (),
     );
 }
+
+// ── Upgrade events ──────────────────────────────────────────────────────────
+
+/// Emitted when an admin schedules a WASM contract upgrade.
+pub fn emit_upgrade_scheduled(env: &Env, admin: &Address, wasm_hash: &BytesN<32>) {
+    env.events().publish(
+        (symbol_short!("upg_sch"),),
+        (admin.clone(), wasm_hash.clone(), env.ledger().timestamp()),
+    );
+}
+
+/// Emitted when an admin cancels a pending WASM upgrade.
+pub fn emit_upgrade_cancelled(env: &Env, admin: &Address, wasm_hash: &BytesN<32>) {
+    env.events().publish(
+        (symbol_short!("upg_can"),),
+        (admin.clone(), wasm_hash.clone()),
+    );
+}
+
+/// Emitted when a pending WASM upgrade is executed (contract code replaced).
+pub fn emit_upgrade_executed(env: &Env, admin: &Address, wasm_hash: &BytesN<32>) {
+    env.events().publish(
+        (symbol_short!("upg_exe"),),
+        (admin.clone(), wasm_hash.clone()),
+    );
+}

--- a/quicklendx-contracts/src/lib.rs
+++ b/quicklendx-contracts/src/lib.rs
@@ -349,6 +349,7 @@ mod test_tier_boundary;
 mod test_verification_matrix;
 pub mod types;
 pub use types::*;
+pub mod upgrade;
 pub mod verification;
 pub mod vesting;
 use admin::require_not_self;
@@ -4781,6 +4782,23 @@ impl QuickLendXContract {
     }
 }
 
+// ── Upgrade control entrypoints ─────────────────────────────────────────────
+
+#[contractimpl]
+impl QuickLendXContract {
+    pub fn schedule_upgrade(env: Env, admin: Address, wasm_hash: BytesN<32>) -> Result<(), QuickLendXError> {
+        upgrade::UpgradeControl::schedule_upgrade(&env, &admin, &wasm_hash)
+    }
+
+    pub fn cancel_upgrade(env: Env, admin: Address) -> Result<(), QuickLendXError> {
+        upgrade::UpgradeControl::cancel_upgrade(&env, &admin)
+    }
+
+    pub fn execute_upgrade(env: Env, admin: Address) -> Result<(), QuickLendXError> {
+        upgrade::UpgradeControl::execute_upgrade(&env, &admin)
+    }
+}
+
 // =============================================================================
 // Feature-gated contract entrypoints
 // =============================================================================
@@ -4822,6 +4840,9 @@ mod test_view_only;
 
 #[cfg(test)]
 mod test_business_freeze_reason;
+
+#[cfg(test)]
+mod test_upgrade_guard;
 
 #[cfg(all(test, feature = "fuzz-tests"))]
 mod test_fuzz_accounting;

--- a/quicklendx-contracts/src/maintenance.rs
+++ b/quicklendx-contracts/src/maintenance.rs
@@ -121,10 +121,10 @@ impl MaintenanceControl {
     /// Guard for state-mutating operations.
     pub fn require_write_allowed(env: &Env) -> Result<(), QuickLendXError> {
         if Self::is_maintenance_mode(env) {
-            Err(QuickLendXError::MaintenanceModeActive)
-        } else {
-            Ok(())
+            return Err(QuickLendXError::MaintenanceModeActive);
         }
+        crate::upgrade::UpgradeControl::require_no_pending_upgrade(env)?;
+        Ok(())
     }
 
     /// Admin-only: extends the TTL for all major persistent storage indexes.

--- a/quicklendx-contracts/src/pause.rs
+++ b/quicklendx-contracts/src/pause.rs
@@ -65,6 +65,8 @@ impl PauseControl {
         if Self::is_paused(env) {
             return Err(QuickLendXError::ContractPaused);
         }
+        // Also block writes while an upgrade is pending (defence-in-depth).
+        crate::upgrade::UpgradeControl::require_no_pending_upgrade(env)?;
         Ok(())
     }
 

--- a/quicklendx-contracts/src/test_upgrade_guard.rs
+++ b/quicklendx-contracts/src/test_upgrade_guard.rs
@@ -1,0 +1,101 @@
+#![cfg(test)]
+
+use crate::errors::QuickLendXError;
+use crate::pause::PauseControl;
+use crate::upgrade::UpgradeControl;
+use soroban_sdk::{testutils::Address as _, Address, BytesN, Env, Wasm};
+
+fn setup_test() -> (Env, Address, BytesN<32>) {
+    let env = Env::default();
+    let admin = Address::generate(&env);
+    let wasm_hash = env.deployer().upload_contract_wasm(Wasm::from(&[]));
+
+    // Register admin
+    crate::admin::AdminStorage::set_admin(&env, &admin);
+
+    (env, admin, wasm_hash)
+}
+
+#[test]
+fn test_schedule_and_cancel_upgrade() {
+    let (env, admin, wasm_hash) = setup_test();
+
+    // Schedule upgrade
+    UpgradeControl::schedule_upgrade(&env, &admin, &wasm_hash).unwrap();
+    assert!(UpgradeControl::is_pending_upgrade(&env));
+    assert!(PauseControl::is_paused(&env));
+
+    // Cancel upgrade
+    UpgradeControl::cancel_upgrade(&env, &admin).unwrap();
+    assert!(!UpgradeControl::is_pending_upgrade(&env));
+    assert!(!PauseControl::is_paused(&env));
+}
+
+#[test]
+fn test_schedule_and_execute_upgrade() {
+    let (env, admin, wasm_hash) = setup_test();
+
+    // Schedule upgrade
+    UpgradeControl::schedule_upgrade(&env, &admin, &wasm_hash).unwrap();
+    assert!(UpgradeControl::is_pending_upgrade(&env));
+
+    // Execute upgrade
+    UpgradeControl::execute_upgrade(&env, &admin).unwrap();
+    assert!(!UpgradeControl::is_pending_upgrade(&env));
+    assert!(!PauseControl::is_paused(&env));
+}
+
+#[test]
+fn test_cannot_write_while_upgrade_pending() {
+    let (env, admin, wasm_hash) = setup_test();
+
+    // Schedule an upgrade
+    UpgradeControl::schedule_upgrade(&env, &admin, &wasm_hash).unwrap();
+
+    // Try to call require_not_paused – should return UpgradePending error
+    let err = PauseControl::require_not_paused(&env).unwrap_err();
+    assert_eq!(err, QuickLendXError::UpgradePending);
+}
+
+#[test]
+fn test_schedule_twice_fails() {
+    let (env, admin, wasm_hash) = setup_test();
+
+    UpgradeControl::schedule_upgrade(&env, &admin, &wasm_hash).unwrap();
+
+    let err = UpgradeControl::schedule_upgrade(&env, &admin, &wasm_hash).unwrap_err();
+    assert_eq!(err, QuickLendXError::OperationNotAllowed);
+}
+
+#[test]
+fn test_cancel_without_schedule_fails() {
+    let (env, admin, _) = setup_test();
+
+    let err = UpgradeControl::cancel_upgrade(&env, &admin).unwrap_err();
+    assert_eq!(err, QuickLendXError::OperationNotAllowed);
+}
+
+#[test]
+fn test_execute_without_schedule_fails() {
+    let (env, admin, _) = setup_test();
+
+    let err = UpgradeControl::execute_upgrade(&env, &admin).unwrap_err();
+    assert_eq!(err, QuickLendXError::OperationNotAllowed);
+}
+
+#[test]
+fn test_non_admin_cannot_schedule() {
+    let env = Env::default();
+    let admin = Address::generate(&env);
+    let non_admin = Address::generate(&env);
+    let wasm_hash = env.deployer().upload_contract_wasm(Wasm::from(&[]));
+
+    crate::admin::AdminStorage::set_admin(&env, &admin);
+
+    let err = UpgradeControl::schedule_upgrade(&env, &non_admin, &wasm_hash).unwrap_err();
+    // Either NotAdmin from admin check or auth failure
+    assert!(matches!(
+        err,
+        QuickLendXError::NotAdmin | QuickLendXError::OperationNotAllowed
+    ));
+}

--- a/quicklendx-contracts/src/upgrade.rs
+++ b/quicklendx-contracts/src/upgrade.rs
@@ -1,0 +1,138 @@
+//! Contract upgrade control: schedule, cancel, and execute WASM upgrades.
+//!
+//! When an upgrade is scheduled the contract enters a read-only state:
+//! all writable entrypoints are blocked until the upgrade is either
+//! executed or cancelled.  This prevents state mutations between the
+//! decision to upgrade and the actual code replacement, avoiding
+//! data-format or storage-key incompatibilities between versions.
+
+use crate::admin::AdminStorage;
+use crate::errors::QuickLendXError;
+use soroban_sdk::{symbol_short, Address, BytesN, Env, Symbol};
+
+const PENDING_UPGRADE_WASM_KEY: Symbol = symbol_short!("upg_wasm");
+const PENDING_UPGRADE_AT_KEY: Symbol = symbol_short!("upg_at");
+
+pub struct UpgradeControl;
+
+impl UpgradeControl {
+    /// Check whether a contract upgrade is currently pending.
+    pub fn is_pending_upgrade(env: &Env) -> bool {
+        env.storage().instance().has(&PENDING_UPGRADE_WASM_KEY)
+    }
+
+    /// Get the pending upgrade details, if any.
+    ///
+    /// Returns `(wasm_hash, scheduled_at)` when an upgrade is pending,
+    /// or `None` when no upgrade is scheduled.
+    pub fn get_pending_upgrade(
+        env: &Env,
+    ) -> Option<(BytesN<32>, u64)> {
+        let wasm_hash: BytesN<32> =
+            env.storage().instance().get(&PENDING_UPGRADE_WASM_KEY)?;
+        let scheduled_at: u64 = env
+            .storage()
+            .instance()
+            .get(&PENDING_UPGRADE_AT_KEY)
+            .unwrap_or(0);
+        Some((wasm_hash, scheduled_at))
+    }
+
+    /// Guard: return `Err(UpgradePending)` when a contract upgrade has
+    /// been scheduled but not yet executed or cancelled.
+    pub fn require_no_pending_upgrade(env: &Env) -> Result<(), QuickLendXError> {
+        if Self::is_pending_upgrade(env) {
+            return Err(QuickLendXError::UpgradePending);
+        }
+        Ok(())
+    }
+
+    /// Schedule a WASM upgrade.
+    ///
+    /// Stores the new WASM hash and records the current ledger timestamp.
+    /// After this call all writable entrypoints are blocked until
+    /// [`execute_upgrade`] or [`cancel_upgrade`] is called.
+    ///
+    /// # Arguments
+    /// * `env` — The contract environment.
+    /// * `admin` — The current contract admin (must sign).
+    /// * `wasm_hash` — 32-byte hash of the new WASM blob.
+    pub fn schedule_upgrade(
+        env: &Env,
+        admin: &Address,
+        wasm_hash: &BytesN<32>,
+    ) -> Result<(), QuickLendXError> {
+        admin.require_auth();
+        AdminStorage::require_admin(env, admin)?;
+
+        if Self::is_pending_upgrade(env) {
+            return Err(QuickLendXError::OperationNotAllowed);
+        }
+
+        env.storage()
+            .instance()
+            .set(&PENDING_UPGRADE_WASM_KEY, wasm_hash);
+        env.storage()
+            .instance()
+            .set(&PENDING_UPGRADE_AT_KEY, &env.ledger().timestamp());
+
+        // Auto-pause: block state mutations until the upgrade is resolved.
+        crate::pause::PauseControl::apply_paused(env, true);
+
+        crate::events::emit_upgrade_scheduled(env, admin, wasm_hash);
+        Ok(())
+    }
+
+    /// Cancel a pending upgrade without executing it.
+    ///
+    /// Clears the upgrade state and un-pauses the contract so normal
+    /// operations can resume.
+    pub fn cancel_upgrade(env: &Env, admin: &Address) -> Result<(), QuickLendXError> {
+        admin.require_auth();
+        AdminStorage::require_admin(env, admin)?;
+
+        if !Self::is_pending_upgrade(env) {
+            return Err(QuickLendXError::OperationNotAllowed);
+        }
+
+        let wasm_hash: BytesN<32> = env
+            .storage()
+            .instance()
+            .get(&PENDING_UPGRADE_WASM_KEY)
+            .unwrap();
+        env.storage().instance().remove(&PENDING_UPGRADE_WASM_KEY);
+        env.storage().instance().remove(&PENDING_UPGRADE_AT_KEY);
+
+        // Restore write access.
+        crate::pause::PauseControl::apply_paused(env, false);
+
+        crate::events::emit_upgrade_cancelled(env, admin, &wasm_hash);
+        Ok(())
+    }
+
+    /// Execute a pending WASM upgrade.
+    ///
+    /// Replaces the contract code with the new WASM blob identified by
+    /// the hash stored during [`schedule_upgrade`].  After this call the
+    /// contract runs the new code and writes are re-enabled.
+    pub fn execute_upgrade(env: &Env, admin: &Address) -> Result<(), QuickLendXError> {
+        admin.require_auth();
+        AdminStorage::require_admin(env, admin)?;
+
+        let wasm_hash: BytesN<32> = env
+            .storage()
+            .instance()
+            .get(&PENDING_UPGRADE_WASM_KEY)
+            .ok_or(QuickLendXError::OperationNotAllowed)?;
+
+        env.storage().instance().remove(&PENDING_UPGRADE_WASM_KEY);
+        env.storage().instance().remove(&PENDING_UPGRADE_AT_KEY);
+        crate::pause::PauseControl::apply_paused(env, false);
+
+        crate::events::emit_upgrade_executed(env, admin, &wasm_hash);
+
+        env.deployer().update_current_contract_wasm(wasm_hash.clone());
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
Closes #1922

## Summary

When an admin schedules a WASM upgrade, the contract now auto-pauses all writable entrypoints until the upgrade is either executed or cancelled. This prevents state mutations between the decision to upgrade and the actual code replacement, avoiding data-format or storage-key incompatibilities between versions.

## Changes

- **New `upgrade.rs` module** — `UpgradeControl` with three admin-only entrypoints:
  - `schedule_upgrade(wasm_hash)` — stores the pending hash and timestamp, auto-pauses
  - `cancel_upgrade()` — clears pending state, un-pauses
  - `execute_upgrade()` — replaces contract WASM via `update_current_contract_wasm`, un-pauses
- **`errors.rs`** — new `UpgradePending` (code 2211) error variant
- **`events.rs`** — 3 new event emitters: `emit_upgrade_scheduled`, `emit_upgrade_cancelled`, `emit_upgrade_executed`
- **`maintenance.rs`** — `require_write_allowed` now also checks `UpgradeControl::require_no_pending_upgrade`
- **`pause.rs`** — `require_not_paused` now also checks `UpgradeControl::require_no_pending_upgrade` (defence-in-depth)
- **`lib.rs`** — exposed `pub mod upgrade` and 3 new contract entrypoints
- **`test_upgrade_guard.rs`** — 7 unit tests covering the full lifecycle

## Design

When `schedule_upgrade` is called:
1. The WASM hash and ledger timestamp are durably stored
2. `PauseControl::apply_paused(true)` is called, setting the pause flag
3. Both `require_write_allowed` (maintenance) and `require_not_paused` (pause) reject calls with `UpgradePending`
4. Only `cancel_upgrade` or `execute_upgrade` can un-pause and clear the pending state

## Testing

7 unit tests in `test_upgrade_guard.rs`:
- `test_schedule_and_cancel_upgrade`
- `test_schedule_and_execute_upgrade`
- `test_cannot_write_while_upgrade_pending`
- `test_schedule_twice_fails`
- `test_cancel_without_schedule_fails`
- `test_execute_without_schedule_fails`
- `test_non_admin_cannot_schedule`