### PR TITLE
feat: add require_valid_business_kyc_tier helper (#2078)

### DIFF
--- a/quicklendx-contracts/src/lib.rs
+++ b/quicklendx-contracts/src/lib.rs
@@ -142,6 +142,8 @@ mod test_bid_ttl;
 #[cfg(test)]
 mod test_require_business_active;
 #[cfg(test)]
+mod test_require_valid_business_kyc_tier;
+#[cfg(test)]
 mod test_cancel_invoice_matrix;
 #[cfg(all(test, feature = "legacy-tests"))]
 mod test_cleanup_pagination;
@@ -392,7 +394,7 @@ use verification::{
     calculate_investment_limit, calculate_investor_risk_score, compute_investor_tier,
     determine_investor_tier, get_investor_verification as do_get_investor_verification,
     normalize_tag, recompute_investor_tier, reject_business, reject_investor as do_reject_investor,
-    require_business_not_pending, require_investor_not_pending,
+    require_business_not_pending, require_investor_not_pending, require_valid_business_kyc_tier,
     revoke_investor_kyc as do_revoke_investor_kyc, submit_investor_kyc as do_submit_investor_kyc,
     submit_kyc_application, validate_bid, validate_dispute_evidence, validate_dispute_resolution,
     validate_investor_investment, validate_invoice_metadata, verify_business,

--- a/quicklendx-contracts/src/test_require_valid_business_kyc_tier.rs
+++ b/quicklendx-contracts/src/test_require_valid_business_kyc_tier.rs
@@ -1,0 +1,52 @@
+#![cfg(test)]
+
+use crate::errors::QuickLendXError;
+use crate::verification::{
+    require_valid_business_kyc_tier, BusinessVerification, BusinessVerificationStatus,
+};
+use soroban_sdk::{testutils::Address as _, Address, Env, String};
+
+fn mock_verification(env: &Env, status: BusinessVerificationStatus) -> BusinessVerification {
+    let business = Address::generate(env);
+    BusinessVerification {
+        business,
+        status,
+        verified_at: None,
+        verified_by: None,
+        kyc_data: String::from_str(env, "sample_kyc_data"),
+        submitted_at: env.ledger().timestamp(),
+        rejection_reason: None,
+    }
+}
+
+#[test]
+fn test_require_valid_business_kyc_tier_verified_succeeds() {
+    let env = Env::default();
+    let verification = mock_verification(&env, BusinessVerificationStatus::Verified);
+    let result = require_valid_business_kyc_tier(&verification);
+    assert!(result.is_ok(), "Verified status must return Ok(())");
+}
+
+#[test]
+fn test_require_valid_business_kyc_tier_pending_fails() {
+    let env = Env::default();
+    let verification = mock_verification(&env, BusinessVerificationStatus::Pending);
+    let result = require_valid_business_kyc_tier(&verification);
+    assert_eq!(
+        result,
+        Err(QuickLendXError::KYCAlreadyPending),
+        "Pending status must return KYCAlreadyPending"
+    );
+}
+
+#[test]
+fn test_require_valid_business_kyc_tier_rejected_fails() {
+    let env = Env::default();
+    let verification = mock_verification(&env, BusinessVerificationStatus::Rejected);
+    let result = require_valid_business_kyc_tier(&verification);
+    assert_eq!(
+        result,
+        Err(QuickLendXError::BusinessNotVerified),
+        "Rejected status must return BusinessNotVerified"
+    );
+}

--- a/quicklendx-contracts/src/verification.rs
+++ b/quicklendx-contracts/src/verification.rs
@@ -991,6 +991,21 @@ pub fn require_business_verification(env: &Env, business: &Address) -> Result<()
     Ok(())
 }
 
+/// Enforce that a business KYC verification record has a valid (Verified) KYC status/tier.
+///
+/// Symmetric guard for business KYC tiers.
+///
+/// # Errors
+/// - `KYCAlreadyPending` if the business KYC application is pending review
+/// - `BusinessNotVerified` if the business KYC application is rejected or not verified
+pub fn require_valid_business_kyc_tier(t: &BusinessVerification) -> Result<(), QuickLendXError> {
+    match t.status {
+        BusinessVerificationStatus::Verified => Ok(()),
+        BusinessVerificationStatus::Pending => Err(QuickLendXError::KYCAlreadyPending),
+        BusinessVerificationStatus::Rejected => Err(QuickLendXError::BusinessNotVerified),
+    }
+}
+
 /// Enforce that a business is not in KYC-pending state before allowing a sensitive operation.
 ///
 /// Pending businesses have submitted KYC but have not yet been approved or rejected.
@@ -1005,11 +1020,7 @@ pub fn require_business_not_pending(env: &Env, business: &Address) -> Result<(),
         return Err(QuickLendXError::BusinessDeleted);
     }
     match BusinessVerificationStorage::get_verification(env, business) {
-        Some(v) => match v.status {
-            BusinessVerificationStatus::Pending => Err(QuickLendXError::KYCAlreadyPending),
-            BusinessVerificationStatus::Verified => Ok(()),
-            BusinessVerificationStatus::Rejected => Err(QuickLendXError::BusinessNotVerified),
-        },
+        Some(v) => require_valid_business_kyc_tier(&v),
         None => Err(QuickLendXError::BusinessNotVerified),
     }
 }


### PR DESCRIPTION
## Summary
Adds a symmetric `require_valid_business_kyc_tier(t)` guard function to `quicklendx-contracts/src/verification.rs` (and re-exports it in `lib.rs`) for business KYC records, ensuring business verification status validation is centralized and typed. Refactors `require_business_not_pending` to utilize `require_valid_business_kyc_tier`.

Closes #2078

## Threat Model / Threat Mitigated
Without a centralized, typed `require_valid_business_kyc_tier(t)` guard for `BusinessVerification` records:
- Business KYC status checks across contract entrypoints could inspect a `BusinessVerification` record `t` without explicitly checking that `t.status == BusinessVerificationStatus::Verified`.
- Unverified, pending, or rejected business entities might bypass status enforcement if an entrypoint incorrectly assumed record existence implied verification approval.
- By implementing `require_valid_business_kyc_tier(t)`, we enforce typed error returns (`KYCAlreadyPending` for pending, `BusinessNotVerified` for rejected/unverified), preventing unauthorized business actions on-chain.

## Key Changes
- **`quicklendx-contracts/src/verification.rs`**: Added `require_valid_business_kyc_tier(t: &BusinessVerification) -> Result<(), QuickLendXError>` and refactored `require_business_not_pending` to delegate status checking to it.
- **`quicklendx-contracts/src/lib.rs`**: Re-exported `require_valid_business_kyc_tier` and registered test module `test_require_valid_business_kyc_tier`.
- **`quicklendx-contracts/src/test_require_valid_business_kyc_tier.rs`**: Added unit tests verifying `Verified` status succeeds (`Ok(())`), `Pending` status fails with `KYCAlreadyPending`, and `Rejected` status fails with `BusinessNotVerified`.

## Acceptance Criteria Checklist
- [x] Symmetric guard `require_valid_business_kyc_tier(t)` added for business KYC tiers.
- [x] Negative tests exercise both `Pending` and `Rejected` failure states.
- [x] Threat model and threat mitigation documented in PR description.
- [x] Typed errors returned (`KYCAlreadyPending`, `BusinessNotVerified`).
- [x] References issue with `Closes #2078`.