### PR TITLE
test(pagination): add snap-to-100 final-page boundary and off-by-one regression tests

### DIFF
--- a/quicklendx-contracts/src/test_queries.rs
+++ b/quicklendx-contracts/src/test_queries.rs
@@ -435,6 +435,77 @@ fn test_has_more_over_cap_limit_clamps_correctly() {
 }
 
 // ---------------------------------------------------------------------------
+// 12a. Snap-to-100 at final page — guarded against off-by-one
+// ---------------------------------------------------------------------------
+
+/// Exactly exhausting a 100-item collection at the cap: `(offset=0, limit=100,
+/// total=100)` must snap to `effective_limit=100` and `has_more=false`.
+#[test]
+fn test_has_more_snap_to_100_at_final_page_is_false() {
+    let (safe_off, eff_lim, has_more) = validate_pagination_params(0, 100, 100);
+    assert_eq!(safe_off, 0);
+    assert_eq!(eff_lim, 100);
+    assert!(
+        !has_more,
+        "exactly matching the cap on a 100-item collection must leave has_more=false"
+    );
+}
+
+/// Off-by-one guard: requesting 99 out of 100 items must leave
+/// `has_more=true` because one item remains past the page.
+#[test]
+fn test_has_more_off_by_one_limit_99_is_true() {
+    let (safe_off, eff_lim, has_more) = validate_pagination_params(0, 99, 100);
+    assert_eq!(safe_off, 0);
+    assert_eq!(eff_lim, 99);
+    assert!(
+        has_more,
+        "limit 99 on total 100 must leave has_more=true because 1 item remains"
+    );
+}
+
+/// Over-cap guard: `limit=101` on a 100-item collection is clamped to
+/// `effective_limit=100` and `has_more=false` — the cap does not create a
+/// phantom next page.
+#[test]
+fn test_has_more_over_cap_101_on_total_100_is_false() {
+    let (safe_off, eff_lim, has_more) = validate_pagination_params(0, 101, 100);
+    assert_eq!(safe_off, 0);
+    assert_eq!(
+        eff_lim, 100,
+        "limit 101 must snap to MAX_QUERY_LIMIT (100), not wrap or become 101"
+    );
+    assert!(
+        !has_more,
+        "over-cap request on a 100-item collection must exhaust the set"
+    );
+}
+
+/// Final ledger off-by-one: paging `(offset=99, limit=100)` on a 100-item
+/// collection returns exactly 1 item and `has_more=false`.
+#[test]
+fn test_final_ledger_offset_99_limit_100_yields_one_item() {
+    let (safe_off, eff_lim, has_more) = validate_pagination_params(99, 100, 100);
+    assert_eq!(safe_off, 99);
+    assert_eq!(eff_lim, 1);
+    assert!(
+        !has_more,
+        "only 1 item remains past offset 99; the page must exhaust the collection"
+    );
+}
+
+/// `paginate_slice` with exactly 100 items and `limit=100` returns the full
+/// collection — the last element (index 99) must not be dropped by an
+/// off-by-one error.
+#[test]
+fn test_paginate_slice_exactly_100_returns_full_collection() {
+    let items = build_u64_items(100);
+    let page = paginate_slice(&items, 0, 100);
+    assert_eq!(page.len(), 100);
+    assert_eq!(page, items, "must return the complete 100-item collection");
+}
+
+// ---------------------------------------------------------------------------
 // 13. Proptest - invariants
 // ---------------------------------------------------------------------------
 
@@ -493,6 +564,22 @@ proptest! {
         for (i, item) in collected.iter().enumerate() {
             prop_assert_eq!(*item, v[i]);
         }
+    }
+
+    /// Snap-to-100 at final ledger: for any `total >= MAX_QUERY_LIMIT`, when
+    /// `offset = total - MAX_QUERY_LIMIT` and `limit >= MAX_QUERY_LIMIT`, the
+    /// final page must report `effective_limit = MAX_QUERY_LIMIT` and
+    /// `has_more = false` — never off-by-one.
+    #[test]
+    fn prop_snap_to_cap_final_page_has_no_more(
+        total in MAX_QUERY_LIMIT..=10_000u32,
+        limit in MAX_QUERY_LIMIT..=u32::MAX,
+    ) {
+        let offset = total - MAX_QUERY_LIMIT; // exactly 100 items remain
+        let (safe_off, eff_lim, has_more) = validate_pagination_params(offset, limit, total);
+        prop_assert_eq!(safe_off, offset);
+        prop_assert_eq!(eff_lim, MAX_QUERY_LIMIT);
+        prop_assert!(!has_more);
     }
 
     /// `validate_pagination_params` and `calculate_safe_bounds` never panic on


### PR DESCRIPTION
Closes #1850

## Summary

Adds deterministic unit tests and a property test locking the snap-to-100 behaviour at the final pagination page, guarding against off-by-one errors in `validate_pagination_params` and `paginate_slice`.

## Changes

**`quicklendx-contracts/src/test_queries.rs`** — 5 new unit tests + 1 new property test:

| Test | What it locks |
|---|---|
| `test_has_more_snap_to_100_at_final_page_is_false` | `(offset=0, limit=100, total=100)` → `eff_lim=100, has_more=false` |
| `test_has_more_off_by_one_limit_99_is_true` | `(offset=0, limit=99, total=100)` → `eff_lim=99, has_more=true` |
| `test_has_more_over_cap_101_on_total_100_is_false` | `(offset=0, limit=101, total=100)` → `eff_lim=100, has_more=false` |
| `test_final_ledger_offset_99_limit_100_yields_one_item` | `(offset=99, limit=100, total=100)` → `eff_lim=1, has_more=false` |
| `test_paginate_slice_exactly_100_returns_full_collection` | 100-item collection returned in full at limit=100 |
| `prop_snap_to_cap_final_page_has_no_more` | ∀ `total ≥ 100`, final page with exactly 100 remaining snaps correctly |

## Test coverage

- **Happy path**: snap-to-100 with `limit=100` exactly exhausting a 100-item collection
- **Sad paths**: limit=99 (leaves remainder), limit=101 (over-cap clamp), offset=99 (last item boundary)
- **Property test**: fuzzes the final-page snap invariant across all totals ≥ 100
- All tests are pure-Rust unit tests (no Soroban storage), so they run on every CI matrix entry

## Validation checklist

- [x] Tests are deterministic (no `Date.now()` / `Math.random()`)
- [x] Test names follow the existing `test_has_more_*` naming convention
- [x] `#![no_std]` compliant — no `std::` calls introduced
- [x] Changes are limited to the test file only (no production code touched)
