### PR TITLE
fix: balance_o returns stale value after mid-tx transfer

### DIFF
--- a/quicklendx-contracts/src/escrow.rs
+++ b/quicklendx-contracts/src/escrow.rs
@@ -19,7 +19,7 @@
 use crate::admin::AdminStorage;
 use crate::errors::QuickLendXError;
 use crate::events::{emit_escrow_refunded, emit_investment_withdrawn, emit_invoice_funded};
-use crate::payments::{create_escrow, refund_escrow, EscrowStatus, EscrowStorage};
+use crate::payments::{create_escrow, create_escrow_record_only, refund_escrow, EscrowStatus, EscrowStorage};
 use crate::storage::{BidStorage, InvestmentStorage, InvoiceStorage};
 use crate::types::{BidStatus, Investment, InvestmentStatus, InvoiceStatus};
 use crate::verification::{require_business_active, require_business_not_pending};
@@ -135,16 +135,42 @@ pub fn accept_bid_and_fund(
         escrow_amount = bid.bid_amount.checked_sub(total_fee).ok_or(QuickLendXError::ArithmeticOverflow)?;
         
         if total_fee > 0 {
-            crate::payments::transfer_funds(env, &invoice.currency, &bid.investor, &env.current_contract_address(), total_fee)?;
+            // Single transfer for the full bid amount avoids a stale balance read
+            // that could occur when two sequential transfer_funds calls are made
+            // from the same source address within one transaction.
+            crate::payments::transfer_funds(env, &invoice.currency, &bid.investor, &env.current_contract_address(), bid.bid_amount)?;
             
             let mut fees_collected = soroban_sdk::Map::new(env);
             fees_collected.set(crate::fees::FeeType::Origination, total_fee);
             crate::fees::FeeManager::collect_fees(env, &bid.investor, fees_collected, total_fee)?;
+            
+            // Funds are already in the contract from the single transfer above.
+            // Create the escrow record without a second transfer.
+            let escrow_id = create_escrow_record_only(
+                env,
+                invoice_id,
+                &bid.investor,
+                &invoice.business,
+                escrow_amount,
+                &invoice.currency,
+            )?;
+
+            // 6. Update states
+            update_states_after_funding(env, invoice_id, &mut invoice, &mut bid)?;
+
+            crate::qlx_log!(env, "escrow", "Invoice funded and bid accepted");
+
+            // 7. Events
+            emit_invoice_funded(env, invoice_id, &bid.investor, bid.bid_amount);
+
+            // Lifecycle trigger: emits `NotificationType::BidAccepted` to the investor
+            let _ = crate::notifications::NotificationSystem::notify_bid_accepted(env, &invoice, &bid);
+
+            return Ok(escrow_id);
         }
     }
 
-    // 5. Lock funds in escrow
-    // This calls payments::create_escrow which calls token transfer and emits emit_escrow_created
+    // No fee, or fee is zero: use the standard create_escrow which handles its own transfer.
     let escrow_id = create_escrow(
         env,
         invoice_id,
@@ -155,28 +181,42 @@ pub fn accept_bid_and_fund(
     )?;
 
     // 6. Update states
+    update_states_after_funding(env, invoice_id, &mut invoice, &mut bid)?;
 
-    // Update Bid
+    crate::qlx_log!(env, "escrow", "Invoice funded and bid accepted");
+
+    // 7. Events
+    emit_invoice_funded(env, invoice_id, &bid.investor, bid.bid_amount);
+
+    // Lifecycle trigger: emits `NotificationType::BidAccepted` to the investor
+    // after escrow funding and state transitions complete successfully.
+    let _ = crate::notifications::NotificationSystem::notify_bid_accepted(env, &invoice, &bid);
+
+    Ok(escrow_id)
+}
+
+/// State transitions that follow a successful escrow creation and funding.
+fn update_states_after_funding(
+    env: &Env,
+    invoice_id: &BytesN<32>,
+    invoice: &mut crate::types::Invoice,
+    bid: &mut crate::types::Bid,
+) -> Result<(), QuickLendXError> {
     bid.status = BidStatus::Accepted;
-    BidStorage::update_bid(env, &bid);
+    BidStorage::update_bid(env, bid);
 
-    // Update Invoice
-    // Remove from old status list before changing status
     InvoiceStorage::remove_from_status_invoices(env, InvoiceStatus::Verified, invoice_id);
 
-    // mark_as_funded updates status, funded_amount, investor, and logs audit
     invoice.mark_as_funded(
         env,
         bid.investor.clone(),
         bid.bid_amount,
         env.ledger().timestamp(),
     );
-    InvoiceStorage::update_invoice(env, &invoice);
+    InvoiceStorage::update_invoice(env, invoice);
 
-    // Add to new status list after status change
     InvoiceStorage::add_to_status_invoices(env, InvoiceStatus::Funded, invoice_id);
 
-    // Create Investment
     let investment_id = InvestmentStorage::generate_unique_investment_id(env);
     let investment = Investment {
         investment_id: investment_id.clone(),
@@ -189,16 +229,7 @@ pub fn accept_bid_and_fund(
     };
     InvestmentStorage::store_investment(env, &investment);
 
-    crate::qlx_log!(env, "escrow", "Invoice funded and bid accepted");
-
-    // 7. Events
-    emit_invoice_funded(env, invoice_id, &bid.investor, bid.bid_amount);
-
-    // Lifecycle trigger: emits `NotificationType::BidAccepted` to the investor
-    // after escrow funding and state transitions complete successfully.
-    let _ = crate::notifications::NotificationSystem::notify_bid_accepted(env, &invoice, &bid);
-
-    Ok(escrow_id)
+    Ok(())
 }
 
 /// Explicitly refund escrowed funds to the investor.

--- a/quicklendx-contracts/src/payments.rs
+++ b/quicklendx-contracts/src/payments.rs
@@ -436,6 +436,67 @@ impl EscrowStorage {
     }
 }
 
+/// Shared validation logic for escrow creation.
+///
+/// Returns `(next_held_reserve)` on success.
+fn validate_and_prepare_escrow(
+    env: &Env,
+    invoice_id: &BytesN<32>,
+    investor: &Address,
+    business: &Address,
+    amount: i128,
+    currency: &Address,
+) -> Result<HeldEscrowReserve, QuickLendXError> {
+    if amount <= 0 {
+        return Err(QuickLendXError::InvalidAmount);
+    }
+
+    if EscrowStorage::get_escrow_by_invoice(env, invoice_id).is_some() {
+        return Err(QuickLendXError::InvoiceAlreadyFunded);
+    }
+
+    EscrowStorage::require_no_active_reserve_repair(env, currency)?;
+    let next_held_reserve = EscrowStorage::held_reserve_after_increase(env, currency, amount)?;
+
+    validate_token_address(env, currency, investor)?;
+
+    Ok(next_held_reserve)
+}
+
+/// Write the escrow record and update the held-reserve accumulator.
+///
+/// # Panics
+/// Panics if `next_held_reserve` was not obtained by calling
+/// [`validate_and_prepare_escrow`] with the same arguments.
+fn write_escrow_record(
+    env: &Env,
+    invoice_id: &BytesN<32>,
+    investor: &Address,
+    business: &Address,
+    amount: i128,
+    currency: &Address,
+    next_held_reserve: &HeldEscrowReserve,
+) -> BytesN<32> {
+    let escrow_id = EscrowStorage::generate_unique_escrow_id(env);
+    let escrow = Escrow {
+        escrow_id: escrow_id.clone(),
+        invoice_id: invoice_id.clone(),
+        investor: investor.clone(),
+        business: business.clone(),
+        amount,
+        currency: currency.clone(),
+        created_at: env.ledger().timestamp(),
+        status: EscrowStatus::Held,
+    };
+
+    EscrowStorage::store_escrow(env, &escrow);
+    EscrowStorage::set_held_reserve_record(env, currency, next_held_reserve);
+    EscrowStorage::mark_reserve_accounted(env, &escrow_id);
+    crate::qlx_log!(env, "payment", "Escrow created successfully");
+    emit_escrow_created(env, &escrow);
+    escrow_id
+}
+
 /// Create escrow: transfer `amount` from investor to contract and store escrow record.
 ///
 /// ## One-Escrow-Per-Invoice Guard
@@ -468,20 +529,7 @@ pub fn create_escrow(
     amount: i128,
     currency: &Address,
 ) -> Result<BytesN<32>, QuickLendXError> {
-    if amount <= 0 {
-        return Err(QuickLendXError::InvalidAmount);
-    }
-
-    if EscrowStorage::get_escrow_by_invoice(env, invoice_id).is_some() {
-        return Err(QuickLendXError::InvoiceAlreadyFunded);
-    }
-
-    EscrowStorage::require_no_active_reserve_repair(env, currency)?;
-    let next_held_reserve = EscrowStorage::held_reserve_after_increase(env, currency, amount)?;
-
-    // Compliance-layer seam: verify the token address is a registered contract
-    // before issuing any cross-contract calls to it.
-    validate_token_address(env, currency, investor)?;
+    let next_held_reserve = validate_and_prepare_escrow(env, invoice_id, investor, business, amount, currency)?;
 
     crate::qlx_log!(env, "payment", "Creating escrow: amount={}", amount);
 
@@ -489,23 +537,32 @@ pub fn create_escrow(
     let contract_address = env.current_contract_address();
     transfer_funds(env, currency, investor, &contract_address, amount)?;
 
-    let escrow_id = EscrowStorage::generate_unique_escrow_id(env);
-    let escrow = Escrow {
-        escrow_id: escrow_id.clone(),
-        invoice_id: invoice_id.clone(),
-        investor: investor.clone(),
-        business: business.clone(),
-        amount,
-        currency: currency.clone(),
-        created_at: env.ledger().timestamp(),
-        status: EscrowStatus::Held,
-    };
+    let escrow_id = write_escrow_record(env, invoice_id, investor, business, amount, currency, &next_held_reserve);
+    Ok(escrow_id)
+}
 
-    EscrowStorage::store_escrow(env, &escrow);
-    EscrowStorage::set_held_reserve_record(env, currency, &next_held_reserve);
-    EscrowStorage::mark_reserve_accounted(env, &escrow_id);
-    crate::qlx_log!(env, "payment", "Escrow created successfully");
-    emit_escrow_created(env, &escrow);
+/// Create escrow record without transferring funds (funds must already be in the contract).
+///
+/// Use this when the investor's full bid amount has already been transferred to
+/// the contract (e.g., in flows that split a single transfer into fee + escrow).
+/// All the same validations as [`create_escrow`] are performed, but the token
+/// transfer step is skipped.
+///
+/// # Errors
+/// Same as [`create_escrow`] except token-transfer errors are not possible.
+pub fn create_escrow_record_only(
+    env: &Env,
+    invoice_id: &BytesN<32>,
+    investor: &Address,
+    business: &Address,
+    amount: i128,
+    currency: &Address,
+) -> Result<BytesN<32>, QuickLendXError> {
+    let next_held_reserve = validate_and_prepare_escrow(env, invoice_id, investor, business, amount, currency)?;
+
+    crate::qlx_log!(env, "payment", "Creating escrow record (funds pre-transferred): amount={}", amount);
+
+    let escrow_id = write_escrow_record(env, invoice_id, investor, business, amount, currency, &next_held_reserve);
     Ok(escrow_id)
 }
 
@@ -655,11 +712,6 @@ pub fn transfer_funds(
     to: &Address,
     amount: i128,
 ) -> Result<(), QuickLendXError> {
-    if amount < MIN_TRANSFER {
-        return Err(QuickLendXError::InvalidAmount);
-    }
-
-    // Reject amounts below the minimum transfer threshold (dust prevention)
     if amount < MIN_TRANSFER {
         return Err(QuickLendXError::InvalidAmount);
     }

--- a/quicklendx-contracts/src/test_escrow.rs
+++ b/quicklendx-contracts/src/test_escrow.rs
@@ -1563,6 +1563,152 @@ fn test_accept_bid_and_fund_partial_allowance_leaves_state_unchanged() {
     assert!(client.try_get_escrow_details(&invoice_id).is_err());
 }
 
+/// accept_bid_and_fund with origination fee succeeds and escrow amount
+/// correctly reflects the fee-adjusted value (not the full bid amount).
+///
+/// Ensures that the single-transfer approach correctly funds the escrow
+/// and collects the fee without leaving stale state or double-spending.
+#[test]
+fn test_accept_bid_and_fund_with_origination_fee_succeeds() {
+    let (env, client, admin) = setup();
+    let contract_id = client.address.clone();
+
+    let business = setup_verified_business(&env, &client, &admin);
+    let investor = setup_verified_investor(&env, &client, 50_000);
+
+    let amount = 10_000i128;
+    let fee_bps: u32 = 500; // 5%
+    let expected_fee = amount * (fee_bps as i128) / 10_000; // 500
+    let expected_escrow = amount - expected_fee; // 9500
+
+    let token_admin = Address::generate(&env);
+    let currency = env
+        .register_stellar_asset_contract_v2(token_admin.clone())
+        .address();
+    let token_client = token::Client::new(&env, &currency);
+    let sac_client = token::StellarAssetClient::new(&env, &currency);
+    sac_client.mint(&business, &(amount * 10));
+    sac_client.mint(&investor, &(amount * 2)); // enough for the full bid amount
+    let expiration = env.ledger().sequence() + 10_000;
+    token_client.approve(&business, &contract_id, &(amount * 10), &expiration);
+    token_client.approve(&investor, &contract_id, &(amount * 10), &expiration);
+
+    let due_date = env.ledger().timestamp() + 86400;
+    let invoice_id = client.store_invoice(
+        &business,
+        &amount,
+        &currency,
+        &due_date,
+        &String::from_str(&env, "fee test invoice"),
+        &InvoiceCategory::Services,
+        &Vec::new(&env),
+        &Some(fee_bps),
+    );
+    client.verify_invoice(&invoice_id);
+
+    let bid_id = place_test_bid(&client, &investor, &invoice_id, amount, amount + 500);
+
+    let investor_before = token_client.balance(&investor);
+    let contract_before = token_client.balance(&contract_id);
+
+    let escrow_id = client.accept_bid_and_fund(&invoice_id, &bid_id);
+
+    let investor_after = token_client.balance(&investor);
+    let contract_after = token_client.balance(&contract_id);
+
+    // Total amount transferred = full bid amount
+    assert_eq!(investor_before - investor_after, amount);
+    assert_eq!(contract_after - contract_before, amount);
+
+    // Escrow record reflects the fee-adjusted amount
+    let escrow = client.get_escrow_details(&invoice_id);
+    assert_eq!(escrow.amount, expected_escrow);
+    assert_eq!(escrow.status, EscrowStatus::Held);
+
+    // Invoice is Funded with the full bid amount
+    let invoice = client.get_invoice(&invoice_id);
+    assert_eq!(invoice.status, InvoiceStatus::Funded);
+    assert_eq!(invoice.funded_amount, amount);
+    assert_eq!(invoice.investor, Some(investor.clone()));
+
+    // Bid is Accepted
+    let bid = client.get_bid(&bid_id).unwrap();
+    assert_eq!(bid.status, BidStatus::Accepted);
+
+    // Investment exists with the full amount
+    let investments = client.get_investments_by_investor(&investor);
+    assert_eq!(investments.len(), 1);
+    assert_eq!(investments.get_unchecked(0).amount, amount);
+}
+
+/// accept_bid_and_fund with origination fee fails cleanly when the investor
+/// has insufficient balance for the full bid amount.
+#[test]
+fn test_accept_bid_and_fund_origination_fee_insufficient_balance() {
+    let (env, client, admin) = setup();
+    let contract_id = client.address.clone();
+
+    let business = setup_verified_business(&env, &client, &admin);
+    let investor = setup_verified_investor(&env, &client, 50_000);
+
+    let amount = 10_000i128;
+    let fee_bps: u32 = 500; // 5%
+
+    let token_admin = Address::generate(&env);
+    let currency = env
+        .register_stellar_asset_contract_v2(token_admin.clone())
+        .address();
+    let token_client = token::Client::new(&env, &currency);
+    let sac_client = token::StellarAssetClient::new(&env, &currency);
+    sac_client.mint(&business, &(amount * 10));
+    // Investor only has fee amount, NOT the full bid amount
+    sac_client.mint(&investor, &(amount - 1));
+    let expiration = env.ledger().sequence() + 10_000;
+    token_client.approve(&business, &contract_id, &(amount * 10), &expiration);
+    token_client.approve(&investor, &contract_id, &(amount * 10), &expiration);
+
+    let due_date = env.ledger().timestamp() + 86400;
+    let invoice_id = client.store_invoice(
+        &business,
+        &amount,
+        &currency,
+        &due_date,
+        &String::from_str(&env, "fee fail test"),
+        &InvoiceCategory::Services,
+        &Vec::new(&env),
+        &Some(fee_bps),
+    );
+    client.verify_invoice(&invoice_id);
+
+    let bid_id = place_test_bid(&client, &investor, &invoice_id, amount, amount + 500);
+
+    let investor_before = token_client.balance(&investor);
+    let contract_before = token_client.balance(&contract_id);
+
+    let result = client.try_accept_bid_and_fund(&invoice_id, &bid_id);
+    assert!(result.is_err(), "must fail with insufficient balance for the full bid amount");
+    assert_eq!(
+        result.unwrap_err().unwrap(),
+        QuickLendXError::InsufficientFunds,
+    );
+
+    // No funds moved.
+    assert_eq!(token_client.balance(&investor), investor_before);
+    assert_eq!(token_client.balance(&contract_id), contract_before);
+
+    // Invoice untouched.
+    let invoice = client.get_invoice(&invoice_id);
+    assert_eq!(invoice.status, InvoiceStatus::Verified);
+    assert_eq!(invoice.funded_amount, 0);
+    assert!(invoice.investor.is_none());
+
+    // Bid untouched.
+    assert_eq!(client.get_bid(&bid_id).unwrap().status, BidStatus::Placed);
+
+    // No orphan escrow.
+    assert!(client.try_get_escrow_details(&invoice_id).is_err());
+}
+
 /// After a failed accept_bid_and_fund, the bid can be retried once the
 /// investor provides sufficient balance and allowance. No permanent corruption.
 #[test]

--- a/quicklendx-contracts/src/types.rs
+++ b/quicklendx-contracts/src/types.rs
@@ -180,6 +180,29 @@ pub enum BusinessFreezeReason {
     SuspiciousActivity,
     /// Court order or legal hold applied
     LegalHold,
+    /// Suspected fraudulent invoice submission or business identity.
+    FraudSuspected,
+    /// Active or resolved dispute requiring the business to be frozen
+    /// until resolution.
+    Dispute,
+    /// Business requested a voluntary freeze (e.g., for internal audit).
+    Voluntary,
+}
+
+impl BusinessFreezeReason {
+    /// Returns a short human-readable label for event logging.
+    pub fn label(&self) -> &'static str {
+        match self {
+            Self::AdminAction => "admin_action",
+            Self::KYCRejected => "kyc_rejected",
+            Self::ComplianceViolation => "compliance_violation",
+            Self::SuspiciousActivity => "suspicious_activity",
+            Self::LegalHold => "legal_hold",
+            Self::FraudSuspected => "fraud_suspected",
+            Self::Dispute => "dispute",
+            Self::Voluntary => "voluntary",
+        }
+    }
 }
 
 /// Freeze record stored alongside the frozen flag on an invoice
@@ -379,40 +402,6 @@ pub struct PruneReport {
     pub pruned: u32,
     /// Offset to pass on the next call.
     pub next_offset: u32,
-}
-
-/// Typed reason for freezing a business entity or its invoices.
-///
-/// Stored alongside the freeze state to provide an audit trail and enable
-/// targeted unfreeze logic. An admin must supply one of these variants
-/// when freezing; a bare boolean is no longer sufficient.
-#[contracttype]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum BusinessFreezeReason {
-    /// Suspected fraudulent invoice submission or business identity.
-    FraudSuspected,
-    /// Business failed or failed ongoing KYC/AML compliance checks.
-    ComplianceViolation,
-    /// Active or resolved dispute requiring the business to be frozen
-    /// until resolution.
-    Dispute,
-    /// Business requested a voluntary freeze (e.g., for internal audit).
-    Voluntary,
-    /// Admin-initiated freeze for an unspecified or catch-all reason.
-    AdminAction,
-}
-
-impl BusinessFreezeReason {
-    /// Returns a short human-readable label for event logging.
-    pub fn label(&self) -> &'static str {
-        match self {
-            Self::FraudSuspected => "fraud_suspected",
-            Self::ComplianceViolation => "compliance_violation",
-            Self::Dispute => "dispute",
-            Self::Voluntary => "voluntary",
-            Self::AdminAction => "admin_action",
-        }
-    }
 }
 
 /// Typed reason for freezing an investor account.


### PR DESCRIPTION
## Summary

balance_o returns stale value after a mid-tx transfer.

## Background

We want to keep the invoice-lending protocol auditable and safe to change. Landing this issue tightens one specific corner and gives reviewers a clear direction to reason about rather than a general "cleanup" commit. It should be scoped small enough to close in a single PR.

## Acceptance criteria

- [x] The change matches the summary above.
- [x] Tests cover the new behavior (happy path + one explicit failure mode).
- [ ] Lint, type-check, and tests all pass locally.
- [x] PR description references this issue with Closes #2175.

Closes #2175

## Repo-specific notes

- Soroban contract crate. Run cargo build --target wasm32-unknown-unknown --release to verify the change still builds for WASM.
- Run cargo test -p quicklendx-contracts for the affected crate and cargo clippy --workspace --all-targets -- -D warnings before pushing.
- Keep #![no_std] discipline: do not introduce std:: calls; use soroban_sdk primitives.
- Any change touching invoice state MUST include a #[test] that fails on main before the fix.
