### PR TITLE
test: add quorum boundary edge case tests for governance proposals

### DIFF
--- a/quicklendx-contracts/src/test_governance.rs
+++ b/quicklendx-contracts/src/test_governance.rs
@@ -294,6 +294,124 @@ fn finalize_proposal_rejects_non_active_proposal() {
 }
 
 // ============================================================================
+// Quorum boundary edge cases
+// ============================================================================
+
+#[test]
+fn finalize_proposal_passes_when_exactly_at_quorum_with_majority_for() {
+    let (env, contract_id) = setup();
+    let proposer = Address::generate(&env);
+    let voter1 = Address::generate(&env);
+    let voter2 = Address::generate(&env);
+    let voter3 = Address::generate(&env);
+    let id = proposal_id(&env, 1);
+
+    submit_proposal(&env, &contract_id, &proposer, id.clone()).unwrap();
+    cast_vote(&env, &contract_id, &voter1, &id, true).unwrap();
+    cast_vote(&env, &contract_id, &voter2, &id, true).unwrap();
+    cast_vote(&env, &contract_id, &voter3, &id, false).unwrap();
+
+    env.ledger().set_sequence_number(1011);
+    let status = finalize_proposal(&env, &contract_id, &id).unwrap();
+    assert_eq!(status, ProposalStatus::Passed);
+}
+
+#[test]
+fn finalize_proposal_rejects_when_exactly_at_quorum_with_majority_against() {
+    let (env, contract_id) = setup();
+    let proposer = Address::generate(&env);
+    let voter1 = Address::generate(&env);
+    let voter2 = Address::generate(&env);
+    let voter3 = Address::generate(&env);
+    let id = proposal_id(&env, 1);
+
+    submit_proposal(&env, &contract_id, &proposer, id.clone()).unwrap();
+    cast_vote(&env, &contract_id, &voter1, &id, true).unwrap();
+    cast_vote(&env, &contract_id, &voter2, &id, false).unwrap();
+    cast_vote(&env, &contract_id, &voter3, &id, false).unwrap();
+
+    env.ledger().set_sequence_number(1011);
+    let status = finalize_proposal(&env, &contract_id, &id).unwrap();
+    assert_eq!(status, ProposalStatus::Rejected);
+}
+
+#[test]
+fn finalize_proposal_rejects_when_one_vote_below_quorum_even_with_majority_for() {
+    let (env, contract_id) = setup();
+    let proposer = Address::generate(&env);
+    let voter1 = Address::generate(&env);
+    let voter2 = Address::generate(&env);
+    let id = proposal_id(&env, 1);
+
+    submit_proposal(&env, &contract_id, &proposer, id.clone()).unwrap();
+    cast_vote(&env, &contract_id, &voter1, &id, true).unwrap();
+    cast_vote(&env, &contract_id, &voter2, &id, true).unwrap();
+
+    env.ledger().set_sequence_number(1011);
+    let status = finalize_proposal(&env, &contract_id, &id).unwrap();
+    assert_eq!(status, ProposalStatus::Rejected);
+}
+
+#[test]
+fn finalize_proposal_rejects_when_one_vote_below_quorum_with_split_votes() {
+    let (env, contract_id) = setup();
+    let proposer = Address::generate(&env);
+    let voter1 = Address::generate(&env);
+    let voter2 = Address::generate(&env);
+    let id = proposal_id(&env, 1);
+
+    submit_proposal(&env, &contract_id, &proposer, id.clone()).unwrap();
+    cast_vote(&env, &contract_id, &voter1, &id, true).unwrap();
+    cast_vote(&env, &contract_id, &voter2, &id, false).unwrap();
+
+    env.ledger().set_sequence_number(1011);
+    let status = finalize_proposal(&env, &contract_id, &id).unwrap();
+    assert_eq!(status, ProposalStatus::Rejected);
+}
+
+#[test]
+fn finalize_proposal_passes_when_one_vote_above_quorum_with_majority_for() {
+    let (env, contract_id) = setup();
+    let proposer = Address::generate(&env);
+    let voter1 = Address::generate(&env);
+    let voter2 = Address::generate(&env);
+    let voter3 = Address::generate(&env);
+    let voter4 = Address::generate(&env);
+    let id = proposal_id(&env, 1);
+
+    submit_proposal(&env, &contract_id, &proposer, id.clone()).unwrap();
+    cast_vote(&env, &contract_id, &voter1, &id, true).unwrap();
+    cast_vote(&env, &contract_id, &voter2, &id, true).unwrap();
+    cast_vote(&env, &contract_id, &voter3, &id, true).unwrap();
+    cast_vote(&env, &contract_id, &voter4, &id, false).unwrap();
+
+    env.ledger().set_sequence_number(1011);
+    let status = finalize_proposal(&env, &contract_id, &id).unwrap();
+    assert_eq!(status, ProposalStatus::Passed);
+}
+
+#[test]
+fn finalize_proposal_rejects_when_one_vote_above_quorum_but_tied() {
+    let (env, contract_id) = setup();
+    let proposer = Address::generate(&env);
+    let voter1 = Address::generate(&env);
+    let voter2 = Address::generate(&env);
+    let voter3 = Address::generate(&env);
+    let voter4 = Address::generate(&env);
+    let id = proposal_id(&env, 1);
+
+    submit_proposal(&env, &contract_id, &proposer, id.clone()).unwrap();
+    cast_vote(&env, &contract_id, &voter1, &id, true).unwrap();
+    cast_vote(&env, &contract_id, &voter2, &id, true).unwrap();
+    cast_vote(&env, &contract_id, &voter3, &id, false).unwrap();
+    cast_vote(&env, &contract_id, &voter4, &id, false).unwrap();
+
+    env.ledger().set_sequence_number(1011);
+    let status = finalize_proposal(&env, &contract_id, &id).unwrap();
+    assert_eq!(status, ProposalStatus::Rejected);
+}
+
+// ============================================================================
 // Run proposal (execute)
 // ============================================================================
 


### PR DESCRIPTION
# Add tests for quorum edge cases

Closes #1957

## Summary

Adds 6 deterministic unit tests to `src/test_governance.rs` that lock down the quorum boundary logic in `Governable::finalize_proposal` (`governance.rs:262`):

```rust
let total = proposal.votes_for.saturating_add(proposal.votes_against);
let passed = total >= Self::quorum() && proposal.votes_for > proposal.votes_against;
```

The test harness uses a quorum of 3.

## Tests added

| Test | Total votes | For | Against | Expected |
|------|-------------|-----|---------|----------|
| `finalize_proposal_passes_when_exactly_at_quorum_with_majority_for` | 3 (at quorum) | 2 | 1 | Passed |
| `finalize_proposal_rejects_when_exactly_at_quorum_with_majority_against` | 3 (at quorum) | 1 | 2 | Rejected |
| `finalize_proposal_rejects_when_one_vote_below_quorum_even_with_majority_for` | 2 (below quorum) | 2 | 0 | Rejected |
| `finalize_proposal_rejects_when_one_vote_below_quorum_with_split_votes` | 2 (below quorum) | 1 | 1 | Rejected |
| `finalize_proposal_passes_when_one_vote_above_quorum_with_majority_for` | 4 (above quorum) | 3 | 1 | Passed |
| `finalize_proposal_rejects_when_one_vote_above_quorum_but_tied` | 4 (above quorum) | 2 | 2 | Rejected |

## Coverage

- **Happy path:** Quorum met with majority for passes (at and above threshold).
- **Sad paths:** Quorum not met (even with majority for), quorum met but tied, quorum met with majority against — all correctly reject.

## Verification

- All tests follow existing patterns: use `setup()`, `proposal_id()`, `cast_vote()`, `finalize_proposal()` helpers.
- Deterministic: no `Date.now()` / `Math.random()` — uses injected `Address::generate` and fixed ledger sequences.
- `#![no_std]` discipline maintained: only `soroban_sdk` primitives used.
- Test names are assertive and descriptive.
- Only `test_governance.rs` modified; no unrelated refactors.

## Note

The crate has pre-existing compilation errors on `main` (duplicate definitions, missing enum variants, unclosed delimiter in `settlement.rs`) that prevent `cargo test` from running. These are unrelated to quorum logic and tracked separately.
