### PR TITLE
feat: add bid_expiry_grace_seconds for auto-cancelling stale bids

### DIFF
--- a/docs/BID_LIFECYCLE_DIAGRAM.md
+++ b/docs/BID_LIFECYCLE_DIAGRAM.md
@@ -107,7 +107,9 @@ contract.withdraw_bid(env, bid_id: BytesN<32>) -> Result<(), QuickLendXError>
 ### Placed → Expired (automatic)
 
 No explicit entrypoint transitions a bid to `Expired`. The transition happens
-inside the following paths when `current_timestamp ≥ expiration_timestamp`:
+inside the following paths once the bid becomes **cleanup-eligible**
+(`current_timestamp ≥ expiration_timestamp + bid_expiry_grace_seconds`; see
+[Bid Expiry Grace Period](#bid-expiry-grace-period) below):
 
 - `cleanup_expired_bids` / `cleanup_expired_bids_paged` — public permissionless
   cleanup that scans and prunes expired bids.
@@ -140,6 +142,48 @@ TTL can be configured by admin between 1 and 30 days via `set_bid_ttl_days`.
 The investor active-bid limit can be set to any `u32`; `0` disables enforcement.
 Each change emits a `ttl_upd` event for auditability.
 
+## Bid Expiry Grace Period
+
+Once a bid's `expiration_timestamp` passes, it is immediately treated as
+expired for **acceptance** (`accept_bid` rejects it) and for **active-bid
+counting** (`get_active_bid_amount_sum_for_investor`,
+`count_active_placed_bids_for_investor`) — this is unchanged and governed by
+the raw `Bid::is_expired` predicate.
+
+What *is* delayed is the permissionless cleanup path: the storage transition
+from `Placed` to `Expired` (and the accompanying index pruning) performed by
+`cleanup_expired_bids` / `cleanup_expired_bids_paged` / `refresh_expired_bids`
+/ `refresh_investor_bids` only fires once `Bid::is_cleanup_eligible` is true,
+i.e. `current_timestamp >= expiration_timestamp + bid_expiry_grace_seconds`.
+This gives investors (or the wider system) a buffer window after raw expiry
+before any third-party caller can force the cleanup, without ever making an
+already-dead bid acceptable again.
+
+| Constant                              | Value        | Admin entrypoint                        |
+|----------------------------------------|--------------|------------------------------------------|
+| `DEFAULT_BID_EXPIRY_GRACE_SECONDS`     | 0 (no grace — matches pre-existing immediate-cleanup behaviour) | `reset_bid_expiry_grace_to_default` |
+| `MIN_BID_EXPIRY_GRACE_SECONDS`         | 0            | —                                          |
+| `MAX_BID_EXPIRY_GRACE_SECONDS`         | 2592000 (30 days) | —                                     |
+
+The default of `0` is intentional: it keeps out-of-the-box cleanup behaviour
+byte-for-byte identical to before this feature existed. Operators opt into a
+buffer window by calling `set_bid_expiry_grace_seconds` with a positive value.
+
+```rust
+// Admin-only.
+contract.set_bid_expiry_grace_seconds(env, seconds: u64) -> Result<u64, QuickLendXError>
+contract.reset_bid_expiry_grace_to_default(env) -> Result<u64, QuickLendXError>
+
+// Read-only.
+contract.get_bid_expiry_grace_seconds(env) -> u64
+contract.get_bid_expiry_grace_config(env) -> BidExpiryGraceConfig
+```
+
+`set_bid_expiry_grace_seconds` rejects out-of-range values with
+`InvalidTimestamp` (matching the convention used by the invoice-side
+`defaults::resolve_grace_period`), and emits a `BidExpiryGraceUpdated` event
+on every successful change (including resets).
+
 ## Expiry Semantics
 
 ```rust
@@ -147,6 +191,12 @@ Each change emits a `ttl_upd` event for auditability.
 // Valid until the second before expiry; expired at the expiry boundary.
 pub fn is_expired(&self, current_timestamp: u64) -> bool {
     current_timestamp >= self.expiration_timestamp
+}
+
+// A bid becomes eligible for permissionless cleanup once the grace period
+// has also elapsed on top of the raw expiry boundary.
+pub fn is_cleanup_eligible(&self, current_timestamp: u64, grace_seconds: u64) -> bool {
+    current_timestamp >= self.expiration_timestamp.saturating_add(grace_seconds)
 }
 ```
 
@@ -231,6 +281,7 @@ Detailed cross-module invariants: [`docs/contracts/lifecycle.md`](contracts/life
 | `get_all_bids_by_investor`     | `Vec<Bid>`                   | All bids across all invoices.      |
 | `get_bid_ttl_config`           | `BidTtlConfig`               | Full TTL config snapshot.          |
 | `get_bid_limit_config`         | `BidLimitConfig`             | Full bid limit policy snapshot.    |
+| `get_bid_expiry_grace_config`  | `BidExpiryGraceConfig`       | Full cleanup grace-period snapshot.|
 
 ## Error Codes
 

--- a/quicklendx-contracts/src/bid.rs
+++ b/quicklendx-contracts/src/bid.rs
@@ -3,7 +3,7 @@ use soroban_sdk::{contracttype, symbol_short, Address, BytesN, Env, Symbol, Vec}
 
 use crate::admin::AdminStorage;
 use crate::errors::QuickLendXError;
-use crate::events::{emit_bid_expired, emit_bid_ttl_updated};
+use crate::events::{emit_bid_expired, emit_bid_expiry_grace_updated, emit_bid_ttl_updated};
 use crate::storage::{bump_persistent, extend_persistent_ttl};
 pub use crate::types::{Bid, BidStatus};
 
@@ -41,6 +41,26 @@ const MAX_ACTIVE_BIDS_PER_INVESTOR_KEY: Symbol = symbol_short!("mx_actbd");
 const DEFAULT_MAX_ACTIVE_BIDS_PER_INVESTOR: u32 = 20;
 const SECONDS_PER_DAY: u64 = 86400;
 
+// --- Bid expiry grace period -------------------------------------------------
+//
+// A stale `Placed` bid (one whose `expiration_timestamp` has already passed)
+// only becomes eligible for the permissionless cleanup entrypoints
+// (`cleanup_expired_bids` / `cleanup_expired_bids_paged`, and the lazy-refresh
+// helpers they share) once this additional grace window has also elapsed on
+// top of `expiration_timestamp`. The grace period exists purely to give the
+// investor (or the wider system) a buffer before a third party can force the
+// `Placed -> Expired` transition; it never affects acceptance or active-bid
+// counting, which continue to key off the raw `expiration_timestamp` via
+// `Bid::is_expired`.
+//
+// Admin-configurable within [MIN, MAX], mirroring the bid TTL knob above.
+// Default: 0 (matches the pre-existing behaviour of cleaning up immediately
+// at raw expiry) | Min: 0 | Max: 30 days.
+pub const DEFAULT_BID_EXPIRY_GRACE_SECONDS: u64 = 0;
+pub const MIN_BID_EXPIRY_GRACE_SECONDS: u64 = 0;
+pub const MAX_BID_EXPIRY_GRACE_SECONDS: u64 = 30 * SECONDS_PER_DAY;
+const BID_EXPIRY_GRACE_KEY: Symbol = symbol_short!("bid_grace");
+
 /// @notice Maximum number of active bids allowed per invoice.
 /// @dev An active bid is one in the `Placed` status. Limiting this prevents unbounded
 /// storage growth, keeping state reads and iterations highly efficient and within
@@ -68,6 +88,28 @@ pub struct BidTtlConfig {
     pub default_days: u64,
     /// `true` when the admin has explicitly set a TTL; `false` when the
     /// compile-time default is in use.
+    pub is_custom: bool,
+}
+
+/// Snapshot of the current bid expiry grace-period configuration returned by
+/// `get_bid_expiry_grace_config`.
+///
+/// The grace period is added on top of a bid's `expiration_timestamp` before
+/// `cleanup_stale_bid` is allowed to auto-cancel it. See
+/// `docs/BID_EXPIRY_GRACE.md` for the full auto-cancellation flow.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct BidExpiryGraceConfig {
+    /// Currently active grace period in seconds (admin-set or compile-time default).
+    pub current_seconds: u64,
+    /// Minimum allowed grace period in seconds (compile-time constant: 0).
+    pub min_seconds: u64,
+    /// Maximum allowed grace period in seconds (compile-time constant: 30 days).
+    pub max_seconds: u64,
+    /// Compile-time default grace period in seconds (0 — immediate cleanup).
+    pub default_seconds: u64,
+    /// `true` when the admin has explicitly set a grace period; `false` when
+    /// the compile-time default is in use.
     pub is_custom: bool,
 }
 
@@ -111,6 +153,25 @@ impl Bid {
     /// @return true when the bid has reached or passed its expiry boundary.
     pub fn is_expired(&self, current_timestamp: u64) -> bool {
         current_timestamp >= self.expiration_timestamp
+    }
+
+    /// @notice Returns whether a bid is eligible for permissionless cleanup
+    ///      (the `Placed -> Expired` transition performed by
+    ///      `cleanup_expired_bids`/`cleanup_expired_bids_paged` and the
+    ///      lazy-refresh helpers) at `current_timestamp`.
+    /// @dev A bid is excluded from acceptance and active-bid counting as soon
+    ///      as `is_expired` is true (no change there — see
+    ///      `docs/BID_EXPIRY_GRACE.md`), but the actual storage transition and
+    ///      index pruning are deferred until `grace_seconds` (the
+    ///      admin-configurable `bid_expiry_grace_seconds`) have also elapsed
+    ///      on top of `expiration_timestamp`. This gives the investor a
+    ///      buffer before any third party can force the cleanup.
+    /// @param current_timestamp Current ledger timestamp.
+    /// @param grace_seconds Configured grace window, from
+    ///      `BidStorage::get_bid_expiry_grace_seconds`.
+    /// @return true once `current_timestamp >= expiration_timestamp + grace_seconds`.
+    pub fn is_cleanup_eligible(&self, current_timestamp: u64, grace_seconds: u64) -> bool {
+        current_timestamp >= self.expiration_timestamp.saturating_add(grace_seconds)
     }
 
     /// Backward-compatible helper used by some tests: uses compile-time default.
@@ -337,6 +398,82 @@ impl BidStorage {
         Ok(DEFAULT_BID_TTL_DAYS)
     }
 
+    /// Return the currently active bid expiry grace period, in seconds.
+    ///
+    /// Falls back to `DEFAULT_BID_EXPIRY_GRACE_SECONDS` (0 — no grace, matching
+    /// pre-existing behaviour) when no admin override has been stored.
+    pub fn get_bid_expiry_grace_seconds(env: &Env) -> u64 {
+        env.storage()
+            .instance()
+            .get(&BID_EXPIRY_GRACE_KEY)
+            .unwrap_or(DEFAULT_BID_EXPIRY_GRACE_SECONDS)
+    }
+
+    /// Return the full bid expiry grace-period configuration snapshot.
+    pub fn get_bid_expiry_grace_config(env: &Env) -> BidExpiryGraceConfig {
+        let stored: Option<u64> = env.storage().instance().get(&BID_EXPIRY_GRACE_KEY);
+        BidExpiryGraceConfig {
+            current_seconds: stored.unwrap_or(DEFAULT_BID_EXPIRY_GRACE_SECONDS),
+            min_seconds: MIN_BID_EXPIRY_GRACE_SECONDS,
+            max_seconds: MAX_BID_EXPIRY_GRACE_SECONDS,
+            default_seconds: DEFAULT_BID_EXPIRY_GRACE_SECONDS,
+            is_custom: stored.is_some(),
+        }
+    }
+
+    /// Admin-only: set the bid expiry grace period, in seconds.
+    ///
+    /// ### Bounds
+    /// - Minimum: `MIN_BID_EXPIRY_GRACE_SECONDS` (0) - allows cleanup
+    ///   immediately at expiry when no buffer is desired.
+    /// - Maximum: `MAX_BID_EXPIRY_GRACE_SECONDS` (30 days) - prevents a grace
+    ///   window so long that stale bids never become cleanable.
+    ///
+    /// ### Errors
+    /// Returns `InvalidTimestamp` for an out-of-bounds value, matching the
+    /// convention used by `defaults::resolve_grace_period` for the analogous
+    /// invoice grace period.
+    ///
+    /// ### Events
+    /// Emits `BidExpiryGraceUpdated` with the old value, new value, admin
+    /// address, and ledger timestamp so off-chain monitors can track every
+    /// config change.
+    pub fn set_bid_expiry_grace_seconds(
+        env: &Env,
+        admin: &Address,
+        seconds: u64,
+    ) -> Result<u64, QuickLendXError> {
+        admin.require_auth();
+        AdminStorage::require_admin(env, admin)?;
+
+        if seconds > MAX_BID_EXPIRY_GRACE_SECONDS {
+            return Err(QuickLendXError::InvalidTimestamp);
+        }
+
+        let old_seconds = Self::get_bid_expiry_grace_seconds(env);
+        env.storage().instance().set(&BID_EXPIRY_GRACE_KEY, &seconds);
+        emit_bid_expiry_grace_updated(env, old_seconds, seconds, admin);
+        Ok(seconds)
+    }
+
+    /// Admin-only: reset the bid expiry grace period to the compile-time
+    /// default (0).
+    ///
+    /// Removes the stored override so `get_bid_expiry_grace_seconds` returns
+    /// the default and `get_bid_expiry_grace_config` reports `is_custom = false`.
+    pub fn reset_bid_expiry_grace_to_default(
+        env: &Env,
+        admin: &Address,
+    ) -> Result<u64, QuickLendXError> {
+        admin.require_auth();
+        AdminStorage::require_admin(env, admin)?;
+
+        let old_seconds = Self::get_bid_expiry_grace_seconds(env);
+        env.storage().instance().remove(&BID_EXPIRY_GRACE_KEY);
+        emit_bid_expiry_grace_updated(env, old_seconds, DEFAULT_BID_EXPIRY_GRACE_SECONDS, admin);
+        Ok(DEFAULT_BID_EXPIRY_GRACE_SECONDS)
+    }
+
     /// Get configured max number of active (Placed) bids per investor across all invoices.
     /// A value of 0 disables this limit.
     pub fn get_max_active_bids_per_investor(env: &Env) -> u32 {
@@ -448,6 +585,14 @@ impl BidStorage {
     /// - Placed (non-expired) bids are preserved
     /// - The index after refresh accurately reflects countable active bids for rate-limiting
     ///
+    /// # Grace period
+    /// A `Placed` bid only transitions to `Expired` once it has passed its
+    /// `expiration_timestamp` by at least the configured
+    /// `bid_expiry_grace_seconds` (see `BidStorage::get_bid_expiry_grace_seconds`).
+    /// It is still excluded from acceptance and active-bid counts as soon as
+    /// its raw TTL passes; the grace period only delays this storage
+    /// transition and index pruning. See `docs/BID_LIFECYCLE_DIAGRAM.md`.
+    ///
     /// # Parameters
     /// @param env The Soroban environment
     /// @param investor The address of the investor
@@ -455,6 +600,7 @@ impl BidStorage {
     /// @return newly_expired The number of bids that transitioned from Placed to Expired in this call
     pub fn refresh_investor_bids(env: &Env, investor: &Address) -> u32 {
         let current_timestamp = env.ledger().timestamp();
+        let grace_seconds = Self::get_bid_expiry_grace_seconds(env);
         let bid_ids = Self::get_bids_by_investor_all(env, investor);
         let mut active = Vec::new(env);
         let mut newly_expired = 0u32;
@@ -465,7 +611,7 @@ impl BidStorage {
                 // We keep terminal states (Accepted, Withdrawn, Cancelled) in the index
                 // but prune Expired ones to keep the list size manageable.
                 if bid.status == BidStatus::Placed {
-                    if bid.is_expired(current_timestamp) {
+                    if bid.is_cleanup_eligible(current_timestamp, grace_seconds) {
                         bid.status = BidStatus::Expired;
                         Self::update_bid(env, &bid);
                         emit_bid_expired(env, &bid);
@@ -554,8 +700,12 @@ impl BidStorage {
     /// @param env The Soroban environment (for timestamp, storage access).
     /// @param invoice_id The unique identifier of the invoice.
     /// @return cleaned_count Total number of bids cleaned (transitioned to Expired or already Expired bids removed from index).
+    ///
+    /// A `Placed` bid transitions to `Expired` only after `expiration_timestamp
+    /// + bid_expiry_grace_seconds` has elapsed; see `Bid::is_cleanup_eligible`.
     pub fn refresh_expired_bids(env: &Env, invoice_id: &BytesN<32>) -> u32 {
         let current_timestamp = env.ledger().timestamp();
+        let grace_seconds = Self::get_bid_expiry_grace_seconds(env);
         let count_key = Self::invoice_bid_count_key(invoice_id);
         let old_count: u32 = env.storage().persistent().get(&count_key).unwrap_or(0);
         if old_count > 0 {
@@ -581,7 +731,7 @@ impl BidStorage {
                         if is_terminal {
                             true
                         } else if bid.status == BidStatus::Placed
-                            && bid.is_expired(current_timestamp)
+                            && bid.is_cleanup_eligible(current_timestamp, grace_seconds)
                         {
                             bid.status = BidStatus::Expired;
                             Self::update_bid(env, &bid);
@@ -726,6 +876,7 @@ impl BidStorage {
         }
 
         let current_timestamp = env.ledger().timestamp();
+        let grace_seconds = Self::get_bid_expiry_grace_seconds(env);
         let count_key = Self::invoice_bid_count_key(invoice_id);
         let old_count: u32 = env.storage().persistent().get(&count_key).unwrap_or(0);
 
@@ -760,7 +911,7 @@ impl BidStorage {
                         if is_terminal {
                             true
                         } else if bid.status == BidStatus::Placed
-                            && bid.is_expired(current_timestamp)
+                            && bid.is_cleanup_eligible(current_timestamp, grace_seconds)
                         {
                             bid.status = BidStatus::Expired;
                             Self::update_bid(env, &bid);

--- a/quicklendx-contracts/src/events.rs
+++ b/quicklendx-contracts/src/events.rs
@@ -649,6 +649,14 @@ pub struct BidTtlUpdated {
     pub timestamp: u64,
 }
 
+#[contractevent]
+pub struct BidExpiryGraceUpdated {
+    pub old_seconds: u64,
+    pub new_seconds: u64,
+    pub admin: Address,
+    pub timestamp: u64,
+}
+
 pub fn emit_ttl_extended(env: &Env, kind: &String, count: u32) {
     TtlExtended {
         kind: kind.clone(),
@@ -1360,6 +1368,16 @@ pub fn emit_bid_ttl_updated(env: &Env, old_days: u64, new_days: u64, admin: &Add
     BidTtlUpdated {
         old_days,
         new_days,
+        admin: admin.clone(),
+        timestamp: env.ledger().timestamp(),
+    }
+    .publish(env);
+}
+
+pub fn emit_bid_expiry_grace_updated(env: &Env, old_seconds: u64, new_seconds: u64, admin: &Address) {
+    BidExpiryGraceUpdated {
+        old_seconds,
+        new_seconds,
         admin: admin.clone(),
         timestamp: env.ledger().timestamp(),
     }

--- a/quicklendx-contracts/src/lib.rs
+++ b/quicklendx-contracts/src/lib.rs
@@ -137,6 +137,8 @@ mod test_backup_safety;
 mod test_bid_cancel_accept_race;
 #[cfg(all(test, feature = "legacy-tests"))]
 mod test_bid_expiry_boundary;
+#[cfg(test)]
+mod test_bid_expiry_grace;
 #[cfg(all(test, feature = "legacy-tests"))]
 mod test_bid_ttl;
 #[cfg(test)]
@@ -745,6 +747,35 @@ impl QuickLendXContract {
     pub fn reset_bid_ttl_to_default(env: Env) -> Result<u64, QuickLendXError> {
         let admin = AdminStorage::get_admin(&env).ok_or(QuickLendXError::NotAdmin)?;
         bid::BidStorage::reset_bid_ttl_to_default(&env, &admin)
+    }
+
+    /// Admin-only: configure the bid expiry grace period (seconds). Bounds: 0..=2_592_000 (30 days).
+    ///
+    /// This is the additional buffer, on top of a bid's expiration timestamp,
+    /// that must elapse before the permissionless cleanup entrypoints
+    /// (`cleanup_expired_bids` / `cleanup_expired_bids_paged`) will transition
+    /// it from `Placed` to `Expired`. Defaults to `0`, matching the
+    /// pre-existing behaviour of cleaning up immediately at raw expiry.
+    pub fn set_bid_expiry_grace_seconds(env: Env, seconds: u64) -> Result<u64, QuickLendXError> {
+        pause::PauseControl::require_not_paused(&env)?;
+        let admin = AdminStorage::get_admin(&env).ok_or(QuickLendXError::NotAdmin)?;
+        bid::BidStorage::set_bid_expiry_grace_seconds(&env, &admin, seconds)
+    }
+
+    /// Get the configured bid expiry grace period in seconds (returns default 0 if not set)
+    pub fn get_bid_expiry_grace_seconds(env: Env) -> u64 {
+        bid::BidStorage::get_bid_expiry_grace_seconds(&env)
+    }
+
+    /// Get the current bid expiry grace-period configuration snapshot
+    pub fn get_bid_expiry_grace_config(env: Env) -> bid::BidExpiryGraceConfig {
+        bid::BidStorage::get_bid_expiry_grace_config(&env)
+    }
+
+    /// Reset the bid expiry grace period to the compile-time default (0)
+    pub fn reset_bid_expiry_grace_to_default(env: Env) -> Result<u64, QuickLendXError> {
+        let admin = AdminStorage::get_admin(&env).ok_or(QuickLendXError::NotAdmin)?;
+        bid::BidStorage::reset_bid_expiry_grace_to_default(&env, &admin)
     }
 
     /// Get maximum active bids allowed per investor

--- a/quicklendx-contracts/src/test_bid_expiry_grace.rs
+++ b/quicklendx-contracts/src/test_bid_expiry_grace.rs
@@ -1,0 +1,272 @@
+//! Tests for issue #1830 - `bid_expiry_grace_seconds` gating permissionless
+//! bid cleanup (auto-cancellation of stale bids).
+//!
+//! Validates:
+//! - Default grace period is 0, matching the pre-existing immediate-cleanup
+//!   behaviour byte-for-byte (no regression for callers that never configure
+//!   the new knob).
+//! - A bid past its raw TTL is *not* cleaned up while still inside a
+//!   configured grace window (`Placed -> Expired` transition is deferred).
+//! - The same bid becomes cleanable once the grace window has also elapsed.
+//! - Acceptance (`accept_bid`) is unaffected by the grace period: a bid past
+//!   its raw TTL is rejected immediately, regardless of grace.
+//! - `set_bid_expiry_grace_seconds` enforces `[0, MAX_BID_EXPIRY_GRACE_SECONDS]`
+//!   and is admin-only.
+//! - `get_bid_expiry_grace_config` reports bounds, default, and `is_custom`.
+//! - `reset_bid_expiry_grace_to_default` restores the default and clears
+//!   `is_custom`.
+
+#![cfg(test)]
+
+use crate::bid::{
+    BidStatus, DEFAULT_BID_EXPIRY_GRACE_SECONDS, MAX_BID_EXPIRY_GRACE_SECONDS,
+    MIN_BID_TTL_DAYS,
+};
+use crate::errors::QuickLendXError;
+use crate::invoice::InvoiceCategory;
+use crate::{QuickLendXContract, QuickLendXContractClient};
+use soroban_sdk::{
+    testutils::{Address as _, Ledger},
+    token, Address, BytesN, Env, String, Vec,
+};
+
+const SECONDS_PER_DAY: u64 = 86_400;
+
+fn setup() -> (Env, QuickLendXContractClient<'static>, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+    let contract_id = env.register(QuickLendXContract, ());
+    let client = QuickLendXContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    client.set_admin(&admin);
+    client.initialize_fee_system(&admin);
+    (env, client, admin)
+}
+
+fn make_token(env: &Env, contract_id: &Address, business: &Address, investor: &Address) -> Address {
+    let token_admin = Address::generate(env);
+    let currency = env
+        .register_stellar_asset_contract_v2(token_admin)
+        .address();
+    let sac = token::StellarAssetClient::new(env, &currency);
+    let tok = token::Client::new(env, &currency);
+    sac.mint(business, &100_000i128);
+    sac.mint(investor, &100_000i128);
+    sac.mint(contract_id, &1i128);
+    let exp = env.ledger().sequence() + 100_000;
+    tok.approve(business, contract_id, &400_000i128, &exp);
+    tok.approve(investor, contract_id, &400_000i128, &exp);
+    currency
+}
+
+fn funded_setup(
+    env: &Env,
+    client: &QuickLendXContractClient,
+    admin: &Address,
+    amount: i128,
+) -> (Address, Address, BytesN<32>) {
+    let business = Address::generate(env);
+    let investor = Address::generate(env);
+    let contract_id = client.address.clone();
+    let currency = make_token(env, &contract_id, &business, &investor);
+
+    client.submit_kyc_application(&business, &String::from_str(env, "KYC"));
+    client.verify_business(admin, &business);
+    client.submit_investor_kyc(&investor, &String::from_str(env, "KYC"));
+    client.verify_investor(&investor, &200_000i128);
+
+    let due_date = env.ledger().timestamp() + 30 * SECONDS_PER_DAY;
+    let invoice_id = client.upload_invoice(
+        &business,
+        &amount,
+        &currency,
+        &due_date,
+        &String::from_str(env, "Test invoice"),
+        &InvoiceCategory::Services,
+        &Vec::new(env),
+    );
+    client.verify_invoice(&invoice_id);
+    (business, investor, invoice_id)
+}
+
+fn place_test_bid(
+    env: &Env,
+    client: &QuickLendXContractClient,
+    investor: &Address,
+    invoice_id: &BytesN<32>,
+) -> BytesN<32> {
+    client.place_bid(
+        investor,
+        invoice_id,
+        &5_000,
+        &6_000,
+        &BytesN::from_array(env, &[0u8; 32]),
+    )
+}
+
+#[test]
+fn default_grace_period_is_zero() {
+    let (env, client, _admin) = setup();
+    assert_eq!(client.get_bid_expiry_grace_seconds(), 0);
+    assert_eq!(DEFAULT_BID_EXPIRY_GRACE_SECONDS, 0);
+
+    let config = client.get_bid_expiry_grace_config();
+    assert_eq!(config.current_seconds, 0);
+    assert_eq!(config.default_seconds, 0);
+    assert_eq!(config.min_seconds, 0);
+    assert_eq!(config.max_seconds, MAX_BID_EXPIRY_GRACE_SECONDS);
+    assert!(!config.is_custom);
+
+    let _ = env;
+}
+
+/// With the default (zero) grace period, cleanup still fires immediately at
+/// raw expiry - this is the "no regression" guarantee for existing callers.
+#[test]
+fn cleanup_fires_immediately_when_grace_is_default_zero() {
+    let (env, client, admin) = setup();
+    client.set_bid_ttl_days(&MIN_BID_TTL_DAYS);
+    let (_, investor, invoice_id) = funded_setup(&env, &client, &admin, 10_000);
+    let bid_id = place_test_bid(&env, &client, &investor, &invoice_id);
+    let bid = client.get_bid(&bid_id).unwrap();
+
+    env.ledger().set_timestamp(bid.expiration_timestamp + 1);
+
+    let cleaned = client.cleanup_expired_bids(&invoice_id);
+    assert_eq!(cleaned, 1, "zero grace must behave like pre-existing immediate cleanup");
+
+    let bid_after = client.get_bid(&bid_id).unwrap();
+    assert_eq!(bid_after.status, BidStatus::Expired);
+}
+
+/// A bid past its raw TTL is not cleaned up while still within a configured
+/// grace window: the `Placed -> Expired` transition is deferred.
+#[test]
+fn bid_is_not_cleaned_up_within_grace_window() {
+    let (env, client, admin) = setup();
+    client.set_bid_ttl_days(&MIN_BID_TTL_DAYS);
+    let grace_seconds: u64 = 1_000;
+    client.set_bid_expiry_grace_seconds(&grace_seconds);
+
+    let (_, investor, invoice_id) = funded_setup(&env, &client, &admin, 10_000);
+    let bid_id = place_test_bid(&env, &client, &investor, &invoice_id);
+    let bid = client.get_bid(&bid_id).unwrap();
+
+    // Past raw expiry, but still inside the grace window.
+    env.ledger().set_timestamp(bid.expiration_timestamp + 1);
+
+    let cleaned = client.cleanup_expired_bids(&invoice_id);
+    assert_eq!(cleaned, 0, "bid must not be cleaned up while inside grace window");
+
+    let bid_after = client.get_bid(&bid_id).unwrap();
+    assert_eq!(bid_after.status, BidStatus::Placed);
+}
+
+/// Once the grace window has also elapsed on top of the raw TTL, cleanup
+/// transitions the bid to `Expired` as usual.
+#[test]
+fn bid_is_cleaned_up_after_grace_window_elapses() {
+    let (env, client, admin) = setup();
+    client.set_bid_ttl_days(&MIN_BID_TTL_DAYS);
+    let grace_seconds: u64 = 1_000;
+    client.set_bid_expiry_grace_seconds(&grace_seconds);
+
+    let (_, investor, invoice_id) = funded_setup(&env, &client, &admin, 10_000);
+    let bid_id = place_test_bid(&env, &client, &investor, &invoice_id);
+    let bid = client.get_bid(&bid_id).unwrap();
+
+    // Still within grace: no-op.
+    env.ledger().set_timestamp(bid.expiration_timestamp + 1);
+    assert_eq!(client.cleanup_expired_bids(&invoice_id), 0);
+
+    // Now past expiration + grace: cleanup must act.
+    env.ledger()
+        .set_timestamp(bid.expiration_timestamp + grace_seconds);
+    let cleaned = client.cleanup_expired_bids(&invoice_id);
+    assert_eq!(cleaned, 1, "bid must be cleaned up once grace window elapses");
+
+    let bid_after = client.get_bid(&bid_id).unwrap();
+    assert_eq!(bid_after.status, BidStatus::Expired);
+}
+
+/// The grace period never resurrects acceptability: a bid past its raw TTL
+/// is rejected by `accept_bid` immediately, even while a grace period would
+/// otherwise keep it un-cleaned-up in storage.
+#[test]
+fn accept_bid_still_rejects_bid_past_raw_ttl_during_grace_window() {
+    let (env, client, admin) = setup();
+    client.set_bid_ttl_days(&MIN_BID_TTL_DAYS);
+    client.set_bid_expiry_grace_seconds(&10_000u64);
+
+    let (_business, investor, invoice_id) = funded_setup(&env, &client, &admin, 10_000);
+    let bid_id = place_test_bid(&env, &client, &investor, &invoice_id);
+    let bid = client.get_bid(&bid_id).unwrap();
+
+    // Past raw expiry, well within the grace window.
+    env.ledger().set_timestamp(bid.expiration_timestamp + 1);
+
+    let bid_still_placed = client.get_bid(&bid_id).unwrap();
+    assert_eq!(bid_still_placed.status, BidStatus::Placed);
+
+    let result = client.try_accept_bid(&invoice_id, &bid_id);
+    assert!(
+        result.is_err(),
+        "accept_bid must reject a bid past raw TTL regardless of grace period"
+    );
+}
+
+#[test]
+fn set_bid_expiry_grace_seconds_rejects_value_above_maximum() {
+    let (_env, client, _admin) = setup();
+    let result = client.try_set_bid_expiry_grace_seconds(&(MAX_BID_EXPIRY_GRACE_SECONDS + 1));
+    assert!(result.is_err());
+    let err = result
+        .err()
+        .unwrap()
+        .expect("expected contract error, got host error");
+    assert_eq!(err, QuickLendXError::InvalidTimestamp);
+}
+
+#[test]
+fn set_bid_expiry_grace_seconds_accepts_boundary_values() {
+    let (_env, client, _admin) = setup();
+    assert_eq!(client.set_bid_expiry_grace_seconds(&0u64), 0);
+    assert_eq!(
+        client.set_bid_expiry_grace_seconds(&MAX_BID_EXPIRY_GRACE_SECONDS),
+        MAX_BID_EXPIRY_GRACE_SECONDS
+    );
+}
+
+#[test]
+fn get_bid_expiry_grace_config_reports_custom_after_set_and_clears_after_reset() {
+    let (_env, client, _admin) = setup();
+
+    client.set_bid_expiry_grace_seconds(&5_000u64);
+    let config = client.get_bid_expiry_grace_config();
+    assert_eq!(config.current_seconds, 5_000);
+    assert!(config.is_custom);
+
+    client.reset_bid_expiry_grace_to_default();
+    let config_after_reset = client.get_bid_expiry_grace_config();
+    assert_eq!(config_after_reset.current_seconds, DEFAULT_BID_EXPIRY_GRACE_SECONDS);
+    assert!(!config_after_reset.is_custom);
+}
+
+/// Calling `set_bid_expiry_grace_seconds` before any admin has been
+/// configured for the contract must fail with `NotAdmin`.
+#[test]
+fn non_admin_cannot_set_bid_expiry_grace_seconds() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(QuickLendXContract, ());
+    let client = QuickLendXContractClient::new(&env, &contract_id);
+
+    let result = client.try_set_bid_expiry_grace_seconds(&1_000u64);
+    assert!(result.is_err());
+    let err = result
+        .err()
+        .unwrap()
+        .expect("expected contract error, got host error");
+    assert_eq!(err, QuickLendXError::NotAdmin);
+}

--- a/quicklendx-contracts/src/test_snapshots/storage_keys.txt
+++ b/quicklendx-contracts/src/test_snapshots/storage_keys.txt
@@ -37,6 +37,7 @@ persistent | investments_by_status         | inv_st
 persistent | all_bids                      | all_bids
 instance   | bid_ttl                       | bid_ttl
 instance   | max_active_bids_per_investor  | mx_actbd
+instance   | bid_expiry_grace_seconds      | bid_grace
 
 # ── InvestmentStorage: additional investment keys ────────────────────────────
 persistent | invoice_to_investment_map     | inv_map

--- a/quicklendx-contracts/src/test_storage_key_layout.rs
+++ b/quicklendx-contracts/src/test_storage_key_layout.rs
@@ -355,6 +355,13 @@ fn test_bid_storage_max_active_bids_key_stable() {
     assert_eq!(symbol_short!("mx_actbd"), symbol_short!("mx_actbd"));
 }
 
+/// STORAGE CLASS: Instance  Namespace: bid_grace (admin-configurable bid expiry grace period)
+#[test]
+fn test_bid_storage_expiry_grace_key_stable() {
+    assert_snapshot_entry("bid_expiry_grace_seconds", "bid_grace");
+    assert_eq!(symbol_short!("bid_grace"), symbol_short!("bid_grace"));
+}
+
 // ---------------------------------------------------------------------------
 // InvestmentStorage — extra persistent/instance keys
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #1830

## Summary

Adds an admin-configurable `bid_expiry_grace_seconds` window (0..=30 days, default `0`) that must elapse **on top of** a bid's `expiration_timestamp` before the existing permissionless cleanup entrypoints (`cleanup_expired_bids` / `cleanup_expired_bids_paged`, and the lazy-refresh helpers they share) will auto-cancel it — i.e. transition it from `Placed` to `Expired`.

The default of `0` keeps out-of-the-box behaviour byte-for-byte identical to before this change (cleanup still fires immediately at raw expiry). Bid **acceptance** and **active-bid counting** are unaffected by the grace period and continue to key off the raw `expiration_timestamp` — a stale bid is never made acceptable again just because it's inside its grace window; the grace period only delays the storage transition/index pruning performed by the permissionless cleanup path.

## Implementation details

- `Bid::is_cleanup_eligible(current_timestamp, grace_seconds)` — new predicate: `current_timestamp >= expiration_timestamp.saturating_add(grace_seconds)`. Used by `refresh_investor_bids`, `refresh_expired_bids`, `cleanup_expired_bids`, and `cleanup_expired_bids_paged` in place of the raw `is_expired` check for the `Placed -> Expired` storage transition. `is_expired` itself is untouched, so acceptance/active-bid-counting logic (which calls `is_expired` directly) is unaffected.
- `BidStorage::get_bid_expiry_grace_seconds` / `get_bid_expiry_grace_config` / `set_bid_expiry_grace_seconds` / `reset_bid_expiry_grace_to_default` — new admin-configurable knob stored under a new instance key (`bid_grace`), mirroring the existing `bid_ttl` pattern. Bounds: `MIN_BID_EXPIRY_GRACE_SECONDS` (0) to `MAX_BID_EXPIRY_GRACE_SECONDS` (30 days); out-of-range values return `QuickLendXError::InvalidTimestamp`. Setting/resetting requires the stored admin's auth and emits a new `BidExpiryGraceUpdated` event (old value, new value, admin, timestamp) for off-chain monitoring.
- New public contract entrypoints in `lib.rs`: `set_bid_expiry_grace_seconds`, `get_bid_expiry_grace_seconds`, `get_bid_expiry_grace_config`, `reset_bid_expiry_grace_to_default` — same shape as the existing bid-TTL entrypoints (`set_bid_ttl_days` / `reset_bid_ttl_to_default`).

## Files changed

**New files:**
- `quicklendx-contracts/src/test_bid_expiry_grace.rs` — test suite for the new behaviour

**Modified files:**
- `quicklendx-contracts/src/bid.rs` — `BidExpiryGraceConfig` type, `Bid::is_cleanup_eligible`, grace-period storage/config functions, grace-aware cleanup in `refresh_investor_bids` / `refresh_expired_bids` / `cleanup_expired_bids` / `cleanup_expired_bids_paged`
- `quicklendx-contracts/src/events.rs` — `BidExpiryGraceUpdated` event + `emit_bid_expiry_grace_updated`
- `quicklendx-contracts/src/lib.rs` — new public entrypoints (see above)
- `quicklendx-contracts/src/test_storage_key_layout.rs` / `test_snapshots/storage_keys.txt` — snapshot coverage for the new `bid_grace` instance key
- `docs/BID_LIFECYCLE_DIAGRAM.md` — new "Bid Expiry Grace Period" section documenting the behaviour, constants, and API surface

## Tests added (`test_bid_expiry_grace.rs`)

- `default_grace_period_is_zero` — default config snapshot is all-zero/non-custom
- `cleanup_fires_immediately_when_grace_is_default_zero` — no-regression guarantee for existing callers
- `bid_is_not_cleaned_up_within_grace_window` — cleanup is a no-op while inside a configured grace window
- `bid_is_cleaned_up_after_grace_window_elapses` — cleanup fires once `expiration_timestamp + grace_seconds` has passed
- `accept_bid_still_rejects_bid_past_raw_ttl_during_grace_window` — grace period never resurrects acceptability
- `set_bid_expiry_grace_seconds_rejects_value_above_maximum` / `_accepts_boundary_values` — bounds validation
- `get_bid_expiry_grace_config_reports_custom_after_set_and_clears_after_reset` — `is_custom` flag behaviour
- `non_admin_cannot_set_bid_expiry_grace_seconds` — admin-only enforcement

## How to test

```bash
cd quicklendx-contracts
cargo test --lib test_bid_expiry_grace
cargo build --target wasm32-unknown-unknown --release
cargo clippy --workspace --all-targets -- -D warnings
```

**Note:** `main` at the base of this branch currently fails to compile independently of this change (duplicate `set_protocol_limits_full` definitions from two colliding merges, plus a `QuickLendXError::BatchSizeTooLarge` variant referenced in `lib.rs` but not defined in `errors.rs`). This PR does not touch `set_protocol_limits*` or the batch-size error path, so it does not introduce or worsen that breakage, but it does mean `cargo build`/`test`/`clippy` cannot currently succeed on this branch until that unrelated issue is fixed. Flagging here for maintainer awareness — happy to open a separate PR for it if useful.