### PR TITLE
Fix: Add tests for the investor-kyc-tier helper (Auto-Generated)

### DIFF
--- a/quicklendx-contracts/tests/investor_kyc_tier.rs
+++ b/quicklendx-contracts/tests/investor_kyc_tier.rs
@@ -1,0 +1,16 @@
+use quicklendx_contracts::is_investor_kyc_tier_sufficient;
+
+#[test]
+fn returns_false_when_investor_tier_is_below_required_tier() {
+    assert!(!is_investor_kyc_tier_sufficient(1, 2));
+}
+
+#[test]
+fn returns_true_when_investor_tier_matches_required_tier() {
+    assert!(is_investor_kyc_tier_sufficient(2, 2));
+}
+
+#[test]
+fn returns_true_when_investor_tier_is_above_required_tier() {
+    assert!(is_investor_kyc_tier_sufficient(3, 2));
+}


### PR DESCRIPTION
Closes #2076

This PR was generated by the DripTide AI coder and scoped strictly to issue #2076.

### Changes
Adds integration tests covering investor KYC tiers below, equal to, and above the required tier.

### Verification
Passed automated self-review (lint + issue-coverage checks).

_Linked with `Closes #2076` so the Drips Wave bot resolves the issue on merge._