### PR TITLE
Config: expose the corridor list as init arg

### DIFF
--- a/quicklendx-contracts/src/contract.rs
+++ b/quicklendx-contracts/src/contract.rs
@@ -29,6 +29,7 @@ impl QuickLendXContract {
         max_due_date_days: u64,
         grace_period_seconds: u64,
         initial_currencies: Vec<Address>,
+        corridors: Vec<Address>,
     ) -> Result<(), QuickLendXError> {
         let params = InitializationParams {
             admin,
@@ -38,7 +39,8 @@ impl QuickLendXContract {
             max_due_date_days,
             grace_period_seconds,
             initial_currencies,
-        backfill_max_batch_size: 100,
+            corridors,
+            backfill_max_batch_size: 100,
         };
         ProtocolInitializer::initialize(&env, &params)
     }

--- a/quicklendx-contracts/src/events.rs
+++ b/quicklendx-contracts/src/events.rs
@@ -6,7 +6,7 @@ use crate::payments::Escrow;
 use crate::types::Bid;
 use crate::types::{Invoice, InvoiceMetadata, PlatformFeeConfig};
 use crate::verification::InvestorVerification;
-use soroban_sdk::{contractevent, symbol_short, Address, BytesN, Env, String, Symbol};
+use soroban_sdk::{contractevent, symbol_short, Address, BytesN, Env, String, Symbol, Vec};
 
 // ============================================================================
 // Topic Constants
@@ -685,6 +685,7 @@ pub struct ProtocolInitialized {
     pub max_due_date_days: u64,
     pub grace_period_seconds: u64,
     pub backfill_max_batch_size: u32,
+    pub corridors: Vec<Address>,
     pub timestamp: u64,
 }
 
@@ -1528,6 +1529,7 @@ pub fn emit_protocol_initialized(
     max_due_date_days: u64,
     grace_period_seconds: u64,
     backfill_max_batch_size: u32,
+    corridors: &Vec<Address>,
 ) {
     ProtocolInitialized {
         admin: admin.clone(),
@@ -1537,6 +1539,7 @@ pub fn emit_protocol_initialized(
         max_due_date_days,
         grace_period_seconds,
         backfill_max_batch_size,
+        corridors: corridors.clone(),
         timestamp: env.ledger().timestamp(),
     }
     .publish(env);

--- a/quicklendx-contracts/src/health.rs
+++ b/quicklendx-contracts/src/health.rs
@@ -165,6 +165,7 @@ mod tests {
                 v.push_back(currency.clone());
                 v
             },
+            corridors: soroban_sdk::Vec::new(&env),
             backfill_max_batch_size: 100,
         };
 

--- a/quicklendx-contracts/src/init.rs
+++ b/quicklendx-contracts/src/init.rs
@@ -54,6 +54,9 @@ const FEE_BPS_KEY: Symbol = symbol_short!("fee_bps");
 /// Storage key for currency whitelist
 const WHITELIST_KEY: Symbol = symbol_short!("curr_wl");
 
+/// Storage key for corridor list
+const CORRIDORS_KEY: Symbol = symbol_short!("corridors");
+
 /// Storage key for initialization lock (prevents concurrent initialization)
 const INIT_LOCK_KEY: Symbol = symbol_short!("init_lck");
 
@@ -136,6 +139,8 @@ pub struct InitializationParams {
     pub grace_period_seconds: u64,
     /// Initial whitelisted currencies
     pub initial_currencies: Vec<Address>,
+    /// Initial corridor list (approved counterparty addresses for cross-invoice operations)
+    pub corridors: Vec<Address>,
     /// Maximum number of items processed in a single backfill or heavy run
     pub backfill_max_batch_size: u32,
 }
@@ -335,6 +340,11 @@ impl ProtocolInitializer {
                 .instance()
                 .get(&WHITELIST_KEY)
                 .unwrap_or(Vec::new(env));
+            let current_corridors: Vec<Address> = env
+                .storage()
+                .instance()
+                .get(&CORRIDORS_KEY)
+                .unwrap_or(Vec::new(env));
 
             if let (Some(c_admin), Some(c_treasury), Some(c_fee), Some(c_conf)) = (
                 current_admin,
@@ -350,6 +360,7 @@ impl ProtocolInitializer {
                     && c_conf.grace_period_seconds == params.grace_period_seconds
                     && c_conf.backfill_max_batch_size == params.backfill_max_batch_size
                     && current_whitelist == params.initial_currencies
+                    && current_corridors == params.corridors
                 {
                     return Ok(());
                 }
@@ -404,6 +415,13 @@ impl ProtocolInitializer {
                 .set(&WHITELIST_KEY, &params.initial_currencies);
         }
 
+        // Initialize corridor list with provided addresses
+        if !params.corridors.is_empty() {
+            env.storage()
+                .instance()
+                .set(&CORRIDORS_KEY, &params.corridors);
+        }
+
         // ATOMIC: Persist the protocol version so get_version is consistent
         // with the version that was active at initialization time.
         env.storage()
@@ -425,6 +443,7 @@ impl ProtocolInitializer {
             params.max_due_date_days,
             params.grace_period_seconds,
             params.backfill_max_batch_size,
+            &params.corridors,
         );
 
         Ok(())
@@ -535,6 +554,25 @@ impl ProtocolInitializer {
             for j in (i + 1)..len {
                 if curr == params.initial_currencies.get(j).unwrap() {
                     return Err(QuickLendXError::InvalidCurrency);
+                }
+            }
+        }
+
+        // VALIDATION: Corridor list must not contain duplicates, reserved
+        // addresses, or the well-known zero/burn address.
+        let corridor_len = params.corridors.len();
+        for i in 0..corridor_len {
+            let corridor = params.corridors.get(i).unwrap();
+            if corridor == params.admin
+                || corridor == params.treasury
+                || corridor == contract_address
+                || corridor == zero
+            {
+                return Err(QuickLendXError::InvalidAddress);
+            }
+            for j in (i + 1)..corridor_len {
+                if corridor == params.corridors.get(j).unwrap() {
+                    return Err(QuickLendXError::InvalidAddress);
                 }
             }
         }
@@ -942,6 +980,20 @@ impl ProtocolInitializer {
             .map(|config| config.grace_period_seconds)
             .unwrap_or(DEFAULT_GRACE_PERIOD_SECONDS)
     }
+
+    /// Get the corridor list.
+    ///
+    /// # Arguments
+    /// * `env` - The contract environment
+    ///
+    /// # Returns
+    /// * The stored corridor address list (empty vec if not set)
+    pub fn get_corridors(env: &Env) -> Vec<Address> {
+        env.storage()
+            .instance()
+            .get(&CORRIDORS_KEY)
+            .unwrap_or(Vec::new(env))
+    }
 }
 
 // ============================================================================
@@ -959,6 +1011,7 @@ fn emit_protocol_initialized(
     max_due_date_days: u64,
     grace_period_seconds: u64,
     backfill_max_batch_size: u32,
+    corridors: &Vec<Address>,
 ) {
     crate::events::emit_protocol_initialized(
         env,
@@ -969,6 +1022,7 @@ fn emit_protocol_initialized(
         max_due_date_days,
         grace_period_seconds,
         backfill_max_batch_size,
+        corridors,
     );
 }
 

--- a/quicklendx-contracts/src/lib.rs
+++ b/quicklendx-contracts/src/lib.rs
@@ -740,6 +740,11 @@ impl QuickLendXContract {
         init::ProtocolInitializer::get_grace_period_seconds(&env)
     }
 
+    /// Get the corridor list (approved counterparty addresses for cross-invoice operations)
+    pub fn get_corridors(env: Env) -> Vec<Address> {
+        init::ProtocolInitializer::get_corridors(&env)
+    }
+
     /// Admin-only: configure default bid TTL (days). Bounds: 1..=30.
     pub fn set_bid_ttl_days(env: Env, days: u64) -> Result<u64, QuickLendXError> {
         pause::PauseControl::require_not_paused(&env)?;

--- a/quicklendx-contracts/src/test_init.rs
+++ b/quicklendx-contracts/src/test_init.rs
@@ -42,6 +42,8 @@ mod test_init {
             max_due_date_days: 365,
             grace_period_seconds: 604800, // 7 days
             initial_currencies: Vec::new(env),
+            corridors: Vec::new(env),
+            backfill_max_batch_size: 100,
         }
     }
 
@@ -444,6 +446,8 @@ mod test_init {
             max_due_date_days: 0,
             grace_period_seconds: 0,
             initial_currencies: Vec::new(&env),
+            corridors: Vec::new(&env),
+            backfill_max_batch_size: 100,
         };
 
         let result = client.try_initialize(&params);
@@ -490,6 +494,8 @@ mod test_init {
             max_due_date_days: 0,
             grace_period_seconds: 0,
             initial_currencies: Vec::new(&env),
+            corridors: Vec::new(&env),
+            backfill_max_batch_size: 100,
         };
 
         let result = client.try_initialize(&params);

--- a/quicklendx-contracts/src/test_init_debug.rs
+++ b/quicklendx-contracts/src/test_init_debug.rs
@@ -27,6 +27,7 @@ fn base_params(
         max_due_date_days: 365,
         grace_period_seconds: 604800,
         initial_currencies: currencies,
+        corridors: Vec::new(&env),
         backfill_max_batch_size: 100,
     }
 }

--- a/quicklendx-contracts/src/test_init_invariants.rs
+++ b/quicklendx-contracts/src/test_init_invariants.rs
@@ -46,6 +46,7 @@ fn valid_params(env: &Env) -> InitializationParams {
         max_due_date_days: 365,
         grace_period_seconds: 604_800, // 7 days
         initial_currencies: Vec::new(env),
+        corridors: Vec::new(env),
         backfill_max_batch_size: 100,
     }
 }
@@ -54,8 +55,7 @@ fn valid_params(env: &Env) -> InitializationParams {
 fn initialized(env: &Env, client: &QuickLendXContractClient) -> InitializationParams {
     let p = valid_params(env);
     client.initialize(&p);
-    p,
-        backfill_max_batch_size: 100,
+    p
 }
 
 // ===========================================================================
@@ -811,5 +811,133 @@ fn test_validation_order_fee_before_amount() {
     assert_eq!(
         client.try_initialize(&p),
         Err(Ok(QuickLendXError::InvalidFeeBasisPoints)),
+    );
+}
+
+// ===========================================================================
+// 7. CORRIDOR LIST TESTS
+// ===========================================================================
+
+/// Happy path: initializing with an empty corridor list must succeed.
+#[test]
+fn test_init_with_empty_corridors_succeeds() {
+    let (env, client) = setup();
+    let mut p = valid_params(&env);
+    p.corridors = Vec::new(&env);
+    assert!(client.try_initialize(&p).is_ok());
+    let stored = ProtocolInitializer::get_corridors(&env);
+    assert!(stored.is_empty());
+}
+
+/// Happy path: initializing with a non-empty corridor list must succeed.
+#[test]
+fn test_init_with_non_empty_corridors_succeeds() {
+    let (env, client) = setup();
+    let corridor1 = Address::generate(&env);
+    let corridor2 = Address::generate(&env);
+    let mut p = valid_params(&env);
+    p.corridors = Vec::from_array(&env, [corridor1.clone(), corridor2.clone()]);
+    assert!(client.try_initialize(&p).is_ok());
+    let stored = ProtocolInitializer::get_corridors(&env);
+    assert_eq!(stored.len(), 2);
+    assert_eq!(stored.get(0).unwrap(), corridor1);
+    assert_eq!(stored.get(1).unwrap(), corridor2);
+}
+
+/// Failure mode: duplicate corridors must be rejected.
+#[test]
+fn test_init_with_duplicate_corridors_fails() {
+    let (env, client) = setup();
+    let addr = Address::generate(&env);
+    let mut p = valid_params(&env);
+    p.corridors = Vec::from_array(&env, [addr.clone(), addr]);
+    assert_eq!(
+        client.try_initialize(&p),
+        Err(Ok(QuickLendXError::InvalidAddress)),
+    );
+}
+
+/// Failure mode: corridor equal to admin must be rejected.
+#[test]
+fn test_init_with_corridor_equal_to_admin_fails() {
+    let (env, client) = setup();
+    let mut p = valid_params(&env);
+    let admin = p.admin.clone();
+    p.corridors = Vec::from_array(&env, [admin]);
+    assert_eq!(
+        client.try_initialize(&p),
+        Err(Ok(QuickLendXError::InvalidAddress)),
+    );
+}
+
+/// Failure mode: corridor equal to treasury must be rejected.
+#[test]
+fn test_init_with_corridor_equal_to_treasury_fails() {
+    let (env, client) = setup();
+    let mut p = valid_params(&env);
+    let treasury = p.treasury.clone();
+    p.corridors = Vec::from_array(&env, [treasury]);
+    assert_eq!(
+        client.try_initialize(&p),
+        Err(Ok(QuickLendXError::InvalidAddress)),
+    );
+}
+
+/// Failure mode: corridor equal to the contract address must be rejected.
+#[test]
+fn test_init_with_corridor_equal_to_contract_fails() {
+    let (env, client) = setup();
+    let contract_id = env.register(QuickLendXContract, ());
+    let client2 = QuickLendXContractClient::new(&env, &contract_id);
+    let mut p = valid_params(&env);
+    p.corridors = Vec::from_array(&env, [contract_id]);
+    assert_eq!(
+        client2.try_initialize(&p),
+        Err(Ok(QuickLendXError::InvalidAddress)),
+    );
+}
+
+/// Failure mode: corridor equal to zero address must be rejected.
+#[test]
+fn test_init_with_corridor_equal_to_zero_fails() {
+    let (env, client) = setup();
+    let zero = Address::from_string(&soroban_sdk::String::from_str(
+        &env,
+        "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
+    ));
+    let mut p = valid_params(&env);
+    p.corridors = Vec::from_array(&env, [zero]);
+    assert_eq!(
+        client.try_initialize(&p),
+        Err(Ok(QuickLendXError::InvalidAddress)),
+    );
+}
+
+/// Idempotency: re-initializing with the same corridor list must succeed.
+#[test]
+fn test_reinit_with_same_corridors_succeeds() {
+    let (env, client) = setup();
+    let p = valid_params(&env);
+    client.initialize(&p);
+    assert!(client.try_initialize(&p).is_ok());
+}
+
+/// Stored corridors survive a re-init with the same params.
+#[test]
+fn test_corridors_persist_across_idempotent_reinit() {
+    let (env, client) = setup();
+    let corridor = Address::generate(&env);
+    let mut p = valid_params(&env);
+    p.corridors = Vec::from_array(&env, [corridor.clone()]);
+    client.initialize(&p);
+    assert_eq!(
+        ProtocolInitializer::get_corridors(&env).get(0).unwrap(),
+        corridor,
+    );
+    // Idempotent reinit
+    assert!(client.try_initialize(&p).is_ok());
+    assert_eq!(
+        ProtocolInitializer::get_corridors(&env).get(0).unwrap(),
+        corridor,
     );
 }

--- a/quicklendx-contracts/src/test_protocol_health.rs
+++ b/quicklendx-contracts/src/test_protocol_health.rs
@@ -42,9 +42,9 @@ fn setup_initialized_with_admin() -> (Env, Address, Address) {
         initial_currencies: {
             let mut v = soroban_sdk::Vec::new(&env);
             v.push_back(currency1);
-            v,
-        backfill_max_batch_size: 100,
+            v
         },
+        corridors: soroban_sdk::Vec::new(&env),
         backfill_max_batch_size: 100,
     };
 

--- a/quicklendx-contracts/src/test_protocol_limits.rs
+++ b/quicklendx-contracts/src/test_protocol_limits.rs
@@ -267,6 +267,7 @@ fn test_initialize_rejects_invalid_limit_combination_before_state_commit() {
         max_due_date_days: 1,
         grace_period_seconds: 86_401,
         initial_currencies: Vec::new(&env),
+        corridors: Vec::new(&env),
         backfill_max_batch_size: 100,
     };
 

--- a/quicklendx-contracts/src/test_ratings_snapshot.rs
+++ b/quicklendx-contracts/src/test_ratings_snapshot.rs
@@ -20,6 +20,9 @@ fn test_ratings_snapshot_lifecycle() {
         min_invoice_amount: 100,
         max_due_date_days: 90,
         grace_period_seconds: 86400,
+        initial_currencies: soroban_sdk::Vec::new(&env),
+        corridors: soroban_sdk::Vec::new(&env),
+        backfill_max_batch_size: 100,
     });
     
     let business = Address::generate(&env);


### PR DESCRIPTION
## 📝 Description

Expose the corridor list as an init argument for the protocol. This adds a `corridors` field to `InitializationParams` so the list of approved counterparty addresses can be configured at deployment time rather than being hardcoded.

## 🎯 Type of Change
- [x] New feature

## 🔧 Changes Made

### Files Modified
- `quicklendx-contracts/src/init.rs` — Added `CORRIDORS_KEY`, `corridors` field to `InitializationParams`, validation (no duplicates/reserved addresses), storage writes, `get_corridors()` query
- `quicklendx-contracts/src/events.rs` — Added `corridors` to `ProtocolInitialized` event struct and emitter
- `quicklendx-contracts/src/lib.rs` — Added `get_corridors()` public entry point
- `quicklendx-contracts/src/contract.rs` — Added `corridors` parameter to `initialize()`
- `quicklendx-contracts/src/test_init_invariants.rs` — 9 new corridor tests + fixed pre-existing bug in `initialized()` helper
- `quicklendx-contracts/src/test_init.rs`, `test_init_debug.rs`, `health.rs`, `test_protocol_limits.rs`, `test_protocol_health.rs`, `test_ratings_snapshot.rs` — Added `corridors` to all `InitializationParams` constructors

### Key Changes
- New `corridors: Vec<Address>` field on `InitializationParams`
- Sane default: empty vec when not provided
- Validation mirrors currency whitelist pattern: no reserved addresses, no duplicates
- Stored in instance storage under `corridors` key
- Emitted in `ProtocolInitialized` event
- 9 tests covering happy path + 5 explicit failure modes

## 🧪 Testing
- [ ] Unit tests pass (requires Rust toolchain to run `cargo test`)
- [ ] No breaking changes introduced

### Test Coverage
- Empty corridor list init succeeds
- Non-empty corridor list stores correctly
- Duplicate corridors rejected (`InvalidAddress`)
- Corridor == admin rejected (`InvalidAddress`)
- Corridor == treasury rejected (`InvalidAddress`)
- Corridor == contract address rejected (`InvalidAddress`)
- Corridor == zero address rejected (`InvalidAddress`)
- Idempotent re-init with same corridors succeeds
- Corridors persist across idempotent re-init

## 📋 Contract-Specific Checks
- [ ] Soroban contract builds successfully
- [x] No gas usage change for existing flows (empty vec = no-op)
- [x] Events properly emitted
- [x] Error handling implemented

## 🔗 Related Issues
Closes #2183
