### PR TITLE
feat: add late_payment_penalty_bps config per invoice (#1817)

### DIFF
--- a/quicklendx-contracts/src/fees.rs
+++ b/quicklendx-contracts/src/fees.rs
@@ -664,6 +664,7 @@ impl FeeManager {
         transaction_amount: i128,
         is_early_payment: bool,
         is_late_payment: bool,
+        late_payment_penalty_bps: Option<u32>,
     ) -> Result<i128, QuickLendXError> {
         if transaction_amount <= 0 {
             return Err(QuickLendXError::InvalidAmount);
@@ -699,7 +700,9 @@ impl FeeManager {
                     .ok_or(QuickLendXError::ArithmeticOverflow)?;
             }
             if is_late_payment && structure.fee_type == FeeType::LatePayment {
-                let late = Self::checked_mul_div(fee, LATE_FEE_SURCHARGE_BPS, BPS_DENOMINATOR)?;
+                let surcharge_bps = late_payment_penalty_bps
+                    .unwrap_or(LATE_FEE_SURCHARGE_BPS as u32) as i128;
+                let late = Self::checked_mul_div(fee, surcharge_bps, BPS_DENOMINATOR)?;
                 fee = fee
                     .checked_add(late)
                     .ok_or(QuickLendXError::ArithmeticOverflow)?;

--- a/quicklendx-contracts/src/invoice.rs
+++ b/quicklendx-contracts/src/invoice.rs
@@ -33,6 +33,7 @@ impl Invoice {
         category: InvoiceCategory,
         tags: Vec<String>,
         origination_fee_bps: Option<u32>,
+        late_payment_penalty_bps: Option<u32>,
     ) -> Result<Self, QuickLendXError> {
         if amount <= 0 {
             return Err(QuickLendXError::InvalidAmount);
@@ -40,6 +41,12 @@ impl Invoice {
 
         if due_date <= env.ledger().timestamp() {
             return Err(QuickLendXError::InvoiceDueDateInvalid);
+        }
+
+        if let Some(penalty_bps) = late_payment_penalty_bps {
+            if penalty_bps > 5000 {
+                return Err(QuickLendXError::InvalidFeeBasisPoints);
+            }
         }
 
         let mut normalized_tags = Vec::new(env);
@@ -88,6 +95,7 @@ impl Invoice {
             total_paid: 0,
             payment_history: Vec::new(env),
             origination_fee_bps,
+            late_payment_penalty_bps,
         })
     }
 

--- a/quicklendx-contracts/src/invoice_search.rs
+++ b/quicklendx-contracts/src/invoice_search.rs
@@ -283,6 +283,8 @@ mod tests {
             String::from_str(env, description),
             InvoiceCategory::Services,
             Vec::new(env),
+            None,
+            None,
         )
         .unwrap();
         invoice.metadata_customer_name = customer_name.map(|name| String::from_str(env, name));

--- a/quicklendx-contracts/src/lib.rs
+++ b/quicklendx-contracts/src/lib.rs
@@ -1111,6 +1111,7 @@ impl QuickLendXContract {
         category: InvoiceCategory,
         tags: Vec<String>,
         origination_fee_bps: Option<u32>,
+        late_payment_penalty_bps: Option<u32>,
     ) -> Result<BytesN<32>, QuickLendXError> {
         pause::PauseControl::require_not_paused(&env)?;
         require_not_self(&env, &business)?;
@@ -1173,6 +1174,7 @@ impl QuickLendXContract {
             category,
             tags,
             origination_fee_bps,
+            late_payment_penalty_bps,
         )?;
 
         // Store the invoice
@@ -1207,6 +1209,7 @@ impl QuickLendXContract {
         category: InvoiceCategory,
         tags: Vec<String>,
         origination_fee_bps: Option<u32>,
+        late_payment_penalty_bps: Option<u32>,
     ) -> Result<BytesN<32>, QuickLendXError> {
         pause::PauseControl::require_not_paused(&env)?;
         // Only the business can upload their own invoice
@@ -1248,6 +1251,7 @@ impl QuickLendXContract {
             category,
             tags,
             origination_fee_bps,
+            late_payment_penalty_bps,
         )?;
         InvoiceStorage::store_invoice(&env, &invoice);
 
@@ -1367,6 +1371,7 @@ impl QuickLendXContract {
                 input.category,
                 input.tags.clone(),
                 None, // origination_fee_bps
+                input.late_payment_penalty_bps,
             )?;
             let id = invoice.id.clone();
             InvoiceStorage::store_invoice(&env, &invoice);
@@ -3385,6 +3390,7 @@ impl QuickLendXContract {
         transaction_amount: i128,
         is_early_payment: bool,
         is_late_payment: bool,
+        late_payment_penalty_bps: Option<u32>,
     ) -> Result<i128, QuickLendXError> {
         fees::FeeManager::calculate_total_fees(
             &env,
@@ -3392,6 +3398,7 @@ impl QuickLendXContract {
             transaction_amount,
             is_early_payment,
             is_late_payment,
+            late_payment_penalty_bps,
         )
     }
 

--- a/quicklendx-contracts/src/test/test_invoice_status.rs
+++ b/quicklendx-contracts/src/test/test_invoice_status.rs
@@ -35,6 +35,8 @@ mod tests {
             description,
             category,
             tags,
+            None,
+            None,
         ).expect("invoice creation should succeed");
         // Manually set status to the desired variant for testing
         inv.status = status;

--- a/quicklendx-contracts/src/test_cancel_invoice_matrix.rs
+++ b/quicklendx-contracts/src/test_cancel_invoice_matrix.rs
@@ -103,6 +103,8 @@ fn test_cancel_ownership_matrix() {
             String::from_str(&env, "owner matrix"),
             InvoiceCategory::Services,
             Vec::new(&env),
+            None,
+            None,
         )
         .expect("invoice creation")
     });

--- a/quicklendx-contracts/src/test_clock_rollover.rs
+++ b/quicklendx-contracts/src/test_clock_rollover.rs
@@ -111,6 +111,8 @@ fn invoice_not_overdue_when_due_date_equals_u64_max() {
                 String::from_str(&env, "rollover test"),
                 InvoiceCategory::Services,
                 Vec::new(&env),
+                None,
+                None,
             )
         })
         .expect("invoice construction must succeed at NEAR_MAX");
@@ -144,6 +146,8 @@ fn invoice_not_overdue_after_clock_rollover_to_zero_when_due_date_is_u64_max() {
                 String::from_str(&env, "rollover test"),
                 InvoiceCategory::Services,
                 Vec::new(&env),
+                None,
+                None,
             )
         })
         .expect("invoice construction must succeed");
@@ -176,6 +180,8 @@ fn invoice_is_overdue_at_u64_max_minus_one_when_due_date_is_small() {
                 String::from_str(&env, "small due date"),
                 InvoiceCategory::Services,
                 Vec::new(&env),
+                None,
+                None,
             )
         })
         .expect("invoice construction must succeed");
@@ -208,6 +214,8 @@ fn grace_deadline_saturates_at_u64_max_when_due_date_is_near_max() {
                 String::from_str(&env, "grace saturation"),
                 InvoiceCategory::Services,
                 Vec::new(&env),
+                None,
+                None,
             )
         })
         .expect("invoice construction must succeed");
@@ -251,6 +259,8 @@ fn grace_deadline_at_u64_max_minus_one_saturates_with_overflow_grace_period() {
                 String::from_str(&env, "near max due date"),
                 InvoiceCategory::Services,
                 Vec::new(&env),
+                None,
+                None,
             )
         })
         .expect("invoice construction must succeed");

--- a/quicklendx-contracts/src/test_dispute_timeline_props.rs
+++ b/quicklendx-contracts/src/test_dispute_timeline_props.rs
@@ -108,6 +108,8 @@ mod test_dispute_timeline_props {
                 String::from_str(env, "Dispute timeline property invoice"),
                 InvoiceCategory::Services,
                 Vec::new(env),
+                None,
+                None,
             )
             .expect("invoice should build");
 

--- a/quicklendx-contracts/src/test_due_date_guard.rs
+++ b/quicklendx-contracts/src/test_due_date_guard.rs
@@ -55,6 +55,8 @@ fn invoice_new_rejects_due_date_in_past() {
             String::from_str(&env, "past-due invoice"),
             InvoiceCategory::Services,
             Vec::new(&env),
+            None,
+            None,
         )
     });
 
@@ -79,6 +81,8 @@ fn invoice_new_rejects_due_date_equal_to_current_timestamp() {
             String::from_str(&env, "due-now invoice"),
             InvoiceCategory::Services,
             Vec::new(&env),
+            None,
+            None,
         )
     });
 
@@ -103,6 +107,8 @@ fn invoice_new_accepts_due_date_strictly_in_future() {
             String::from_str(&env, "future invoice"),
             InvoiceCategory::Services,
             Vec::new(&env),
+            None,
+            None,
         )
     });
 

--- a/quicklendx-contracts/src/test_fuzz_invoice_metadata.rs
+++ b/quicklendx-contracts/src/test_fuzz_invoice_metadata.rs
@@ -48,6 +48,8 @@ fn make_invoice_unit(env: &Env) -> (Invoice, Address) {
         SStr::from_str(env, "fuzz invoice"),
         InvoiceCategory::Services,
         SVec::new(env),
+        None,
+        None,
     )
     .expect("baseline invoice creation must succeed");
     (inv, business)
@@ -104,6 +106,8 @@ proptest! {
                 SStr::from_str(&env, "t"),
                 InvoiceCategory::Services,
                 tags,
+                None,
+                None,
             );
             prop_assert!(result.is_ok(), "count={} should succeed", count);
             prop_assert_eq!(result.unwrap().tags.len(), count);
@@ -130,6 +134,8 @@ proptest! {
                 SStr::from_str(&env, "t"),
                 InvoiceCategory::Services,
                 tags,
+                None,
+                None,
             );
             prop_assert_eq!(
                 result,

--- a/quicklendx-contracts/src/test_invoice.rs
+++ b/quicklendx-contracts/src/test_invoice.rs
@@ -159,6 +159,7 @@ fn test_invoice_cancel_authorization() {
         tags,
 
         None,
+        None,
 
     ).expect("Invoice creation should succeed");
 
@@ -210,6 +211,7 @@ fn test_invoice_cancel_no_state_preconditions() {
             category,
             tags.clone(),
 
+            None,
             None,
 
         ).expect("Invoice creation should succeed");

--- a/quicklendx-contracts/src/test_invoice_metadata.rs
+++ b/quicklendx-contracts/src/test_invoice_metadata.rs
@@ -42,6 +42,8 @@ fn make_invoice(env: &Env, business: &Address) -> Invoice {
         String::from_str(env, "Test invoice"),
         InvoiceCategory::Services,
         tags,
+        None,
+        None,
     )
     .unwrap()
 }
@@ -565,6 +567,8 @@ fn test_invoice_new_deduplicates_trimmed_casefolded_tags() {
             String::from_str(&env, "Normalized tags"),
             InvoiceCategory::Services,
             tags,
+            None,
+            None,
         )
         .expect("invoice creation should normalize tags");
 

--- a/quicklendx-contracts/src/test_line_item_consistency.rs
+++ b/quicklendx-contracts/src/test_line_item_consistency.rs
@@ -28,6 +28,8 @@ fn make_invoice_with_amount(env: &Env, business: &Address, amount: i128) -> Invo
         String::from_str(env, "Test invoice"),
         InvoiceCategory::Services,
         tags,
+        None,
+        None,
     )
     .unwrap()
 }

--- a/quicklendx-contracts/src/test_overflow.rs
+++ b/quicklendx-contracts/src/test_overflow.rs
@@ -338,6 +338,8 @@ fn test_timestamp_invoice_grace_deadline_saturates() {
             String::from_str(&env, "Test"),
             InvoiceCategory::Services,
             Vec::new(&env),
+            None,
+            None,
         )
     });
     let deadline = inv.unwrap().grace_deadline(grace_period);

--- a/quicklendx-contracts/src/test_rating_override.rs
+++ b/quicklendx-contracts/src/test_rating_override.rs
@@ -52,6 +52,8 @@ fn seed_invoice(env: &Env, contract_id: &Address) -> BytesN<32> {
             String::from_str(env, "Test invoice"),
             InvoiceCategory::Services,
             Vec::new(env),
+            None,
+            None,
         )
         .unwrap();
         let id = invoice.id.clone();

--- a/quicklendx-contracts/src/types.rs
+++ b/quicklendx-contracts/src/types.rs
@@ -226,6 +226,11 @@ pub struct Invoice {
     pub total_paid: i128,
     pub payment_history: Vec<PaymentRecord>,
     pub origination_fee_bps: Option<u32>,
+    /// Per-invoice late payment penalty in basis points (0–5000 bps, i.e. 0–50%).
+    /// When `Some`, this overrides the global `LATE_FEE_SURCHARGE_BPS` constant
+    /// during late-payment fee calculation. `None` falls back to the default
+    /// 20 % surcharge.
+    pub late_payment_penalty_bps: Option<u32>,
 }
 
 pub const RATINGS_SNAPSHOT_SCHEMA_VERSION: u32 = 1;
@@ -264,6 +269,9 @@ pub struct InvoiceInput {
     pub category: InvoiceCategory,
     /// Optional searchable tags (max `MAX_INVOICE_TAGS` entries, each max 50 bytes).
     pub tags: Vec<String>,
+    /// Per-invoice late payment penalty in basis points (0–5000).
+    /// Applied when a payment lands after the invoice due date.
+    pub late_payment_penalty_bps: Option<u32>,
 }
 
 /// Helper struct for metadata updates


### PR DESCRIPTION
## Overview

Applied when a payment lands after the due date. This adds a per-invoice `late_payment_penalty_bps` field that overrides the global `LATE_FEE_SURCHARGE_BPS` constant when set.

## Related Issue

Closes #1817

## Changes

### 📄 Invoice Config
- **\[ADD]** `late_payment_penalty_bps: Option<u32>` to `Invoice` and `InvoiceInput` structs in `types.rs`
- **\[MODIFY]** `Invoice::new()` in `invoice.rs` — accepts `late_payment_penalty_bps` param with validation (0–5000 bps)
- **\[MODIFY]** `fees.rs` — `calculate_total_fees` uses per-invoice value; falls back to `LATE_FEE_SURCHARGE_BPS` (2000) when `None`
- **\[MODIFY]** `lib.rs` — `store_invoice`, `upload_invoice`, `store_invoices_batch`, `calculate_transaction_fees` pass through the field
- **\[MODIFY]** All test files updated with `None` for the new parameter

## Verification Results
- `cargo build` succeeds
- All existing test call sites updated
- Backwards-compatible: `None` falls back to existing behaviour