### PR TITLE
feat: add InvestorFreezeReason typed enum with freeze/unfreeze entry points

### DIFF
--- a/quicklendx-contracts/src/errors.rs
+++ b/quicklendx-contracts/src/errors.rs
@@ -111,6 +111,8 @@ pub enum QuickLendXError {
     InvalidKYCStatus = 1604,
     /// BREAKING: Do not renumber this variant. public ABI consumption.
     InvestorNotVerified = 1605,
+    /// BREAKING: Do not renumber this variant. public ABI consumption.
+    InvestorFrozen = 1610,
     BusinessDeleted = 1660,
 
     // Audit (1700-1702)
@@ -263,6 +265,7 @@ impl From<QuickLendXError> for Symbol {
             QuickLendXError::KYCNotFound => symbol_short!("KYC_NF"),
             QuickLendXError::InvalidKYCStatus => symbol_short!("KYC_IS"),
             QuickLendXError::InvestorNotVerified => symbol_short!("INV_NV"),
+            QuickLendXError::InvestorFrozen => symbol_short!("INV_FRZ"),
             QuickLendXError::BusinessDeleted => symbol_short!("BUS_DEL"),
             // Audit
             QuickLendXError::AuditLogNotFound => symbol_short!("AUD_NF"),

--- a/quicklendx-contracts/src/lib.rs
+++ b/quicklendx-contracts/src/lib.rs
@@ -51,6 +51,9 @@ mod test_settlement_history_reconstruction;
 // Issue #1920 — confirm require_regulatory_ok is truly a no-op by default.
 #[cfg(test)]
 mod test_regulatory_gate;
+// Issue #1902 — investor freeze reason typed enum
+#[cfg(test)]
+mod test_investor_freeze_reason;
 use crate::idempotency::{idempotency_exists, idempotency_key, store_idempotency};
 use soroban_sdk::{contract, contractimpl, symbol_short, Address, BytesN, Env, Map, String, Vec};
 
@@ -392,7 +395,7 @@ use verification::{
     calculate_investment_limit, calculate_investor_risk_score, compute_investor_tier,
     determine_investor_tier, get_investor_verification as do_get_investor_verification,
     normalize_tag, recompute_investor_tier, reject_business, reject_investor as do_reject_investor,
-    require_business_not_pending, require_investor_not_pending,
+    require_business_not_pending, require_investor_not_frozen, require_investor_not_pending,
     revoke_investor_kyc as do_revoke_investor_kyc, submit_investor_kyc as do_submit_investor_kyc,
     submit_kyc_application, validate_bid, validate_dispute_evidence, validate_dispute_resolution,
     validate_investor_investment, validate_invoice_metadata, verify_business,
@@ -1534,6 +1537,67 @@ impl QuickLendXContract {
         InvoiceStorage::get_freeze_info(&env, &invoice_id)
     }
 
+    /// Freeze an investor with a specific reason (admin only).
+    ///
+    /// When frozen, the following operations are blocked:
+    /// - `place_bid` → `InvestorFrozen`
+    /// - `withdraw_bid` → `InvestorFrozen`
+    ///
+    /// The freeze reason and metadata are stored alongside the frozen flag
+    /// and are queryable via `get_investor_freeze_info`.
+    ///
+    /// # Arguments
+    /// * `admin`    - Must be the current protocol admin.
+    /// * `investor` - The investor to freeze.
+    /// * `reason`   - An `InvestorFreezeReason` variant describing why.
+    ///
+    /// # Errors
+    /// * `NotAdmin` if the caller is not the current admin.
+    /// * `KYCNotFound` if no investor KYC record exists.
+    pub fn freeze_investor(
+        env: Env,
+        admin: Address,
+        investor: Address,
+        reason: InvestorFreezeReason,
+    ) -> Result<(), QuickLendXError> {
+        AdminStorage::require_admin(&env, &admin)?;
+        // Verify the investor has a KYC record before freezing.
+        InvestorVerificationStorage::get(&env, &investor)
+            .ok_or(QuickLendXError::KYCNotFound)?;
+
+        let info = InvestorFreezeInfo {
+            reason,
+            frozen_by: admin.clone(),
+            frozen_at: env.ledger().timestamp(),
+        };
+        InvoiceStorage::set_investor_freeze_info(&env, &investor, &info);
+        Ok(())
+    }
+
+    /// Unfreeze a previously frozen investor (admin only).
+    ///
+    /// Removes the stored investor freeze info.
+    /// After unfreezing, all operations resume normal behaviour.
+    ///
+    /// # Errors
+    /// * `NotAdmin` if the caller is not the current admin.
+    pub fn unfreeze_investor(
+        env: Env,
+        admin: Address,
+        investor: Address,
+    ) -> Result<(), QuickLendXError> {
+        AdminStorage::require_admin(&env, &admin)?;
+        InvoiceStorage::remove_investor_freeze_info(&env, &investor);
+        Ok(())
+    }
+
+    /// Return the stored freeze info for an investor, if any.
+    ///
+    /// Returns `None` when the investor is not frozen.
+    pub fn get_investor_freeze_info(env: Env, investor: Address) -> Option<InvestorFreezeInfo> {
+        InvoiceStorage::get_investor_freeze_info(&env, &investor)
+    }
+
     /// Get an invoice by ID.
     ///
     /// # Returns
@@ -1878,6 +1942,7 @@ impl QuickLendXContract {
         pause::PauseControl::require_not_paused(&env)?;
         let mut bid = BidStorage::get_bid(&env, &bid_id).unwrap();
         bid.investor.require_auth();
+        require_investor_not_frozen(&env, &bid.investor)?;
         require_investor_not_pending(&env, &bid.investor)?;
         // Re-read status after auth to guard against concurrent transitions.
         let bid_fresh = BidStorage::get_bid(&env, &bid_id).unwrap();
@@ -1922,6 +1987,8 @@ impl QuickLendXContract {
         // jurisdiction-specific or on-chain oracle-based compliance checks without
         // touching this call site.
         crate::regulatory::require_regulatory_ok(&env, &investor)?;
+        // Reject bids from frozen investors.
+        require_investor_not_frozen(&env, &investor)?;
         // Idempotency check
         let idem_key = idempotency_key(&invoice_id, &investor, &salt, &env);
         if idempotency_exists(&env, &idem_key) {
@@ -2034,6 +2101,7 @@ impl QuickLendXContract {
         let invoice_id = bid.invoice_id.clone();
         BidStorage::cleanup_expired_bids(&env, &invoice_id);
         let mut bid = BidStorage::get_bid(&env, &bid_id).unwrap();
+        require_investor_not_frozen(&env, &bid.investor)?;
         invoice.business.require_auth();
 
         // Enforce business is active (not deleted/frozen).

--- a/quicklendx-contracts/src/storage.rs
+++ b/quicklendx-contracts/src/storage.rs
@@ -7,8 +7,9 @@ use soroban_sdk::{contracttype, symbol_short, Address, BytesN, Env, String, Symb
 
 use crate::protocol_limits;
 use crate::types::{
-    BidStatus, BusinessFreezeReason, InvestmentStatus, Invoice, InvoiceCategory,
-    InvoiceStatus, PlatformFeeConfig, PruneReport, RebuildReport,
+    BidStatus, BusinessFreezeReason, FreezeInfo, InvestmentStatus, InvestorFreezeInfo,
+    Invoice, InvoiceCategory, InvoiceLock, InvoiceStatus, PlatformFeeConfig, PruneReport,
+    RebuildReport,
 };
 
 /// Default TTL threshold for persistent storage (adjust the value as needed)
@@ -59,6 +60,7 @@ pub enum DataKey {
     FrozenInvoice(BytesN<32>),
     FreezeInfo(BytesN<32>),
     EscrowExtension(BytesN<32>),
+    InvestorFreezeInfo(Address),
 }
 
 impl StorageKeys {
@@ -317,6 +319,41 @@ impl InvoiceStorage {
     ) -> Option<BusinessFreezeReason> {
         let key = DataKey::FrozenInvoice(invoice_id.clone());
         env.storage().persistent().get(&key)
+    }
+
+    pub fn is_frozen(env: &Env, invoice_id: &BytesN<32>) -> bool {
+        Self::get_invoice_lock(env, invoice_id).is_locked()
+    }
+
+    pub fn set_frozen(env: &Env, invoice_id: &BytesN<32>, frozen: bool) {
+        if frozen {
+            Self::set_invoice_lock(env, invoice_id, InvoiceLock::Frozen);
+        } else {
+            Self::set_invoice_lock(env, invoice_id, InvoiceLock::None);
+        }
+    }
+
+    pub fn set_investor_freeze_info(env: &Env, investor: &Address, info: &InvestorFreezeInfo) {
+        let key = DataKey::InvestorFreezeInfo(investor.clone());
+        env.storage().persistent().set(&key, info);
+        extend_persistent_ttl(env, &key);
+    }
+
+    pub fn get_investor_freeze_info(
+        env: &Env,
+        investor: &Address,
+    ) -> Option<InvestorFreezeInfo> {
+        let key = DataKey::InvestorFreezeInfo(investor.clone());
+        let result = env.storage().persistent().get::<_, InvestorFreezeInfo>(&key);
+        if result.is_some() {
+            extend_persistent_ttl(env, &key);
+        }
+        result
+    }
+
+    pub fn remove_investor_freeze_info(env: &Env, investor: &Address) {
+        let key = DataKey::InvestorFreezeInfo(investor.clone());
+        env.storage().persistent().remove(&key);
     }
 
     pub fn get_by_business(env: &Env, business: &Address) -> Vec<BytesN<32>> {

--- a/quicklendx-contracts/src/test_investor_freeze_reason.rs
+++ b/quicklendx-contracts/src/test_investor_freeze_reason.rs
@@ -1,0 +1,385 @@
+#![cfg(test)]
+
+use crate::errors::QuickLendXError;
+use crate::types::InvestorFreezeReason;
+use soroban_sdk::testutils::{Address as _, Ledger};
+use soroban_sdk::{token, Address, BytesN, Env, String, Vec};
+
+fn setup_env() -> (Env, crate::QuickLendXContractClient<'static>, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(crate::QuickLendXContract, ());
+    let client = crate::QuickLendXContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    client.set_admin(&admin);
+    (env, client, admin)
+}
+
+fn setup_investor(env: &Env, client: &crate::QuickLendXContractClient, limit: i128) -> Address {
+    let investor = Address::generate(env);
+    client.submit_investor_kyc(&investor, &String::from_str(env, "Investor KYC"));
+    client.verify_investor(&investor, &limit);
+    investor
+}
+
+fn setup_business(env: &Env, client: &crate::QuickLendXContractClient, admin: &Address) -> Address {
+    let business = Address::generate(env);
+    client.submit_kyc_application(&business, &String::from_str(env, "Business KYC"));
+    client.verify_business(admin, &business);
+    business
+}
+
+fn setup_currency(
+    env: &Env,
+    client: &crate::QuickLendXContractClient,
+    admin: &Address,
+    business: &Address,
+) -> Address {
+    let token_admin = Address::generate(env);
+    let currency = env
+        .register_stellar_asset_contract_v2(token_admin.clone())
+        .address();
+    let sac = token::StellarAssetClient::new(env, &currency);
+    let tok = token::Client::new(env, &currency);
+    let initial = 100_000i128;
+    sac.mint(business, &initial);
+    let expiry = env.ledger().sequence() + 10_000;
+    tok.approve(business, &client.address, &initial, &expiry);
+    client.add_currency(admin, &currency);
+    currency
+}
+
+fn setup_invoice(
+    env: &Env,
+    client: &crate::QuickLendXContractClient,
+    admin: &Address,
+    business: &Address,
+) -> (BytesN<32>, Address) {
+    let currency = setup_currency(env, client, admin, business);
+    let due = env.ledger().timestamp() + 86_400;
+    let invoice_id = client.upload_invoice(
+        business,
+        &1_000i128,
+        &currency,
+        &due,
+        &String::from_str(env, "test invoice"),
+        &crate::invoice::InvoiceCategory::Services,
+        &Vec::new(env),
+    );
+    (invoice_id, currency)
+}
+
+fn fund_user(
+    env: &Env,
+    client: &crate::QuickLendXContractClient,
+    currency: &Address,
+    user: &Address,
+    amount: i128,
+) {
+    let sac = token::StellarAssetClient::new(env, currency);
+    let tok = token::Client::new(env, currency);
+    sac.mint(user, &amount);
+    let expiry = env.ledger().sequence() + 10_000;
+    tok.approve(user, &client.address, &amount, &expiry);
+}
+
+// ============================================================================
+// Happy path — each freeze variant can be stored and retrieved
+// ============================================================================
+
+#[test]
+fn test_freeze_investor_admin_action() {
+    let (env, client, admin) = setup_env();
+    let investor = setup_investor(&env, &client, 10_000);
+
+    client.freeze_investor(&admin, &investor, &InvestorFreezeReason::AdminAction);
+
+    let info = client.get_investor_freeze_info(&investor).unwrap();
+    assert_eq!(info.reason, InvestorFreezeReason::AdminAction);
+    assert_eq!(info.frozen_by, admin);
+}
+
+#[test]
+fn test_freeze_investor_kyc_expired() {
+    let (env, client, admin) = setup_env();
+    let investor = setup_investor(&env, &client, 10_000);
+
+    client.freeze_investor(&admin, &investor, &InvestorFreezeReason::KYCExpired);
+
+    let info = client.get_investor_freeze_info(&investor).unwrap();
+    assert_eq!(info.reason, InvestorFreezeReason::KYCExpired);
+}
+
+#[test]
+fn test_freeze_investor_compliance_violation() {
+    let (env, client, admin) = setup_env();
+    let investor = setup_investor(&env, &client, 10_000);
+
+    client.freeze_investor(
+        &admin,
+        &investor,
+        &InvestorFreezeReason::ComplianceViolation,
+    );
+
+    let info = client.get_investor_freeze_info(&investor).unwrap();
+    assert_eq!(info.reason, InvestorFreezeReason::ComplianceViolation);
+}
+
+#[test]
+fn test_freeze_investor_suspicious_activity() {
+    let (env, client, admin) = setup_env();
+    let investor = setup_investor(&env, &client, 10_000);
+
+    client.freeze_investor(
+        &admin,
+        &investor,
+        &InvestorFreezeReason::SuspiciousActivity,
+    );
+
+    let info = client.get_investor_freeze_info(&investor).unwrap();
+    assert_eq!(info.reason, InvestorFreezeReason::SuspiciousActivity);
+}
+
+#[test]
+fn test_freeze_investor_legal_hold() {
+    let (env, client, admin) = setup_env();
+    let investor = setup_investor(&env, &client, 10_000);
+
+    client.freeze_investor(&admin, &investor, &InvestorFreezeReason::LegalHold);
+
+    let info = client.get_investor_freeze_info(&investor).unwrap();
+    assert_eq!(info.reason, InvestorFreezeReason::LegalHold);
+}
+
+// ============================================================================
+// Freeze blocks operations
+// ============================================================================
+
+#[test]
+fn test_freeze_blocks_place_bid() {
+    let (env, client, admin) = setup_env();
+    let business = setup_business(&env, &client, &admin);
+    let (invoice_id, _) = setup_invoice(&env, &client, &admin, &business);
+    let investor = setup_investor(&env, &client, 10_000);
+
+    client.verify_invoice(&invoice_id);
+
+    client.freeze_investor(&admin, &investor, &InvestorFreezeReason::KYCExpired);
+
+    let result = client.try_place_bid(
+        &investor,
+        &invoice_id,
+        &900i128,
+        &950i128,
+        &BytesN::from_array(&env, &[0u8; 32]),
+    );
+    assert!(result.is_err());
+    assert_eq!(result.unwrap_err().unwrap(), QuickLendXError::InvestorFrozen);
+}
+
+#[test]
+fn test_freeze_blocks_withdraw_bid() {
+    let (env, client, admin) = setup_env();
+    let business = setup_business(&env, &client, &admin);
+    let (invoice_id, _) = setup_invoice(&env, &client, &admin, &business);
+    let investor = setup_investor(&env, &client, 10_000);
+
+    client.verify_invoice(&invoice_id);
+
+    let bid_id = client.place_bid(
+        &investor,
+        &invoice_id,
+        &900i128,
+        &950i128,
+        &BytesN::from_array(&env, &[0u8; 32]),
+    );
+
+    client.freeze_investor(&admin, &investor, &InvestorFreezeReason::AdminAction);
+
+    let result = client.try_withdraw_bid(&bid_id);
+    assert!(result.is_err());
+    assert_eq!(result.unwrap_err().unwrap(), QuickLendXError::InvestorFrozen);
+}
+
+#[test]
+fn test_freeze_blocks_accept_bid() {
+    let (env, client, admin) = setup_env();
+    let business = setup_business(&env, &client, &admin);
+    let (invoice_id, currency) = setup_invoice(&env, &client, &admin, &business);
+    let investor = setup_investor(&env, &client, 10_000);
+
+    client.verify_invoice(&invoice_id);
+    fund_user(&env, &client, &currency, &investor, 10_000);
+
+    let bid_id = client.place_bid(
+        &investor,
+        &invoice_id,
+        &900i128,
+        &950i128,
+        &BytesN::from_array(&env, &[0u8; 32]),
+    );
+
+    client.freeze_investor(&admin, &investor, &InvestorFreezeReason::AdminAction);
+
+    let result = client.try_accept_bid(&invoice_id, &bid_id);
+    assert!(result.is_err());
+    assert_eq!(result.unwrap_err().unwrap(), QuickLendXError::InvestorFrozen);
+}
+
+// ============================================================================
+// Unfreeze restores operations
+// ============================================================================
+
+#[test]
+fn test_unfreeze_investor_restores_bid() {
+    let (env, client, admin) = setup_env();
+    let business = setup_business(&env, &client, &admin);
+    let (invoice_id, _) = setup_invoice(&env, &client, &admin, &business);
+    let investor = setup_investor(&env, &client, 10_000);
+
+    client.verify_invoice(&invoice_id);
+
+    client.freeze_investor(&admin, &investor, &InvestorFreezeReason::KYCExpired);
+    assert!(client.get_investor_freeze_info(&investor).is_some());
+
+    client.unfreeze_investor(&admin, &investor);
+    assert!(client.get_investor_freeze_info(&investor).is_none());
+
+    let result = client.try_place_bid(
+        &investor,
+        &invoice_id,
+        &900i128,
+        &950i128,
+        &BytesN::from_array(&env, &[0u8; 32]),
+    );
+    assert!(result.is_ok());
+}
+
+// ============================================================================
+// Sad path — non-admin cannot freeze
+// ============================================================================
+
+#[test]
+fn test_freeze_investor_requires_admin() {
+    let (env, client, admin) = setup_env();
+    let investor = setup_investor(&env, &client, 10_000);
+
+    let non_admin = Address::generate(&env);
+    let result = client.try_freeze_investor(
+        &non_admin,
+        &investor,
+        &InvestorFreezeReason::AdminAction,
+    );
+    assert!(result.is_err());
+}
+
+// ============================================================================
+// Sad path — freeze on non-existent investor
+// ============================================================================
+
+#[test]
+fn test_freeze_nonexistent_investor() {
+    let (env, client, admin) = setup_env();
+    let fake_investor = Address::generate(&env);
+
+    let result = client.try_freeze_investor(
+        &admin,
+        &fake_investor,
+        &InvestorFreezeReason::AdminAction,
+    );
+    assert!(result.is_err());
+    assert_eq!(
+        result.unwrap_err().unwrap(),
+        QuickLendXError::KYCNotFound
+    );
+}
+
+// ============================================================================
+// Query — get_investor_freeze_info returns None for non-frozen investors
+// ============================================================================
+
+#[test]
+fn test_get_freeze_info_none_when_not_frozen() {
+    let (env, client, admin) = setup_env();
+    let investor = setup_investor(&env, &client, 10_000);
+
+    let info = client.get_investor_freeze_info(&investor);
+    assert!(info.is_none());
+}
+
+#[test]
+fn test_get_freeze_info_none_after_unfreeze() {
+    let (env, client, admin) = setup_env();
+    let investor = setup_investor(&env, &client, 10_000);
+
+    client.freeze_investor(&admin, &investor, &InvestorFreezeReason::LegalHold);
+    assert!(client.get_investor_freeze_info(&investor).is_some());
+
+    client.unfreeze_investor(&admin, &investor);
+    assert!(client.get_investor_freeze_info(&investor).is_none());
+}
+
+// ============================================================================
+// Freeze info contains correct metadata
+// ============================================================================
+
+#[test]
+fn test_freeze_info_includes_timestamp() {
+    let (env, client, admin) = setup_env();
+    let investor = setup_investor(&env, &client, 10_000);
+    let now = env.ledger().timestamp();
+
+    client.freeze_investor(
+        &admin,
+        &investor,
+        &InvestorFreezeReason::SuspiciousActivity,
+    );
+
+    let info = client.get_investor_freeze_info(&investor).unwrap();
+    assert_eq!(info.frozen_by, admin);
+    assert!(info.frozen_at >= now);
+    assert_eq!(info.reason, InvestorFreezeReason::SuspiciousActivity);
+}
+
+// ============================================================================
+// Freeze one investor does not affect another
+// ============================================================================
+
+#[test]
+fn test_freeze_investor_does_not_affect_others() {
+    let (env, client, admin) = setup_env();
+    let business = setup_business(&env, &client, &admin);
+    let (invoice_id, _) = setup_invoice(&env, &client, &admin, &business);
+
+    let frozen_investor = setup_investor(&env, &client, 10_000);
+    let active_investor = setup_investor(&env, &client, 10_000);
+
+    client.freeze_investor(
+        &admin,
+        &frozen_investor,
+        &InvestorFreezeReason::KYCExpired,
+    );
+
+    client.verify_invoice(&invoice_id);
+
+    // Frozen investor cannot bid
+    let result = client.try_place_bid(
+        &frozen_investor,
+        &invoice_id,
+        &500i128,
+        &550i128,
+        &BytesN::from_array(&env, &[0u8; 32]),
+    );
+    assert!(result.is_err());
+    assert_eq!(result.unwrap_err().unwrap(), QuickLendXError::InvestorFrozen);
+
+    // Active investor can still bid
+    let result = client.try_place_bid(
+        &active_investor,
+        &invoice_id,
+        &500i128,
+        &550i128,
+        &BytesN::from_array(&env, &[0u8; 32]),
+    );
+    assert!(result.is_ok());
+}

--- a/quicklendx-contracts/src/types.rs
+++ b/quicklendx-contracts/src/types.rs
@@ -191,6 +191,31 @@ pub struct FreezeInfo {
     pub frozen_at: u64,
 }
 
+/// Freeze reason enumeration representing why an investor was frozen.
+#[contracttype]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum InvestorFreezeReason {
+    /// Generic administrative freeze (admin's discretion)
+    AdminAction,
+    /// Investor KYC has expired
+    KYCExpired,
+    /// Legal or compliance policy violation
+    ComplianceViolation,
+    /// Fraud or suspicious activity detected
+    SuspiciousActivity,
+    /// Court order or legal hold applied
+    LegalHold,
+}
+
+/// Freeze record stored for a frozen investor
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct InvestorFreezeInfo {
+    pub reason: InvestorFreezeReason,
+    pub frozen_by: Address,
+    pub frozen_at: u64,
+}
+
 /// Core Invoice data structure
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/quicklendx-contracts/src/verification.rs
+++ b/quicklendx-contracts/src/verification.rs
@@ -1,5 +1,6 @@
 use crate::bid::BidStorage;
 use crate::errors::QuickLendXError;
+use crate::storage::InvoiceStorage;
 use crate::protocol_limits::{
     check_string_length, ProtocolLimitsContract, MAX_ADDRESS_LENGTH, MAX_DESCRIPTION_LENGTH,
     MAX_DISPUTE_EVIDENCE_LENGTH, MAX_DISPUTE_REASON_LENGTH, MAX_DISPUTE_RESOLUTION_LENGTH,
@@ -1048,6 +1049,20 @@ pub fn require_investor_not_pending(env: &Env, investor: &Address) -> Result<(),
     }
 }
 
+/// Enforce that an investor is not frozen before performing an operation.
+///
+/// A frozen investor must not be allowed to place bids, withdraw bids, or
+/// perform any investment action until unfrozen by an admin.
+///
+/// # Errors
+/// - `InvestorFrozen` if the investor has a freeze record.
+pub fn require_investor_not_frozen(env: &Env, investor: &Address) -> Result<(), QuickLendXError> {
+    if InvoiceStorage::get_investor_freeze_info(env, investor).is_some() {
+        return Err(QuickLendXError::InvestorFrozen);
+    }
+    Ok(())
+}
+
 /// Regulatory compliance gate, reserved for future jurisdiction/sanctions-list
 /// checks (see `docs/contracts/currency-whitelist.md` "Regulatory Compliance").
 ///
@@ -1662,6 +1677,8 @@ pub fn validate_investor_investment(
     investor: &Address,
     investment_amount: i128,
 ) -> Result<(), QuickLendXError> {
+    require_investor_not_frozen(env, investor)?;
+
     let limits = ProtocolLimitsContract::get_protocol_limits(env.clone());
 
     if let Some(verification) = InvestorVerificationStorage::get(env, investor) {


### PR DESCRIPTION
Closes #1902

## Summary

Adds `InvestorFreezeReason` typed enum (`KYCExpired` as the primary use case) with admin-gated freeze/unfreeze entry points for investors, mirroring the `BusinessFreezeReason` pattern added in PR #1905.

## Changes

### New Types
- `InvestorFreezeReason` enum: `AdminAction`, `KYCExpired`, `ComplianceViolation`, `SuspiciousActivity`, `LegalHold`
- `InvestorFreezeInfo` struct: `reason`, `frozen_by`, `frozen_at`

### Storage
- `DataKey::InvestorFreezeInfo(Address)` variant for per-investor freeze records
- `set_investor_freeze_info` / `get_investor_freeze_info` / `remove_investor_freeze_info` methods
- Added previously-missing `set_frozen` / `is_frozen` convenience methods

### Entry Points
- `freeze_investor(admin, investor, reason)`
- `unfreeze_investor(admin, investor)`
- `get_investor_freeze_info(investor)`

### Frozen Checks
- `require_investor_not_frozen` helper in `verification.rs`
- Checked in: `place_bid`, `withdraw_bid`, `accept_bid_impl`, `validate_investor_investment`

## Testing
15 tests in `test_investor_freeze_reason.rs`