### PR TITLE
test: add before/at/after boundary tests for get_freshness ledger_seq

### DIFF
--- a/quicklendx-contracts/src/lib.rs
+++ b/quicklendx-contracts/src/lib.rs
@@ -171,7 +171,7 @@ mod test_escrow_refund_after_expiry;
 #[cfg(all(test, feature = "legacy-tests"))]
 mod test_expired_bids_cleanup;
 #[cfg(test)]
-// mod test_freshness;
+mod test_freshness;
 #[cfg(all(test, feature = "legacy-tests"))]
 mod test_freshness_bounds;
 #[cfg(test)]

--- a/quicklendx-contracts/src/test_freshness.rs
+++ b/quicklendx-contracts/src/test_freshness.rs
@@ -2,6 +2,14 @@
 //!
 //! Verifies that the contract-level freshness query returns the correct
 //! Map<String, String> with all four required keys and correct values.
+//!
+//! # Before/At/After Boundary Tests for `indexed_ledger_seq`
+//!
+//! - Before 0: `indexed_ledger_seq = 1` succeeds (minimum valid Soroban sequence).
+//! - At 0: `indexed_ledger_seq = 0` is rejected with `InvalidLedgerSequence`.
+//! - After: `indexed_ledger_seq = u32::MAX` succeeds at the opposite boundary.
+//!
+//! These tests run on every CI matrix entry (no feature gate).
 
 use super::*;
 use soroban_sdk::{testutils::Ledger, Env, String};
@@ -20,7 +28,9 @@ fn test_get_freshness_returns_all_keys() {
     env.ledger().set_sequence_number(500);
     env.ledger().set_timestamp(1_700_000_000);
 
-    let result = client.get_freshness(&500u32, &1_700_000_000u64, &0u32).unwrap();
+    let result = client
+        .get_freshness(&500u32, &1_700_000_000u64, &0u32)
+        .unwrap();
 
     assert!(result.contains_key(String::from_str(&env, "last_indexed_ledger")));
     assert!(result.contains_key(String::from_str(&env, "index_lag_seconds")));
@@ -34,7 +44,9 @@ fn test_get_freshness_zero_lag() {
     env.ledger().set_sequence_number(500);
     env.ledger().set_timestamp(1_700_000_000);
 
-    let result = client.get_freshness(&500u32, &1_700_000_000u64, &0u32).unwrap();
+    let result = client
+        .get_freshness(&500u32, &1_700_000_000u64, &0u32)
+        .unwrap();
 
     let lag = result
         .get(String::from_str(&env, "index_lag_seconds"))
@@ -48,7 +60,9 @@ fn test_get_freshness_positive_lag() {
     env.ledger().set_sequence_number(500);
     env.ledger().set_timestamp(1_700_000_060); // 60 s ahead of indexed
 
-    let result = client.get_freshness(&499u32, &1_700_000_000u64, &0u32).unwrap();
+    let result = client
+        .get_freshness(&499u32, &1_700_000_000u64, &0u32)
+        .unwrap();
 
     let lag = result
         .get(String::from_str(&env, "index_lag_seconds"))
@@ -62,7 +76,9 @@ fn test_get_freshness_cursor_encodes_seq_and_offset() {
     env.ledger().set_sequence_number(1000);
     env.ledger().set_timestamp(1_700_000_000);
 
-    let result = client.get_freshness(&1000u32, &1_700_000_000u64, &25u32).unwrap();
+    let result = client
+        .get_freshness(&1000u32, &1_700_000_000u64, &25u32)
+        .unwrap();
 
     let cursor = result.get(String::from_str(&env, "cursor")).unwrap();
     assert_eq!(cursor, String::from_str(&env, "1000_25"));
@@ -74,7 +90,9 @@ fn test_get_freshness_last_updated_at_is_iso8601() {
     env.ledger().set_sequence_number(1000);
     env.ledger().set_timestamp(1_700_000_000);
 
-    let result = client.get_freshness(&1000u32, &1_700_000_000u64, &0u32).unwrap();
+    let result = client
+        .get_freshness(&1000u32, &1_700_000_000u64, &0u32)
+        .unwrap();
 
     let ts = result
         .get(String::from_str(&env, "last_updated_at"))
@@ -84,13 +102,79 @@ fn test_get_freshness_last_updated_at_is_iso8601() {
     assert_eq!(ts, String::from_str(&env, "2023-11-14T22:13:20Z"));
 }
 
+// =============================================================================
+// Before/At/After boundary tests for indexed_ledger_seq
+// =============================================================================
+
+/// `indexed_ledger_seq = 1` is the minimum valid Soroban ledger sequence.
+/// This is the "before zero" boundary: the smallest value that must succeed.
+#[test]
+fn get_freshness_ledger_seq_one_succeeds() {
+    let (env, client) = setup();
+    env.ledger().set_sequence_number(1);
+    env.ledger().set_timestamp(1_700_000_000);
+
+    let result = client.get_freshness(&1u32, &1_700_000_000u64, &0u32);
+    assert!(
+        result.is_ok(),
+        "ledger_seq = 1 must succeed as minimum valid sequence"
+    );
+}
+
+/// `indexed_ledger_seq = 0` is NOT a valid Soroban ledger sequence.
+/// This is the "at zero" boundary: must be rejected with `InvalidLedgerSequence`.
+#[test]
+fn get_freshness_ledger_seq_zero_rejected() {
+    let (env, client) = setup();
+    env.ledger().set_timestamp(1_700_000_000);
+
+    let err = client
+        .try_get_freshness(&0u32, &1_700_000_000u64, &0u32)
+        .expect_err("ledger_seq = 0 must be rejected");
+    assert_eq!(
+        err,
+        Ok(crate::errors::QuickLendXError::InvalidLedgerSequence),
+        "expected InvalidLedgerSequence error for ledger_seq = 0"
+    );
+}
+
+/// `indexed_ledger_seq = u32::MAX` tests the opposite boundary.
+/// This is the "after" boundary: the largest possible value that must still succeed.
+#[test]
+fn get_freshness_ledger_seq_max_succeeds() {
+    let (env, client) = setup();
+    env.ledger().set_sequence_number(u32::MAX);
+    env.ledger().set_timestamp(1_700_000_000);
+
+    let result = client.get_freshness(&u32::MAX, &1_700_000_000u64, &0u32);
+    assert!(
+        result.is_ok(),
+        "ledger_seq = u32::MAX must succeed at the upper boundary"
+    );
+}
+
+/// `indexed_ledger_seq = u32::MAX - 1` is just below the max boundary.
+/// Ensures the upper boundary is genuinely valid, not just u32::MAX coincidentally.
+#[test]
+fn get_freshness_ledger_seq_one_below_max_succeeds() {
+    let (env, client) = setup();
+    let seq = u32::MAX - 1;
+    env.ledger().set_sequence_number(seq);
+    env.ledger().set_timestamp(1_700_000_000);
+
+    let result = client.get_freshness(&seq, &1_700_000_000u64, &0u32);
+    assert!(result.is_ok(), "ledger_seq = u32::MAX - 1 must succeed");
+}
+
 #[test]
 fn test_get_freshness_no_topology_in_values() {
     let (env, client) = setup();
     env.ledger().set_sequence_number(1000);
     env.ledger().set_timestamp(1_700_000_000);
 
-    let result = client.get_freshness(&1000u32, &1_700_000_000u64, &0u32).unwrap();
+    let result = client
+        .get_freshness(&1000u32, &1_700_000_000u64, &0u32)
+        .unwrap();
 
     // Cursor must only contain digits and underscore.
     let cursor = result.get(String::from_str(&env, "cursor")).unwrap();


### PR DESCRIPTION
## Summary

Adds before/at/after boundary tests for `get_freshness`'s `indexed_ledger_seq` parameter, and re-enables the previously disabled `test_freshness` module so it runs on every CI matrix entry.

## Changes

- **`lib.rs`**: Uncommented `mod test_freshness;` (was disabled — now runs on every CI, no feature gate)
- **`test_freshness.rs`**: Added 4 new boundary tests following the before/at/after pattern:
  - `get_freshness_ledger_seq_zero_rejected` — seq=0 → `InvalidLedgerSequence` (at boundary)
  - `get_freshness_ledger_seq_one_succeeds` — seq=1 succeeds (before zero)
  - `get_freshness_ledger_seq_max_succeeds` — seq=u32::MAX succeeds (after)
  - `get_freshness_ledger_seq_one_below_max_succeeds` — seq=u32::MAX-1 succeeds

## Background

The recent fix `reject ledger_seq == 0 at get_freshness entrypoint boundary` had its test gated behind `legacy-tests`, meaning it didn't run on every CI matrix entry. This PR ungates the freshness tests and adds comprehensive boundary coverage.

Closes #2116