### PR TITLE
feat: add justfile with help target

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,0 +1,63 @@
+# QuickLendX protocol — justfile
+# Run `just` or `just help` for available recipes.
+
+# List available recipes
+help:
+    @just --list
+
+# ── Contracts ────────────────────────────────────────────────────────────
+
+# Build all Soroban contracts
+build:
+    cargo build --target wasm32-unknown-unknown --release
+
+# Run contract tests
+test:
+    cargo test -p quicklendx-contracts
+
+# Run fuzz tests (quick | standard | extended | thorough)
+fuzz level="standard":
+    ./run_fuzz_tests.sh {{level}}
+
+# Check WASM binary size (256 KB budget)
+check-wasm:
+    ./scripts/check-wasm-size.sh
+
+# Clippy lint (deny warnings)
+clippy:
+    cargo clippy --workspace --all-targets -- -D warnings
+
+# Format all code
+fmt:
+    cargo fmt --all
+
+# Check formatting without writing
+fmt-check:
+    cargo fmt --all -- --check
+
+# ── Frontend ─────────────────────────────────────────────────────────────
+
+# Install frontend dependencies
+frontend-install:
+    cd quicklendx-frontend && npm ci
+
+# Start local dev server
+frontend-dev:
+    cd quicklendx-frontend && npm run dev
+
+# Production build (includes type checks)
+frontend-build:
+    cd quicklendx-frontend && npm run build
+
+# Lint frontend
+frontend-lint:
+    cd quicklendx-frontend && npm run lint
+
+# Type-check frontend
+frontend-typecheck:
+    cd quicklendx-frontend && npx tsc --noEmit
+
+# ── Combined ─────────────────────────────────────────────────────────────
+
+# Run all checks (format, clippy, tests, WASM size, frontend lint + typecheck)
+check: fmt-check clippy test check-wasm frontend-lint frontend-typecheck


### PR DESCRIPTION
## Summary

Adds a `justfile` with a `help` target (the default recipe) that lists all available development commands for both the Soroban contracts and the Next.js frontend.

## Changes

New file: `justfile` with recipes:

| Recipe | Description |
|--------|-------------|
| `help` (default) | List all recipes |
| `build` | Build Soroban contracts to WASM |
| `test` | Run contract tests |
| `fuzz [level]` | Run fuzz tests (quick/standard/extended/thorough) |
| `check-wasm` | Enforce 256 KB WASM size budget |
| `clippy` | Clippy lint with deny warnings |
| `fmt` / `fmt-check` | Format / check formatting |
| `frontend-*` | Install, dev, build, lint, typecheck frontend |
| `check` | Combined: fmt-check + clippy + tests + WASM + frontend |

## Usage

```
$ just
Available recipes:
    build             # Build all Soroban contracts
    check             # Run all checks (format, clippy, tests, WASM size, frontend lint + typecheck)
    check-wasm        # Check WASM binary size (256 KB budget)
    clippy            # Clippy lint (deny warnings)
    fmt               # Format all code
    fmt-check         # Check formatting without writing
    frontend-build    # Production build (includes type checks)
    frontend-dev      # Start local dev server
    frontend-install  # Install frontend dependencies
    frontend-lint     # Lint frontend
    frontend-typecheck # Type-check frontend
    fuzz              # Run fuzz tests (quick | standard | extended | thorough)
    help              # List available recipes
    test              # Run contract tests
```

---

closes #2187
