### PR TITLE
docs: add insurance claim lifecycle doc (Closes #1983)

### DIFF
--- a/docs/QLX_INSURANCE_CLAIM_LIFECYCLE.md
+++ b/docs/QLX_INSURANCE_CLAIM_LIFECYCLE.md
@@ -1,0 +1,69 @@
+# QuickLendX Insurance Claim Lifecycle
+
+This document describes the insurance lifecycle in the QuickLendX protocol for downstream integrators and smart contract developers. It explains how an investment opts into insurance and how claims are processed upon default.
+
+## 1. Opt-In: Adding Insurance to an Investment
+
+An investor or protocol automation can attach insurance to an active investment. Insurance bounds the downside risk in exchange for a premium.
+
+### Entrypoint
+The coverage is added via the `Investment::add_insurance` method:
+
+```rust
+// quicklendx-contracts/src/investment.rs
+pub fn add_insurance(
+    &mut self,
+    provider: Address,
+    coverage_percentage: u32,
+    premium: i128,
+) -> Result<i128, QuickLendXError>
+```
+
+### Concrete Example
+If an investor funds a 1,000 USDC invoice and wants 50% coverage, they might invoke this method with:
+- `provider`: The Soroban `Address` of the insurance pool.
+- `coverage_percentage`: `50` (meaning 50% of the principal is covered).
+- `premium`: The pre-computed premium amount (e.g., `20` USDC, typically 200 bps of the coverage).
+
+This creates an active `InsuranceCoverage` record on the investment.
+
+## 2. Settlement Constraints
+
+Before an invoice defaults, the system enforces that all active policies remain valid. During settlement or default transitions, `require_active_insurance_at_settlement` ensures that if an investment has policies attached, they are still active. If policies were voided prematurely, the transaction will fail with `QuickLendXError::InsuranceNotActive`.
+
+## 3. Claim Processing: The Default Lifecycle
+
+If the borrower fails to repay and the invoice expires, any authorized operator can trigger the default flow.
+
+### Entrypoint
+The default is processed via the `process_invoice_default` function in `quicklendx-contracts/src/defaults.rs`.
+
+During this transition, the protocol automatically processes all active insurance claims atomically:
+
+```rust
+// quicklendx-contracts/src/investment.rs
+pub fn process_all_insurance_claims(&mut self, env: &Env) -> Vec<(Address, i128)>
+```
+
+### Concrete Example
+When `process_invoice_default` is called for the 1,000 USDC invoice with a 50% coverage policy:
+1. The investment's status is updated to `InvestmentStatus::Defaulted`.
+2. `process_all_insurance_claims` iterates over all policies. For our active policy, it sets `active = false` and adds the 500 USDC claim to the payout list.
+3. The protocol emits an `InsuranceClaimed` event so off-chain indexers and downstream contracts can process the actual token transfer from the insurance provider to the investor.
+
+### Event Output
+The emitted `InsuranceClaimed` event looks like this:
+```rust
+InsuranceClaimed {
+    investment_id: BytesN<32>, // The ID of the defaulted investment
+    invoice_id: BytesN<32>,    // The ID of the underlying invoice
+    provider: Address,         // The provider's address
+    amount: i128,              // The exact claim amount (e.g., 500_0000000)
+}
+```
+
+By listening to this event, an integrating insurance provider contract knows exactly when and how much to disburse.
+
+---
+
+*See also: [README](../README.md) for top-level project overview.*

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,6 +22,7 @@
 | [audit.md](contracts/audit.md) | Audit trail and hash chain |
 | [CROSS_INVOICE_ANALYTICS.md](CROSS_INVOICE_ANALYTICS.md) | Cross-invoice read patterns, supported entrypoints, and pagination bounds for contributors and integrators |
 | [UPGRADE_QUIESCE.md](UPGRADE_QUIESCE.md) | How writes drain before a contract upgrade — maintenance mode, drain window, and operator checklist |
+| [QLX_INSURANCE_CLAIM_LIFECYCLE.md](QLX_INSURANCE_CLAIM_LIFECYCLE.md) | From opt-in to claim to close. The insurance claim lifecycle for downstream integrators and operators |
 | [OPERATIONAL_PLAYBOOKS.md](OPERATIONAL_PLAYBOOKS.md) | Protocol reasons, meaning, and operational playbooks |
 
 ## Backend reference


### PR DESCRIPTION
Closes #1983

### Summary
This PR resolves #1983 by introducing `docs/QLX_INSURANCE_CLAIM_LIFECYCLE.md`. It explicitly documents the insurance opt-in, verification, and claim dispatch loop, replacing tribal knowledge with a canonical guide for downstream integrators.

### What Changed
- Created `docs/QLX_INSURANCE_CLAIM_LIFECYCLE.md` targeted at operators and integrators mapping `add_insurance`, `require_active_insurance_at_settlement`, and `process_all_insurance_claims`.
- Added concrete event outputs (e.g., `InsuranceClaimed`) for ease of integration.
- Indexed the document within `docs/README.md`.

### Acceptance Criteria Checklist
- [x] Change matches the issue summary.
- [x] Linked from at least one existing top-level doc (`docs/README.md`).
- [x] Examples in the document compile/match current behavior.
- [x] Lint, type-check, and tests all pass (changes are strictly Markdown).
- [x] PR description references the issue with `Closes #1983`.

### Notes
No functional codebase or dependencies were touched.