### PR TITLE
test: enforce max_due_date_days cap in extend_escrow_expiry (#2184)

### DIFF
--- a/quicklendx-contracts/src/lib.rs
+++ b/quicklendx-contracts/src/lib.rs
@@ -51,6 +51,9 @@ mod test_settlement_history_reconstruction;
 // Issue #1920 — confirm require_regulatory_ok is truly a no-op by default.
 #[cfg(test)]
 mod test_regulatory_gate;
+// Issue #2184 — extend_escrow_expiry must enforce the max_due_date_days ledger cap.
+#[cfg(test)]
+mod test_escrow_expiry_extend;
 use crate::idempotency::{idempotency_exists, idempotency_key, store_idempotency};
 use soroban_sdk::{contract, contractimpl, symbol_short, Address, BytesN, Env, Map, String, Vec};
 
@@ -4884,6 +4887,13 @@ impl QuickLendXContract {
         }
 
         if new_due_date <= invoice.due_date {
+            return Err(QuickLendXError::InvoiceDueDateInvalid);
+        }
+
+        let limits = protocol_limits::ProtocolLimitsContract::get_protocol_limits(env.clone());
+        let max_horizon = limits.max_due_date_days.saturating_mul(86_400);
+        let max_allowed = env.ledger().timestamp().saturating_add(max_horizon);
+        if new_due_date > max_allowed {
             return Err(QuickLendXError::InvoiceDueDateInvalid);
         }
 

--- a/quicklendx-contracts/src/test_escrow_expiry_extend.rs
+++ b/quicklendx-contracts/src/test_escrow_expiry_extend.rs
@@ -194,3 +194,34 @@ fn extend_escrow_expiry_not_held() {
     // This should fail with InvalidStatus
     client.extend_escrow_expiry(&admin, &inv_id, &new_due_date);
 }
+
+#[test]
+#[should_panic(expected = "HostError: Error(Value, InvalidInput)")]
+fn extend_escrow_expiry_past_ledger_cap() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+
+    let (admin, _investor, _business, inv_id, _currency, client) = setup_escrow(&env);
+
+    // Default max_due_date_days is 365.  Setting a due date more than 365 days
+    // from now must be rejected by the ledger-cap guard.
+    let past_cap = env.ledger().timestamp() + SECONDS_PER_DAY * 366;
+    client.extend_escrow_expiry(&admin, &inv_id, &past_cap);
+}
+
+#[test]
+fn extend_escrow_expiry_at_ledger_cap_boundary() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+
+    let (admin, _investor, _business, inv_id, _currency, client) = setup_escrow(&env);
+
+    // Exactly at the 365-day cap boundary should succeed.
+    let at_cap = env.ledger().timestamp() + SECONDS_PER_DAY * 365;
+    client.extend_escrow_expiry(&admin, &inv_id, &at_cap);
+
+    let updated = InvoiceStorage::get_invoice(&env, &inv_id).unwrap();
+    assert_eq!(updated.due_date, at_cap);
+}


### PR DESCRIPTION
Add ledger-cap validation to extend_escrow_expiry so that an admin cannot extend an invoice due date beyond the protocol's max_due_date_days horizon.  Without this guard the due date could be pushed arbitrarily far into the future, bypassing the same cap that is enforced at invoice creation time.

Also register the previously unlinked test module and add two new tests:

- extend_escrow_expiry_past_ledger_cap (happy-path failure): setting a due date more than max_due_date_days from now must be rejected with InvoiceDueDateInvalid.
- extend_escrow_expiry_at_ledger_cap_boundary (happy path): setting a due date exactly at the cap boundary must succeed.

Closes #2184