### PR TITLE
feat: add investor_default_history counter per investor

### DIFF
--- a/docs/DEFAULT_ACCOUNTING.md
+++ b/docs/DEFAULT_ACCOUNTING.md
@@ -82,6 +82,17 @@ InvestmentStorage::update_investment(env, &investment);
 | `InsuranceClaimed` events (per provider) | `defaults.rs:334-344`, `events.rs:847` | `{ investment_id, invoice_id, provider, coverage_amount }` |
 | `NotificationType::InvoiceDefaulted` | `defaults.rs:351`, `notifications.rs:794` | Delivered to business and investor |
 
+### Default-history counters
+
+`handle_default` also bumps two lightweight, persistent per-address counters — independent of the risk-scoring path in [Section 2](#2-effect-on-investor-rating) below:
+
+| Counter | Storage key | Incremented for | Read via |
+|---|---|---|---|
+| Business default history | `StorageKeys::business_default_history` (`biz_def_h`) | `invoice.business` | `get_business_default_history(business) -> u32` |
+| Investor default history | `StorageKeys::investor_default_history` (`inv_def_h`) | `invoice.investor` (if `Some`, i.e. the invoice was funded) | `get_investor_default_history(investor) -> u32` |
+
+Both counters saturate (never overflow/panic) and increment exactly once per successful default transition, in the same atomic `handle_default` call guarded by the transition guard described above — so they can't double-count on retries.
+
 ---
 
 ## 2. Effect on Investor Rating

--- a/quicklendx-contracts/src/defaults.rs
+++ b/quicklendx-contracts/src/defaults.rs
@@ -355,6 +355,19 @@ pub fn handle_default(env: &Env, invoice_id: &BytesN<32>) -> Result<(), QuickLen
         .set(&history_key, &history_count.saturating_add(1));
     crate::storage::bump_persistent(env, &history_key);
 
+    if let Some(investor) = invoice.investor.clone() {
+        let investor_history_key = crate::storage::StorageKeys::investor_default_history(&investor);
+        let investor_history_count: u32 = env
+            .storage()
+            .persistent()
+            .get(&investor_history_key)
+            .unwrap_or(0);
+        env.storage()
+            .persistent()
+            .set(&investor_history_key, &investor_history_count.saturating_add(1));
+        crate::storage::bump_persistent(env, &investor_history_key);
+    }
+
     emit_invoice_expired(env, &invoice);
 
     if let Some(mut investment) = InvestmentStorage::get_investment_by_invoice(env, invoice_id) {

--- a/quicklendx-contracts/src/lib.rs
+++ b/quicklendx-contracts/src/lib.rs
@@ -1711,6 +1711,16 @@ impl QuickLendXContract {
         env.storage().persistent().get(&key).unwrap_or(0)
     }
 
+    /// Get the total number of defaulted investments for an investor.
+    ///
+    /// Increments each time an invoice funded by this investor transitions to
+    /// `Defaulted` (see `defaults::handle_default`). Mirrors
+    /// `get_business_default_history` on the investor side.
+    pub fn get_investor_default_history(env: Env, investor: Address) -> u32 {
+        let key = crate::storage::StorageKeys::investor_default_history(&investor);
+        env.storage().persistent().get(&key).unwrap_or(0)
+    }
+
     /// Get total invoice count
     pub fn get_total_invoice_count(env: Env) -> u32 {
         let pending = Self::get_invoice_count_by_status(env.clone(), InvoiceStatus::Pending);

--- a/quicklendx-contracts/src/storage.rs
+++ b/quicklendx-contracts/src/storage.rs
@@ -82,10 +82,15 @@ impl StorageKeys {
     pub fn investment_count() -> Symbol {
         symbol_short!("inv_cnt")
     }
-    /// **Storage class**: Persistent  
+    /// **Storage class**: Persistent
     /// **BREAKING**: Renaming `"biz_def_h"` resets the business default history counters.
     pub fn business_default_history(business: &Address) -> (Symbol, Address) {
         (symbol_short!("biz_def_h"), business.clone())
+    }
+    /// **Storage class**: Persistent
+    /// **BREAKING**: Renaming `"inv_def_h"` resets the investor default history counters.
+    pub fn investor_default_history(investor: &Address) -> (Symbol, Address) {
+        (symbol_short!("inv_def_h"), investor.clone())
     }
 }
 

--- a/quicklendx-contracts/src/test_default.rs
+++ b/quicklendx-contracts/src/test_default.rs
@@ -135,6 +135,7 @@ fn test_default_after_grace_period() {
 
     // Mark as defaulted
     assert_eq!(client.get_business_default_history(&business), 0);
+    assert_eq!(client.get_investor_default_history(&investor), 0);
     client.mark_invoice_defaulted(&invoice_id, &Some(grace_period));
 
     // Verify invoice is now defaulted
@@ -143,6 +144,48 @@ fn test_default_after_grace_period() {
 
     // Verify business default history counter incremented
     assert_eq!(client.get_business_default_history(&business), 1);
+
+    // Verify investor default history counter incremented
+    assert_eq!(client.get_investor_default_history(&investor), 1);
+}
+
+/// The investor default counter increments once per defaulted invoice funded
+/// by that investor, and never touches an unrelated investor's counter.
+#[test]
+fn test_investor_default_history_isolated_per_investor() {
+    let (env, client, admin) = setup();
+    let business = create_verified_business(&env, &client, &admin);
+    let investor_a = create_verified_investor(&env, &client, &admin, 10000);
+    let investor_b = create_verified_investor(&env, &client, &admin, 10000);
+
+    let amount = 1000;
+    let due_date = env.ledger().timestamp() + 86400;
+    let grace_period = 7 * 24 * 60 * 60;
+
+    let invoice_a = create_and_fund_invoice(
+        &env, &client, &admin, &business, &investor_a, amount, due_date,
+    );
+    let invoice_b = create_and_fund_invoice(
+        &env, &client, &admin, &business, &investor_b, amount, due_date,
+    );
+
+    let default_time = due_date + grace_period + 1;
+    env.ledger().set_timestamp(default_time);
+
+    assert_eq!(client.get_investor_default_history(&investor_a), 0);
+    assert_eq!(client.get_investor_default_history(&investor_b), 0);
+
+    // Only invoice_a (funded by investor_a) defaults.
+    client.mark_invoice_defaulted(&invoice_a, &Some(grace_period));
+
+    assert_eq!(client.get_investor_default_history(&investor_a), 1);
+    assert_eq!(client.get_investor_default_history(&investor_b), 0);
+
+    // Now default invoice_b too; investor_a's counter must stay unaffected.
+    client.mark_invoice_defaulted(&invoice_b, &Some(grace_period));
+
+    assert_eq!(client.get_investor_default_history(&investor_a), 1);
+    assert_eq!(client.get_investor_default_history(&investor_b), 1);
 }
 
 #[test]

--- a/quicklendx-contracts/src/test_snapshots/storage_keys.txt
+++ b/quicklendx-contracts/src/test_snapshots/storage_keys.txt
@@ -14,6 +14,7 @@ persistent | invoice_count      | inv_count
 persistent | bid_count          | bid_count
 persistent | investment_count   | inv_cnt
 persistent | business_default_history | biz_def_h
+persistent | investor_default_history | inv_def_h
 
 # ── Indexes: invoice secondary indexes ──────────────────────────────────────
 persistent | invoices_by_business          | inv_bus

--- a/quicklendx-contracts/src/test_storage_key_layout.rs
+++ b/quicklendx-contracts/src/test_storage_key_layout.rs
@@ -76,6 +76,16 @@ fn test_storage_key_business_default_history_stable() {
     assert_eq!(sym, symbol_short!("biz_def_h"));
 }
 
+/// STORAGE CLASS: Persistent
+#[test]
+fn test_storage_key_investor_default_history_stable() {
+    let env = setup();
+    assert_snapshot_entry("investor_default_history", "inv_def_h");
+    let addr = Address::generate(&env);
+    let (sym, _) = StorageKeys::investor_default_history(&addr);
+    assert_eq!(sym, symbol_short!("inv_def_h"));
+}
+
 // ---------------------------------------------------------------------------
 // Indexes — invoice secondary indexes (all Persistent)
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #1863

## Summary

Adds a persistent, per-investor default counter that increments each time an invoice funded by that investor transitions to `Defaulted`, exposed via a new view function. Mirrors the existing `business_default_history` pattern exactly.

## New files
- None.

## Modified files
- `quicklendx-contracts/src/storage.rs` — new `StorageKeys::investor_default_history(investor: &Address) -> (Symbol, Address)` key builder (symbol `inv_def_h`), alongside the existing `business_default_history`.
- `quicklendx-contracts/src/defaults.rs` — `handle_default` now also bumps the investor counter (via `invoice.investor`, when `Some`) in the same atomic block as the existing business counter bump, so both are protected by the existing default-transition guard and can't double-count on retries.
- `quicklendx-contracts/src/lib.rs` — new `get_investor_default_history(env, investor) -> u32` view entrypoint, placed next to `get_business_default_history` with matching doc comments.
- `quicklendx-contracts/src/test_snapshots/storage_keys.txt` — records the new `inv_def_h` key so a future silent rename is caught (this file is a checked-in snapshot guarding against orphaning on-chain data; see `docs/storage-key-stability.md`).
- `docs/DEFAULT_ACCOUNTING.md` — new "Default-history counters" subsection documenting both the business and investor counters, their storage keys, and how to read them.

## Test files (modified)
- `quicklendx-contracts/src/test_default.rs`
- `quicklendx-contracts/src/test_storage_key_layout.rs`

## Implementation details

`RatingsSnapshot`-style simplicity: this is a dedicated, lightweight counter — separate from the existing `defaulted_investments` field on `InvestorVerification` (used for risk-score/tier calculations in `verification.rs`). That field already exists but is bundled inside the larger verification record and isn't a simple standalone view. This issue asked for a `business_default_history`-style dedicated counter + view function on the investor side, so it's implemented as its own independent counter rather than reusing/exposing the risk-model field, keeping the change backwards-compatible and additive (no existing behavior changed).

The counter:
- Increments by exactly 1 per successful default transition (`saturating_add`, so it can never overflow/panic).
- Is only incremented when `invoice.investor` is `Some` (i.e., the invoice was actually funded before defaulting — always true for invoices reaching `Funded -> Defaulted`).
- Lives under a `Persistent` storage key, bumped via the existing `bump_persistent` helper for TTL extension, matching the business counter's storage class.

## Tests added

- Extended `test_default_after_grace_period` to assert `get_investor_default_history` is `0` before the default and `1` after, mirroring the existing business-counter assertions in the same test.
- Added `test_investor_default_history_isolated_per_investor`: two investors each fund a separate invoice for the same business; only one invoice is defaulted first (asserting only that investor's counter moves), then the second is defaulted too (asserting the first investor's counter is untouched by the second investor's default). Locks in per-investor isolation.
- Added `test_storage_key_investor_default_history_stable` in `test_storage_key_layout.rs`, asserting `StorageKeys::investor_default_history` produces the exact `inv_def_h` symbol recorded in the checked-in snapshot file — consistent with the existing stability test for `business_default_history`.

## How to test

```
cd quicklendx-contracts
cargo test -p quicklendx-contracts test_default
cargo test -p quicklendx-contracts test_storage_key_investor_default_history_stable
```

## Note on current `main` build status (pre-existing, unrelated to this PR)

`main` currently fails to compile with ~124 errors that predate this branch and are unrelated to this change (confirmed via `git blame`/`git show` on `origin/main` before branching — see PR #2193 for the same finding and full evidence). The main culprits: a duplicate `BusinessFreezeReason` enum (`types.rs`, from two independently-merged PRs), a duplicate `set_protocol_limits_full` function with mismatched arity (`lib.rs`), a missing `QuickLendXError::BatchSizeTooLarge` variant, and an undefined `PaginatedCurrencies` type. I verified none of these errors reference any code touched by this PR (`storage.rs`, `defaults.rs`'s `handle_default`, the new `get_investor_default_history` fn, or the test files) — the error set is byte-for-byte identical with and without this branch's changes applied. This blocks local `cargo test`/`clippy`/wasm-build verification for every PR against `main` right now, not just this one, and should be triaged separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)