### PR TITLE
test: cover ratings_snapshot determinism and missing-invoice error path

### DIFF
--- a/quicklendx-contracts/src/lib.rs
+++ b/quicklendx-contracts/src/lib.rs
@@ -4927,6 +4927,9 @@ mod test_business_freeze_reason;
 #[cfg(test)]
 mod test_upgrade_guard;
 
+#[cfg(test)]
+mod test_ratings_snapshot;
+
 #[cfg(all(test, feature = "fuzz-tests"))]
 mod test_fuzz_accounting;
 

--- a/quicklendx-contracts/src/test_ratings_snapshot.rs
+++ b/quicklendx-contracts/src/test_ratings_snapshot.rs
@@ -1,8 +1,9 @@
 #![cfg(test)]
 
-use crate::{QuickLendXContract, QuickLendXContractClient};
+use crate::errors::QuickLendXError;
 use crate::types::{InvoiceCategory, RatingsSnapshot, RATINGS_SNAPSHOT_SCHEMA_VERSION};
-use soroban_sdk::{testutils::Address as _, Address, Env, String, Vec};
+use crate::{QuickLendXContract, QuickLendXContractClient};
+use soroban_sdk::{testutils::Address as _, Address, BytesN, Env, String, Vec};
 
 #[test]
 fn test_ratings_snapshot_lifecycle() {
@@ -68,4 +69,105 @@ fn test_ratings_snapshot_lifecycle() {
     assert_eq!(snapshot.highest_rating, Some(5));
     assert_eq!(snapshot.lowest_rating, Some(5));
     assert_eq!(snapshot.ledger_sequence, 12345);
+}
+
+/// Same invoice state, called repeatedly, must yield an identical snapshot:
+/// deterministic input to output with no hidden state (e.g. randomness or
+/// wall-clock reads) leaking into the result.
+#[test]
+fn test_ratings_snapshot_is_deterministic_for_unchanged_state() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, QuickLendXContract);
+    let client = QuickLendXContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    client.initialize(&crate::init::InitializationParams {
+        admin: admin.clone(),
+        treasury: admin.clone(),
+        fee_bps: 100,
+        min_invoice_amount: 100,
+        max_due_date_days: 90,
+        grace_period_seconds: 86400,
+    });
+
+    let business = Address::generate(&env);
+    let investor = Address::generate(&env);
+    let currency = Address::generate(&env);
+
+    client.add_currency(&admin, &currency);
+    client.submit_investor_kyc(&investor);
+    client.verify_investor(&admin, &investor);
+
+    let due_date = env.ledger().timestamp() + 86400 * 30;
+
+    let invoice_id = client.store_invoice(
+        &business,
+        &1000,
+        &currency,
+        &due_date,
+        &String::from_str(&env, "Deterministic Snapshot Invoice"),
+        &InvoiceCategory::Services,
+        &Vec::new(&env),
+    );
+
+    client.verify_invoice(&admin, &invoice_id);
+    client.accept_bid_and_fund(&investor, &invoice_id, &1000, &1050, &0, &false, &admin);
+    client.add_invoice_rating(&invoice_id, &4, &String::from_str(&env, "Solid"), &investor);
+
+    env.ledger().with_mut(|l| {
+        l.sequence = 777;
+    });
+
+    // Calling the entrypoint multiple times with no state change in between
+    // must return byte-for-byte equal snapshots.
+    let first: RatingsSnapshot = client.ratings_snapshot(&invoice_id);
+    let second: RatingsSnapshot = client.ratings_snapshot(&invoice_id);
+    let third: RatingsSnapshot = client.ratings_snapshot(&invoice_id);
+
+    assert_eq!(first, second);
+    assert_eq!(second, third);
+
+    // Pin down every field explicitly so a future regression that changes
+    // only one field (rather than making the whole struct diverge) is
+    // still caught.
+    assert_eq!(first.schema_version, RATINGS_SNAPSHOT_SCHEMA_VERSION);
+    assert_eq!(first.invoice_id, invoice_id);
+    assert_eq!(first.average_rating, Some(4));
+    assert_eq!(first.total_ratings, 1);
+    assert_eq!(first.highest_rating, Some(4));
+    assert_eq!(first.lowest_rating, Some(4));
+    assert_eq!(first.ledger_sequence, 777);
+}
+
+/// A snapshot request for an invoice that was never stored must fail with
+/// `InvoiceNotFound` rather than panicking or returning a default/empty
+/// snapshot — the explicit sad path for the deterministic-snapshot contract.
+#[test]
+fn test_ratings_snapshot_fails_for_nonexistent_invoice() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, QuickLendXContract);
+    let client = QuickLendXContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    client.initialize(&crate::init::InitializationParams {
+        admin: admin.clone(),
+        treasury: admin.clone(),
+        fee_bps: 100,
+        min_invoice_amount: 100,
+        max_due_date_days: 90,
+        grace_period_seconds: 86400,
+    });
+
+    let missing_invoice_id = BytesN::from_array(&env, &[42u8; 32]);
+    let result = client.try_ratings_snapshot(&missing_invoice_id);
+
+    assert!(result.is_err());
+    assert_eq!(
+        result.unwrap_err().expect("expected contract error"),
+        QuickLendXError::InvoiceNotFound
+    );
 }


### PR DESCRIPTION
Closes #1874

## Summary

Locks in the `ratings_snapshot` contract: same invoice state in, same snapshot out. Also fixes the fact that the existing `test_ratings_snapshot.rs` file was never wired into the crate's module tree, so its one existing test (`test_ratings_snapshot_lifecycle`) was silently dead code and never ran under `cargo test` or CI.

## Changes

### Modified files
- `quicklendx-contracts/src/lib.rs` — added `#[cfg(test)] mod test_ratings_snapshot;` so the test module is actually compiled and run (it was previously present on disk but not declared anywhere, so none of its tests executed).
- `quicklendx-contracts/src/test_ratings_snapshot.rs` — added two new test cases and the imports they need (`QuickLendXError`, `BytesN`).

No production/contract logic was changed — `ratings_snapshot` in `lib.rs` (around line 4175) is untouched; this is test-only.

## Tests added

- `test_ratings_snapshot_is_deterministic_for_unchanged_state` — builds an invoice, funds it, adds a rating, pins the ledger sequence, then calls `ratings_snapshot` three times in a row with no state change in between. Asserts all three results are equal (`RatingsSnapshot` derives `PartialEq`), and explicitly checks every field (`schema_version`, `invoice_id`, `average_rating`, `total_ratings`, `highest_rating`, `lowest_rating`, `ledger_sequence`) so a regression that only changes one field is still caught.
- `test_ratings_snapshot_fails_for_nonexistent_invoice` — the sad path: calls `try_ratings_snapshot` with an invoice id that was never stored and asserts it returns `QuickLendXError::InvoiceNotFound` rather than panicking or returning an empty/default snapshot.

Both tests are fully deterministic: no wall-clock or randomness is used; the ledger sequence is set explicitly via `env.ledger().with_mut(...)`.

## How to test

```
cd quicklendx-contracts
cargo test -p quicklendx-contracts test_ratings_snapshot
```

## Note on current `main` build status

While verifying this change, `cargo check`/`cargo test` on a clean, unmodified `main` failed with ~124 pre-existing compile errors unrelated to this change — most notably a duplicate `set_protocol_limits_full` function definition (one copy missing the `min_investor_tier` parameter added by a separate concurrent change) and a reference to a `QuickLendXError::BatchSizeTooLarge` variant that isn't defined in `errors.rs`. This looks like a merge artifact from unrelated PRs and is out of scope for issue #1874, so it was not touched here — flagging it so a maintainer can address it separately, since it currently blocks the whole crate (including this PR) from compiling in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)