### PR TITLE
test: add regression coverage for report-period guard boundary

### DIFF
--- a/quicklendx-contracts/src/test_analytics_consistency.rs
+++ b/quicklendx-contracts/src/test_analytics_consistency.rs
@@ -32,6 +32,7 @@
 use super::*;
 use crate::analytics::{AnalyticsCalculator, TimePeriod};
 use crate::invoice::{InvoiceCategory, InvoiceStatus};
+use proptest::prelude::*;
 use soroban_sdk::{
     testutils::{Address as _, Ledger},
     Address, Env, String, Vec,
@@ -67,6 +68,37 @@ fn upload(
         &InvoiceCategory::Services,
         &Vec::new(env),
     )
+}
+
+proptest! {
+    #[test]
+    fn get_period_dates_saturates_underflow_for_small_timestamps(timestamp in 0u64..=86_399u64) {
+        for period in [
+            TimePeriod::Daily,
+            TimePeriod::Weekly,
+            TimePeriod::Monthly,
+            TimePeriod::Quarterly,
+            TimePeriod::Yearly,
+            TimePeriod::AllTime,
+        ]
+        .iter()
+        {
+            let (start_date, end_date) = AnalyticsCalculator::get_period_dates(timestamp, period.clone());
+            prop_assert!(start_date <= end_date);
+            prop_assert_eq!(end_date, timestamp);
+            if *period != TimePeriod::AllTime {
+                prop_assert_eq!(start_date, 0);
+            }
+        }
+    }
+}
+
+#[test]
+fn get_period_dates_all_time_keeps_full_history_window() {
+    let timestamp = 10_000u64;
+    let (start_date, end_date) = AnalyticsCalculator::get_period_dates(timestamp, TimePeriod::AllTime);
+    assert_eq!(start_date, 0);
+    assert_eq!(end_date, timestamp);
 }
 
 // --- 1. generated_at correctness --------------------------------------------


### PR DESCRIPTION
Closes #2070

Adds two regression tests to test_analytics_consistency.rs:
- Property-style test covering small timestamps to lock in saturating behavior for timed periods
- Deterministic test for the AllTime window confirming it preserves the full history range

**Blocked on verification:** main (3241a442) currently fails cargo check with 36 pre-existing, unrelated compile errors in quicklendx-contracts (duplicate QuickLendXError definitions, missing InvoiceLock/is_frozen/set_frozen, duplicate imports in idempotency.rs, etc.). Confirmed via git stash that this is not caused by this branch's diff. Opening as draft until main is fixed and I can confirm tests pass, clippy is clean, and the wasm build succeeds.

See issue comment for full error details.