### PR TITLE
docs: add QLX_ESCROW_TIME_LIMITS.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ npm run dev
 - [`docs/QLX_RISK_PARAMETERS.md`](docs/QLX_RISK_PARAMETERS.md): Complete catalog of risk-related parameters with min/max/default values — investor tiers, business supply limits, bid controls, fee ceilings, and operational bounds.
 - [`docs/QLX_GOVERNANCE_PROPOSALS.md`](docs/QLX_GOVERNANCE_PROPOSALS.md): Governance proposal lifecycle, status transitions, and operator workflow.
 - [`docs/QLX_TREASURY_ROTATION.md`](docs/QLX_TREASURY_ROTATION.md): Treasury address rotation flow with two-step validation and timelock.
+- [`docs/QLX_MULTISIG_CONFIG.md`](docs/QLX_MULTISIG_CONFIG.md): Multisig setup, signer rotation, and threshold-signature verification for critical operations.
 - [`docs/APPEALS.md`](docs/APPEALS.md): Appeals process — who reviews, timeline, outcomes, and how they affect funds — operator-facing.
 - [`docs/EVENT_DASHBOARDS.md`](docs/EVENT_DASHBOARDS.md): Standard operator dashboards — panel URLs, PromQL queries, SQLite indexer queries, and alert rules for protocol health, event throughput, disputes, and settlement pipeline.
 

--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ npm run dev
 - [`docs/QLX_GOVERNANCE_PROPOSALS.md`](docs/QLX_GOVERNANCE_PROPOSALS.md): Governance proposal lifecycle, status transitions, and operator workflow.
 - [`docs/QLX_TREASURY_ROTATION.md`](docs/QLX_TREASURY_ROTATION.md): Treasury address rotation flow with two-step validation and timelock.
 - [`docs/QLX_MULTISIG_CONFIG.md`](docs/QLX_MULTISIG_CONFIG.md): Multisig setup, signer rotation, and threshold-signature verification for critical operations.
+- [`docs/QLX_ESCROW_TIME_LIMITS.md`](docs/QLX_ESCROW_TIME_LIMITS.md): How long escrows can remain unclaimed; release/refund paths, grace period, default handling, and the extend_escrow_expiry operation.
 - [`docs/APPEALS.md`](docs/APPEALS.md): Appeals process — who reviews, timeline, outcomes, and how they affect funds — operator-facing.
 - [`docs/EVENT_DASHBOARDS.md`](docs/EVENT_DASHBOARDS.md): Standard operator dashboards — panel URLs, PromQL queries, SQLite indexer queries, and alert rules for protocol health, event throughput, disputes, and settlement pipeline.
 

--- a/docs/QLX_ESCROW_TIME_LIMITS.md
+++ b/docs/QLX_ESCROW_TIME_LIMITS.md
@@ -1,0 +1,218 @@
+# Escrow Time Limits
+
+> **Audience:** Protocol operators — the people who deploy, configure, and monitor QuickLendX Soroban contracts.
+
+This document explains how long escrow funds can remain in `Held` status before they must be acted upon, and how the protocol handles unclaimed escrows through the default and refund mechanisms.
+
+## Overview
+
+When a bid is accepted, the investor's funds are locked in an escrow record (`EscrowStatus::Held`). These funds remain locked until one of three terminal transitions occurs:
+
+1. **Release** — funds are paid to the business when the invoice is settled/paid
+2. **Refund** — funds are returned to the investor when the invoice defaults, is cancelled, or when the due date has passed
+3. **Default handling** — after the grace period expires, the default mechanism processes the invoice and triggers escrow disposition
+
+| Parameter | Default | Max | Where configured |
+|-----------|---------|-----|------------------|
+| `grace_period_seconds` | `604_800` (7 days) | `2_592_000` (30 days) | Protocol limits (`set_protocol_limits`) |
+| `due_date` | Set by business at `store_invoice` | Max `max_due_date_days` ahead | Invoice creation |
+| `escrow_deadline` | Computed as `due_date + grace_period` | N/A | Derived — not stored independently |
+
+**There is no explicit auto-refund timer for escrow records.** Instead, the default mechanism detects overdue invoices after the grace period and handles escrow disposition through the insurance claim and refund pathways.
+
+## Timeline
+
+```
+Invoice funded (escrow Held)
+       │
+       ▼
+  ┌─────────────────────────────────────────────────────────┐
+  │  Invoice is paid before or at due_date                  │
+  │  → release_escrow() moves funds to business             │
+  └─────────────────────────────────────────────────────────┘
+       │ (if invoice is NOT paid)
+       ▼
+  due_date reached
+       │
+       ▼
+  Overdue notification emitted; late-payment surcharge accrues
+       │
+       ▼
+  grace_period running (due_date + grace_period)
+       │
+       ▼
+  ┌─────────────────────────────────────────────────────────┐
+  │  grace_period expired (ledger.timestamp > due_date +    │
+  │  grace_period)                                         │
+  │  → trigger_default() processes the invoice              │
+  │  → insurance claims are paid to the investor            │
+  │  → escrow disposition follows from default handling     │
+  └─────────────────────────────────────────────────────────┘
+```
+
+## Error Codes
+
+| Error | Code | ABI symbol | When it fires |
+|-------|------|-----------|---------------|
+| `InvalidStatus` | 1401 | `INV_ST` | Escrow is not `Held` (already released or refunded) |
+| `InvoiceDueDateInvalid` | 1700 | `IDATE` | `extend_escrow_expiry` called with `new_due_date <= current due_date` |
+| `OperationNotAllowed` | 1600 | `OP_NOT` | `extend_escrow_expiry` called when escrow has already been extended, or when escrow is not in `Held` status |
+
+## Release Path (Funds to Business)
+
+`release_escrow` can only be called when the invoice status is `Paid` and the escrow is in `Held` status. There is no time limit on the release — as long as the invoice is paid, the escrow can be released regardless of the due date.
+
+**Rust entrypoint signature:**
+
+```rust
+pub fn release_escrow(env: &Env, invoice_id: &BytesN<32>) -> Result<(), QuickLendXError>;
+```
+
+**Guard checks:**
+
+- Escrow status must be `Held`
+- Invoice status must be `Paid`
+- Both checks return `InvalidStatus` on failure
+
+### Concrete example
+
+```rust
+// After invoice is paid by the investor
+let invoice_id = BytesN::from_array(&env, &[42u8; 32]);
+
+// Release escrowed funds to the business
+let res = client.release_escrow(&invoice_id);
+assert!(res.is_ok());
+```
+
+If the escrow has already been released or refunded, the call fails:
+
+```rust
+let res = client.try_release_escrow(&invoice_id);
+assert_eq!(res.unwrap_err().ok(), Some(QuickLendXError::InvalidStatus));
+```
+
+## Refund Path (Funds to Investor)
+
+`refund_escrow` can be called when the escrow is in `Held` status. Unlike release, refund is gated by time: it requires that the invoice's due date has passed (`ledger.timestamp() > due_date`).
+
+**Rust entrypoint signature:**
+
+```rust
+pub fn refund_escrow(env: &Env, invoice_id: &BytesN<32>) -> Result<(), QuickLendXError>;
+```
+
+**Guard checks:**
+
+- Escrow status must be `Held`
+- Current timestamp must be strictly greater than `due_date`
+- Returns `InvalidStatus` if escrow is already released/refunded
+- Returns `OperationNotAllowed` if timestamp is not past due_date
+
+### Concrete example
+
+```rust
+use soroban_sdk::{testutils::Ledger as _, BytesN, Env};
+
+let env = Env::default();
+let contract_id = env.register(QuickLendXContract, ());
+let client = QuickLendXContractClient::new(&env, &contract_id);
+
+// Assume invoice was funded with due_date = now + 1 day
+let due_date = env.ledger().timestamp() + 86_400;
+let invoice_id = create_and_fund_invoice(&env, &client, due_date);
+
+// Refund blocked before due_date
+env.ledger().set_timestamp(due_date - 1);
+let res = client.try_refund_escrow(&invoice_id);
+assert!(res.is_err()); // OperationNotAllowed: timestamp not past due_date
+
+// Refund allowed at due_date (strictly greater-than check)
+env.ledger().set_timestamp(due_date);
+let res = client.try_refund_escrow(&invoice_id);
+assert!(res.is_err()); // Still blocked: must be STRICTLY greater
+
+// Refund allowed one second past due_date
+env.ledger().set_timestamp(due_date + 1);
+let res = client.refund_escrow(&invoice_id);
+assert!(res.is_ok());
+```
+
+## Default Handling (Unclaimed Escrows)
+
+When an invoice remains unpaid after the grace period (`due_date + grace_period`), the default mechanism handles it. This is triggered by the `trigger_default` / `scan_funded_invoice_expirations` admin operation or batch scanner.
+
+### Default transition flow
+
+1. `mark_invoice_defaulted` checks `ledger.timestamp() > due_date + grace_period`
+2. Insurance claims are processed for the investor's coverage
+3. The invoice status transitions to `Defaulted`
+4. The settlement path is permanently blocked (settlement finalization requires `dispute_status == None` and invoice status `Paid`)
+5. Escrow disposition follows from the investment status transition and insurance claims — the escrow record itself is not consumed by `trigger_default` but the funds are no longer accessible via normal release
+
+### Boundary check
+
+| Scenario | Timestamp relative to `due_date + grace_period` | Result |
+|----------|--------------------------------------------------|--------|
+| Before grace period ends | `timestamp <= due_date + grace_period` | Cannot default |
+| Exactly at grace deadline | `timestamp == due_date + grace_period` | Cannot default (strictly greater-than required) |
+| One second past deadline | `timestamp == due_date + grace_period + 1` | Default allowed |
+
+## Extending the Escrow Expiry
+
+Admins can extend an invoice's due date for a held escrow using `extend_escrow_expiry`. This is a one-time operation per invoice — the extension can only be applied once.
+
+### Rust entrypoint signature
+
+```rust
+pub fn extend_escrow_expiry(
+    env: Env,
+    admin: Address,
+    invoice_id: BytesN<32>,
+    new_due_date: u64,
+) -> Result<(), QuickLendXError>;
+```
+
+### Guards
+
+| Guard | Error on failure |
+|-------|-----------------|
+| Admin must be authorized | `NotAdmin` |
+| Invoice must exist | `InvoiceNotFound` |
+| Escrow must exist and be in `Held` status | `OperationNotAllowed` |
+| Escrow must not have been extended already | `OperationNotAllowed` |
+| `new_due_date` must be strictly greater than current `due_date` | `InvoiceDueDateInvalid` |
+| `new_due_date` must not exceed `now + max_due_date_days * 86400` | `InvoiceDueDateInvalid` |
+
+### Concrete example
+
+```rust
+let admin = Address::generate(&env);
+client.initialize(&admin);
+
+// Extend due_date by 30 days for a held escrow
+let new_due_date = env.ledger().timestamp() + 30 * 86_400;
+let res = client.extend_escrow_expiry(&admin, &invoice_id, &new_due_date);
+assert!(res.is_ok());
+
+// Second attempt fails (extension can only be applied once)
+let newer_due_date = env.ledger().timestamp() + 60 * 86_400;
+let res = client.try_extend_escrow_expiry(&admin, &invoice_id, &newer_due_date);
+assert!(res.is_err()); // OperationNotAllowed: already extended
+```
+
+## Key Points for Operators
+
+- **Escrows do not auto-refund.** There is no timer that automatically refunds unclaimed escrow funds. The refund/ release must be explicitly triggered by the operator or by the default handling mechanism when the invoice expires.
+- **The grace period controls the default window.** After the grace period expires (due_date + grace_period_seconds), the invoice can be defaulted and escrow disposition follows.
+- **Refund requires the due_date to have passed.** Investors cannot reclaim escrowed funds before the due_date.
+- **Release has no time limit.** As long as the invoice is eventually paid, the escrow can be released regardless of whether the due_date has passed.
+- **Extension is one-time.** `extend_escrow_expiry` can only be called once per invoice — plan the extension carefully.
+- **Persistent TTL.** Escrow records have a 30-day persistent TTL (`PERSISTENT_TTL_THRESHOLD = 34_732_800` seconds). Records that are not accessed within this window may be evicted from storage, though the underlying token balance remains locked.
+
+> **See also:**
+> - [Escrow](contracts/escrow.md) — full escrow lifecycle, creation, release, and refund
+> - [Escrow Refund](contracts/escrow-refund.md) — security improvements for the refund path
+> - [Default Flow Diagram](DEFAULT_FLOW_DIAGRAM.md) — state machine for overdue → default → recovery
+> - [Protocol Limits](contracts/protocol-limits.md) — configurable grace period, due-date horizon, and bounds
+> - [OPERATOR_HANDBOOK.md](OPERATOR_HANDBOOK.md) — CLI reference for escrow operations and limit updates

--- a/docs/QLX_MULTISIG_CONFIG.md
+++ b/docs/QLX_MULTISIG_CONFIG.md
@@ -1,0 +1,233 @@
+# QLX Multisig Configuration
+
+> **Audience:** Protocol operators — the people who deploy, configure, and manage QuickLendX Soroban contracts.
+
+This document covers the on-chain multisig contract: how to initialize it, rotate signers, and use it to authorize critical operations. It complements the [Operator Handbook](OPERATOR_HANDBOOK.md) and the [Emergency Recovery](contracts/emergency-recovery.md) guide.
+
+## Overview
+
+The `MultisigContract` (`quicklendx-contracts/src/multisig.rs`) provides a generic ed25519 threshold-signature verifier. It stores a set of owner public keys and a quorum threshold in contract instance storage. Any off-chain or on-chain caller can submit a batch of signatures and have them verified against the stored owner set.
+
+| Concept | Detail |
+|---------|--------|
+| Owners | Ed25519 public keys (`BytesN<32>`), stored as a `Vec` |
+| Threshold | Minimum number of distinct signatures required (`u32`, range `[1, N-1]`) |
+| Signature scheme | Ed25519, 64-byte signatures |
+| Storage keys | `owners` (`OWNERS_KEY`), `thresh` (`THRESHOLD_KEY`) |
+
+## Error Codes
+
+| Error | Code | When it fires |
+|-------|------|---------------|
+| `InvalidThreshold` | 1 | Threshold is `< 1` or `>= N` (number of owners) |
+| `NotEnoughSignatures` | 2 | Fewer signatures submitted than the threshold |
+| `DuplicateSignature` | 3 | The same owner index appears more than once in a single request |
+| `InvalidOwnerIndex` | 4 | An `owner_index` in the signature batch is `>= N` |
+
+## 1. Initialize the Multisig
+
+Call `initialize` with the list of owner public keys and the quorum threshold. This is a one-time setup entrypoint; re-initialization overwrites the previous owner set and threshold.
+
+**Rust entrypoint signature:**
+
+```rust
+pub fn initialize(
+    env: Env,
+    owners: Vec<BytesN<32>>,
+    threshold: u32,
+) -> Result<(), MultisigError>;
+```
+
+**Constraints:**
+
+- `owners.len()` must be `>= 2` (a single-owner setup is not permitted because `threshold >= 1` and `threshold < N` would be unsatisfiable with `N = 1`).
+- `threshold` must be in `[1, N-1]`.
+
+### Concrete example — 3 owners, threshold 2
+
+```rust
+use soroban_sdk::{BytesN, Env, Vec};
+use quicklendx_contracts::multisig::{MultisigContract, MultisigContractClient};
+
+let env = Env::default();
+let contract_id = env.register(MultisigContract, ());
+let client = MultisigContractClient::new(&env, &contract_id);
+
+// Generate three Ed25519 keypairs
+let (owner0_pub, _priv0) = generate_keypair(&env, 1);
+let (owner1_pub, _priv1) = generate_keypair(&env, 2);
+let (owner2_pub, _priv2) = generate_keypair(&env, 3);
+
+let mut owners = Vec::new(&env);
+owners.push_back(owner0_pub);
+owners.push_back(owner1_pub);
+owners.push_back(owner2_pub);
+
+// threshold = 2: any 2 of 3 owners must sign
+let res = client.initialize(&owners, &2);
+assert!(res.is_ok());
+```
+
+### Boundary checks (tested in `test_multisig.rs`)
+
+| Scenario | Result |
+|----------|--------|
+| `threshold = 0` | `Err(InvalidThreshold)` |
+| `threshold = 1`, `N = 3` | Ok |
+| `threshold = N - 1`, `N = 3` | Ok |
+| `threshold = N` | `Err(InvalidThreshold)` |
+| `threshold = N + 1` | `Err(InvalidThreshold)` |
+| `N = 1`, `threshold = 1` | `Err(InvalidThreshold)` |
+
+## 2. Rotate Signers
+
+To rotate an owner key or change the threshold, call `initialize` again with the updated owner list and threshold. Because `initialize` overwrites the stored state atomically, rotation is a single on-chain transaction.
+
+### Operator rotation workflow
+
+1. **Prepare the new owner list.** Gather the Ed25519 public keys of all new signers. Remove the compromised or departed signer's key; add the replacement key at the same or a new index.
+2. **Choose a new threshold** if needed. The new threshold must still satisfy `1 <= threshold < N` where `N` is the new owner count.
+3. **Execute the rotation transaction.** Call `initialize` from the admin account.
+
+```rust
+// Rotation: replace owner index 1 with a new key, keep threshold = 2
+let (new_owner1_pub, _new_priv1) = generate_keypair(&env, 10);
+
+let mut new_owners = Vec::new(&env);
+new_owners.push_back(owner0_pub);      // unchanged
+new_owners.push_back(new_owner1_pub);  // replaced
+new_owners.push_back(owner2_pub);      // unchanged
+
+let res = client.initialize(&new_owners, &2);
+assert!(res.is_ok());
+```
+
+4. **Verify the rotation.** Re-initialize a client and confirm the new threshold and owner count.
+
+```rust
+let stored_owners: Vec<BytesN<32>> = env
+    .storage()
+    .instance()
+    .get(&OWNERS_KEY)
+    .unwrap();
+assert_eq!(stored_owners.len(), 3);
+```
+
+> **See also:** The treasury rotation pattern used in [QLX_TREASURY_ROTATION.md](QLX_TREASURY_ROTATION.md) applies the same two-step principles (initiate, then confirm) but with a timelock. Multisig rotation does **not** use a timelock — it overwrites state immediately. If your deployment requires a delay, wrap the `initialize` call in a governance proposal or timelock contract.
+
+## 3. Verify a Multisig Signature (verify_op)
+
+After initialization, any caller can submit a message hash and a batch of `OwnerSignature` entries. The contract checks that the number of signatures meets the threshold, that each `owner_index` is valid and non-duplicate, and that each signature is cryptographically valid against the corresponding owner's public key.
+
+**Rust entrypoint signature:**
+
+```rust
+pub fn verify_op(
+    env: Env,
+    message_hash: BytesN<32>,
+    signatures: Vec<OwnerSignature>,
+) -> Result<(), MultisigError>;
+```
+
+**`OwnerSignature` struct:**
+
+```rust
+pub struct OwnerSignature {
+    pub owner_index: u32,    // index into the owners Vec
+    pub signature: BytesN<64>, // ed25519 signature bytes
+}
+```
+
+### Concrete example — 2 of 3 owners sign a message hash
+
+```rust
+use ed25519_dalek::{Signer, SigningKey};
+use soroban_sdk::{BytesN, Env, Vec};
+use quicklendx_contracts::multisig::{MultisigContract, MultisigContractClient, OwnerSignature};
+
+let env = Env::default();
+let contract_id = env.register(MultisigContract, ());
+let client = MultisigContractClient::new(&env, &contract_id);
+
+let (pub0, priv0) = generate_keypair(&env, 1);
+let (pub1, _priv1) = generate_keypair(&env, 2);
+let (pub2, priv2) = generate_keypair(&env, 3);
+
+let mut owners = Vec::new(&env);
+owners.push_back(pub0);
+owners.push_back(pub1);
+owners.push_back(pub2);
+
+client.initialize(&owners, &2);
+
+// The message hash to sign (32 bytes)
+let message_hash = BytesN::from_array(&env, &[9u8; 32]);
+let message_bytes: [u8; 32] = [9u8; 32];
+
+// Owners 0 and 2 sign the message
+let sig0_bytes = priv0.sign(&message_bytes).to_bytes();
+let sig2_bytes = priv2.sign(&message_bytes).to_bytes();
+
+let sig0 = BytesN::from_array(&env, &sig0_bytes);
+let sig2 = BytesN::from_array(&env, &sig2_bytes);
+
+let mut signatures = Vec::new(&env);
+signatures.push_back(OwnerSignature {
+    owner_index: 0,
+    signature: sig0,
+});
+signatures.push_back(OwnerSignature {
+    owner_index: 2,
+    signature: sig2,
+});
+
+let res = client.verify_op(&message_hash, &signatures);
+assert!(res.is_ok());
+```
+
+### Common failure scenarios
+
+| Scenario | Error returned |
+|----------|---------------|
+| Submit 1 signature when threshold = 2 | `NotEnoughSignatures` |
+| Submit the same owner index twice | `DuplicateSignature` |
+| Use `owner_index = N` (out of bounds) | `InvalidOwnerIndex` |
+| Sign the wrong message (mismatched hash) | Panics with `HostError: Error(Crypto, InvalidHash)` |
+| Submit a signature for an owner not in the current set | `InvalidOwnerIndex` (if index >= N) |
+
+## 4. Using Multisig in Critical Operations
+
+The multisig contract is designed to be called by other contracts or by off-chain services that need threshold authorization for sensitive protocol actions. Typical patterns include:
+
+1. **Pre-authorization:** An admin builds a `message_hash` from the operation parameters (e.g., `sha256(treasury_address + amount + nonce)`), collects `threshold` signatures from the owner set off-chain, then calls `verify_op` on-chain before executing the action.
+2. **On-chain composability:** A governance or timelock contract calls `verify_op` as a sub-step before mutating state, ensuring that no single signer can unilaterally trigger critical changes.
+3. **Rotation safety:** Because `initialize` overwrites the entire owner set atomically, rotate signers in a single transaction rather than incremental updates to avoid intermediate states with reduced security.
+
+> **See also:**
+> - [Emergency Recovery](contracts/emergency-recovery.md) — describes where multisig fits into the incident-response path
+> - [QLX_TREASURY_ROTATION.md](QLX_TREASURY_ROTATION.md) — example of a protected rotation with timelock
+> - [Security](contracts/security.md) — reentrancy guard and pause circuit breaker that complement multisig controls
+> - [OPERATOR_HANDBOOK.md](OPERATOR_HANDBOOK.md) — full CLI reference for on-chain operations
+
+## 5. Quick Reference — CLI Example
+
+```bash
+# Initialize multisig with 3 owners, threshold 2
+soroban contract invoke \
+  --id $CONTRACT_ID \
+  --source admin \
+  --network testnet \
+  -- \
+  initialize \
+  --owners "$OWNER0,$OWNER1,$OWNER2" \
+  --threshold 2
+
+# Verify a set of signatures against a message hash
+soroban contract invoke \
+  --id $CONTRACT_ID \
+  --network testnet \
+  -- \
+  verify_op \
+  --message_hash "$MESSAGE_HASH" \
+  --signatures "$SIGNATURES_JSON"
+```

--- a/docs/README.md
+++ b/docs/README.md
@@ -52,6 +52,7 @@
 | [QLX_GOVERNANCE_PROPOSALS.md](QLX_GOVERNANCE_PROPOSALS.md) | Governance proposal lifecycle status transitions and operator workflows |
 | [QLX_TREASURY_ROTATION.md](QLX_TREASURY_ROTATION.md) | Treasury address rotation flow with two-step validation and timelock |
 | [QLX_MULTISIG_CONFIG.md](QLX_MULTISIG_CONFIG.md) | Multisig setup, signer rotation, and threshold-signature verification for critical operations |
+| [QLX_ESCROW_TIME_LIMITS.md](QLX_ESCROW_TIME_LIMITS.md) | Escrow Held status duration, release/refund paths, grace period, and default handling |
 | [MONITORING.md](MONITORING.md) | Per-event alert thresholds for contract events |
 | [DASHBOARD_QUERIES.md](DASHBOARD_QUERIES.md) | Full SQL reference for indexer health and workload queries |
 | [RUNBOOK_INCIDENT_RESPONSE.md](RUNBOOK_INCIDENT_RESPONSE.md) | Step-by-step operator playbook for unexpected contract behavior |

--- a/docs/README.md
+++ b/docs/README.md
@@ -51,6 +51,7 @@
 | [EVENT_DASHBOARDS.md](EVENT_DASHBOARDS.md) | Standard Grafana dashboards — panel URLs, PromQL queries, SQLite indexer queries, and alert rules for protocol health, event throughput, disputes, and settlement pipeline |
 | [QLX_GOVERNANCE_PROPOSALS.md](QLX_GOVERNANCE_PROPOSALS.md) | Governance proposal lifecycle status transitions and operator workflows |
 | [QLX_TREASURY_ROTATION.md](QLX_TREASURY_ROTATION.md) | Treasury address rotation flow with two-step validation and timelock |
+| [QLX_MULTISIG_CONFIG.md](QLX_MULTISIG_CONFIG.md) | Multisig setup, signer rotation, and threshold-signature verification for critical operations |
 | [MONITORING.md](MONITORING.md) | Per-event alert thresholds for contract events |
 | [DASHBOARD_QUERIES.md](DASHBOARD_QUERIES.md) | Full SQL reference for indexer health and workload queries |
 | [RUNBOOK_INCIDENT_RESPONSE.md](RUNBOOK_INCIDENT_RESPONSE.md) | Step-by-step operator playbook for unexpected contract behavior |


### PR DESCRIPTION
Closes #2096

Adds docs/QLX_ESCROW_TIME_LIMITS.md documenting how long escrows can remain unclaimed. Covers the release path (funds to business), refund path (funds to investor), default handling for unclaimed escrows after due_date + grace_period, the extend_escrow_expiry admin operation, boundary cases, error codes, and concrete Rust examples. Linked from README.md and docs/README.md.