### PR TITLE
fix: gracefully handle stale bid and invoice indexes

### DIFF
--- a/quicklendx-contracts/src/bid.rs
+++ b/quicklendx-contracts/src/bid.rs
@@ -963,7 +963,9 @@ impl BidStorage {
         let mut bids = Vec::new(env);
         for bid_id in Self::get_bids_for_invoice(env, invoice_id).iter() {
             if let Some(bid) = Self::get_bid(env, &bid_id) {
-                bids.push_back(bid);
+                if bid.invoice_id == *invoice_id {
+                    bids.push_back(bid);
+                }
             }
         }
         bids
@@ -974,7 +976,9 @@ impl BidStorage {
         let mut idx: u32 = 0;
         while idx < records.len() {
             let bid = records.get(idx).unwrap();
-            if bid.status == status {
+            let eligible = status != BidStatus::Placed
+                || !bid.is_expired(env.ledger().timestamp());
+            if bid.status == status && eligible {
                 filtered.push_back(bid);
             }
             idx += 1;

--- a/quicklendx-contracts/src/lib.rs
+++ b/quicklendx-contracts/src/lib.rs
@@ -476,6 +476,7 @@ use verification::{
     InvestorVerificationStorage,
 };
 
+pub use crate::storage::InvoiceIndex;
 use crate::storage::{BidStorage, InvoiceStorage};
 
 /// Render a 1-5 rating score as a decimal `String` for audit-log serialization.
@@ -2059,7 +2060,16 @@ impl QuickLendXContract {
 
     /// Get all available invoices (verified and not funded)
     pub fn get_available_invoices(env: Env) -> Vec<BytesN<32>> {
-        InvoiceStorage::get_invoices_by_status(&env, InvoiceStatus::Verified)
+        let mut available = Vec::new(&env);
+        let now = env.ledger().timestamp();
+        for invoice_id in InvoiceStorage::get_invoices_by_status(&env, InvoiceStatus::Verified).iter() {
+            if let Some(invoice) = InvoiceStorage::get_invoice(&env, &invoice_id) {
+                if !invoice.is_overdue(now) {
+                    available.push_back(invoice_id);
+                }
+            }
+        }
+        available
     }
 
     /// Update invoice status (admin function)
@@ -4066,6 +4076,9 @@ impl QuickLendXContract {
 
         for invoice_id in verified_invoices.iter() {
             if let Some(invoice) = InvoiceStorage::get_invoice(&env, &invoice_id) {
+                if invoice.is_overdue(env.ledger().timestamp()) {
+                    continue;
+                }
                 // Filter by amount range
                 if let Some(min) = min_amount {
                     if invoice.amount < min {
@@ -5221,6 +5234,26 @@ impl QuickLendXContract {
         }
         let report = InvoiceStorage::rebuild_indexes_page(&env, offset, limit);
         Ok(report)
+    }
+
+    /// Remove invalid entries from one invoice index in a bounded admin page.
+    /// Missing records, status mismatches, metadata mismatches, and duplicates
+    /// are removed; canonical invoice records are never modified.
+    pub fn cleanup_invoice_index(
+        env: Env,
+        admin: Address,
+        index: InvoiceIndex,
+        offset: u32,
+        limit: u32,
+    ) -> Result<crate::types::IndexCleanupReport, QuickLendXError> {
+        admin.require_auth();
+        AdminStorage::require_admin(&env, &admin)?;
+        let config = init::ProtocolInitializer::get_protocol_config(&env)
+            .ok_or(QuickLendXError::OperationNotAllowed)?;
+        if limit > config.backfill_max_batch_size {
+            return Err(QuickLendXError::BatchSizeExceeded);
+        }
+        Ok(InvoiceStorage::cleanup_index_page(&env, &index, offset, limit))
     }
 
     /// Prune terminal-state invoices whose terminal timestamp is older than

--- a/quicklendx-contracts/src/storage.rs
+++ b/quicklendx-contracts/src/storage.rs
@@ -116,6 +116,18 @@ impl StorageKeys {
 /// 4. Document the migration in `docs/storage-key-stability.md`.
 pub struct Indexes;
 
+/// Selects one secondary invoice index for bounded integrity cleanup.
+#[derive(Clone)]
+#[contracttype]
+pub enum InvoiceIndex {
+    Business(Address),
+    Status(InvoiceStatus),
+    Customer(String),
+    TaxId(String),
+    Tag(String),
+    Category(InvoiceCategory),
+}
+
 impl Indexes {
     /// Returns the persistent storage key for the invoice list owned by a business.
     ///
@@ -263,6 +275,91 @@ impl Indexes {
 pub struct InvoiceStorage;
 
 impl InvoiceStorage {
+    fn raw_index_entries(env: &Env, index: &InvoiceIndex) -> Vec<BytesN<32>> {
+        match index {
+            InvoiceIndex::Business(business) => env.storage().persistent().get(&Indexes::invoices_by_business(business)).unwrap_or(Vec::new(env)),
+            InvoiceIndex::Status(status) => env.storage().persistent().get(&Indexes::invoices_by_status(*status)).unwrap_or(Vec::new(env)),
+            InvoiceIndex::Customer(name) => env.storage().persistent().get(&Indexes::invoices_by_customer(name)).unwrap_or(Vec::new(env)),
+            InvoiceIndex::TaxId(tax_id) => env.storage().persistent().get(&Indexes::invoices_by_tax_id(tax_id)).unwrap_or(Vec::new(env)),
+            InvoiceIndex::Tag(tag) => env.storage().persistent().get(&Indexes::invoices_by_tag(tag)).unwrap_or(Vec::new(env)),
+            InvoiceIndex::Category(category) => env.storage().persistent().get(&Indexes::invoices_by_category(*category)).unwrap_or(Vec::new(env)),
+        }
+    }
+
+    fn index_entries(env: &Env, index: &InvoiceIndex) -> Vec<BytesN<32>> {
+        let mut valid = Vec::new(env);
+        for id in Self::raw_index_entries(env, index).iter() {
+            if Self::entry_matches(env, index, &id) && !valid.contains(&id) {
+                valid.push_back(id);
+            }
+        }
+        valid
+    }
+
+    fn entry_matches(env: &Env, index: &InvoiceIndex, id: &BytesN<32>) -> bool {
+        let Some(invoice) = Self::get(env, id) else {
+            return false;
+        };
+        match index {
+            InvoiceIndex::Business(business) => invoice.business == *business,
+            InvoiceIndex::Status(status) => invoice.status == *status,
+            InvoiceIndex::Customer(name) => invoice.metadata_customer_name.as_ref() == Some(name),
+            InvoiceIndex::TaxId(tax_id) => invoice.metadata_tax_id.as_ref() == Some(tax_id),
+            InvoiceIndex::Tag(tag) => invoice.tags.iter().any(|candidate| candidate == *tag),
+            InvoiceIndex::Category(category) => invoice.category == *category,
+        }
+    }
+
+    /// Remove invalid entries from one secondary index in a bounded, replayable page.
+    pub fn cleanup_index_page(
+        env: &Env,
+        index: &InvoiceIndex,
+        offset: u32,
+        limit: u32,
+    ) -> crate::types::IndexCleanupReport {
+        const MAX_INDEX_CLEANUP_PAGE: u32 = 100;
+        let capped_limit = limit.min(MAX_INDEX_CLEANUP_PAGE);
+        let mut entries = Self::raw_index_entries(env, index);
+        let total = entries.len();
+        let start = offset.min(total);
+        let end = start.saturating_add(capped_limit).min(total);
+        let mut removed = 0u32;
+        let mut valid_seen = Vec::new(env);
+        let mut position = start;
+        let mut scanned = 0u32;
+        while scanned < end.saturating_sub(start) && position < entries.len() {
+            let id = entries.get(position).unwrap();
+            let valid = Self::entry_matches(env, index, &id) && !valid_seen.contains(&id);
+            if valid {
+                valid_seen.push_back(id);
+                position += 1;
+            } else {
+                entries.remove(position);
+                removed = removed.saturating_add(1);
+            }
+            scanned += 1;
+        }
+
+        if removed > 0 {
+            let key = match index {
+                InvoiceIndex::Business(business) => Indexes::invoices_by_business(business),
+                InvoiceIndex::Status(status) => Indexes::invoices_by_status(*status),
+                InvoiceIndex::Customer(name) => Indexes::invoices_by_customer(name),
+                InvoiceIndex::TaxId(tax_id) => Indexes::invoices_by_tax_id(tax_id),
+                InvoiceIndex::Tag(tag) => Indexes::invoices_by_tag(tag),
+                InvoiceIndex::Category(category) => Indexes::invoices_by_category(*category),
+            };
+            env.storage().persistent().set(&key, &entries);
+            extend_persistent_ttl(env, &key);
+        }
+
+        crate::types::IndexCleanupReport {
+            scanned,
+            removed,
+            next_offset: if removed > 0 { start } else { end },
+        }
+    }
+
     /// Store an invoice and update all its secondary indexes.
     pub fn store(env: &Env, invoice: &Invoice) {
         crate::assert_view_only!(env);
@@ -385,11 +482,7 @@ impl InvoiceStorage {
     }
 
     pub fn get_by_business(env: &Env, business: &Address) -> Vec<BytesN<32>> {
-        let key = Indexes::invoices_by_business(business);
-        env.storage()
-            .persistent()
-            .get(&key)
-            .unwrap_or(Vec::new(env))
+        Self::index_entries(env, &InvoiceIndex::Business(business.clone()))
     }
 
     pub fn get_business_invoices(env: &Env, business: &Address) -> Vec<BytesN<32>> {
@@ -411,11 +504,7 @@ impl InvoiceStorage {
     }
 
     pub fn get_by_status(env: &Env, status: InvoiceStatus) -> Vec<BytesN<32>> {
-        let key = Indexes::invoices_by_status(status);
-        env.storage()
-            .persistent()
-            .get(&key)
-            .unwrap_or(Vec::new(env))
+        Self::index_entries(env, &InvoiceIndex::Status(status))
     }
 
     pub fn get_invoices_by_status(env: &Env, status: InvoiceStatus) -> Vec<BytesN<32>> {
@@ -784,10 +873,7 @@ impl InvoiceStorage {
     }
 
     pub fn get_invoices_by_customer(env: &Env, customer_name: &String) -> Vec<BytesN<32>> {
-        env.storage()
-            .persistent()
-            .get(&Indexes::invoices_by_customer(customer_name))
-            .unwrap_or(Vec::new(env))
+        Self::index_entries(env, &InvoiceIndex::Customer(customer_name.clone()))
     }
 
     pub fn get_by_customer(env: &Env, customer_name: &String) -> Vec<BytesN<32>> {
@@ -795,10 +881,7 @@ impl InvoiceStorage {
     }
 
     pub fn get_invoices_by_tax_id(env: &Env, tax_id: &String) -> Vec<BytesN<32>> {
-        env.storage()
-            .persistent()
-            .get(&Indexes::invoices_by_tax_id(tax_id))
-            .unwrap_or(Vec::new(env))
+        Self::index_entries(env, &InvoiceIndex::TaxId(tax_id.clone()))
     }
 
     pub fn get_by_tax_id(env: &Env, tax_id: &String) -> Vec<BytesN<32>> {
@@ -838,11 +921,7 @@ impl InvoiceStorage {
         env: &Env,
         category: &InvoiceCategory,
     ) -> Vec<BytesN<32>> {
-        let key = Indexes::invoices_by_category(*category);
-        env.storage()
-            .persistent()
-            .get(&key)
-            .unwrap_or(Vec::new(env))
+        Self::index_entries(env, &InvoiceIndex::Category(*category))
     }
 
     /// Efficiently counts invoices for a category directly from the category index.
@@ -864,10 +943,7 @@ impl InvoiceStorage {
     }
 
     pub fn get_invoices_by_tag(env: &Env, tag: &String) -> Vec<BytesN<32>> {
-        env.storage()
-            .persistent()
-            .get(&Indexes::invoices_by_tag(tag))
-            .unwrap_or(Vec::new(env))
+        Self::index_entries(env, &InvoiceIndex::Tag(tag.clone()))
     }
 
     pub fn get_invoices_by_tags(env: &Env, tags: &Vec<String>) -> Vec<BytesN<32>> {

--- a/quicklendx-contracts/src/types.rs
+++ b/quicklendx-contracts/src/types.rs
@@ -432,6 +432,14 @@ pub struct SearchResult {
 /// signal and what it counts as `reindexed`.
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
+pub struct IndexCleanupReport {
+    pub scanned: u32,
+    pub removed: u32,
+    pub next_offset: u32,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct RebuildReport {
     /// Number of invoice IDs examined in this page.
     pub scanned: u32,

--- a/quicklendx-contracts/test_rebuild_indexes.rs
+++ b/quicklendx-contracts/test_rebuild_indexes.rs
@@ -1,0 +1,120 @@
+#![cfg(test)]
+
+use soroban_sdk::{testutils::Address as _, Address, BytesN, Env, String, Vec};
+
+use crate::storage::{Indexes, InvoiceIndex, InvoiceStorage};
+use crate::types::{InvoiceCategory, InvoiceStatus, RebuildReport};
+use crate::{QuickLendXContract, QuickLendXContractClient};
+
+fn setup() -> (Env, Address, QuickLendXContractClient<'static>, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+    let contract_id = env.register(QuickLendXContract, ());
+    let client = QuickLendXContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    client.initialize_admin(&admin);
+    (env, contract_id, client, admin)
+}
+
+fn make_invoice(env: &Env, client: &QuickLendXContractClient) -> BytesN<32> {
+    let business = Address::generate(env);
+    let currency = Address::generate(env);
+    client.upload_invoice(
+        &business,
+        &1000,
+        &currency,
+        &(env.ledger().timestamp() + 86_400),
+        &String::from_str(env, "Test invoice"),
+        &InvoiceCategory::Services,
+        &Vec::new(env),
+        &None)
+}
+
+#[test]
+fn test_rebuild_empty_range() {
+    let (env, _cid, client, admin) = setup();
+    make_invoice(&env, &client);
+
+    let report = client.rebuild_invoice_indexes(&admin, &100, &50);
+    assert_eq!(report.scanned, 0);
+    assert_eq!(report.reindexed, 0);
+    assert_eq!(report.next_offset, 100);
+}
+
+#[test]
+fn test_rebuild_pagination() {
+    let (env, _cid, client, admin) = setup();
+
+    for _ in 0..3 {
+        make_invoice(&env, &client);
+    }
+
+    let p1: RebuildReport = client.rebuild_invoice_indexes(&admin, &0, &2);
+    assert_eq!(p1.scanned, 2);
+    assert_eq!(p1.next_offset, 2);
+
+    let p2: RebuildReport = client.rebuild_invoice_indexes(&admin, &p1.next_offset, &2);
+    assert_eq!(p2.scanned, 1);
+    assert_eq!(p2.next_offset, 3);
+
+    let p3: RebuildReport = client.rebuild_invoice_indexes(&admin, &p2.next_offset, &2);
+    assert_eq!(p3.scanned, 0);
+}
+
+#[test]
+fn test_rebuild_single_invoice() {
+    let (env, _cid, client, admin) = setup();
+    let _invoice_id = make_invoice(&env, &client);
+
+    let report = client.rebuild_invoice_indexes(&admin, &0, &50);
+    assert_eq!(report.scanned, 1);
+    assert_eq!(report.reindexed, 1);
+    assert_eq!(report.next_offset, 1);
+}
+
+#[test]
+fn test_rebuild_non_admin_rejected() {
+    let (env, _cid, client, admin) = setup();
+    make_invoice(&env, &client);
+
+    let impostor = Address::generate(&env);
+    let result = client.try_rebuild_invoice_indexes(&impostor, &0, &50);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_stale_invoice_index_is_skipped_and_cleanup_is_replayable() {
+    let (env, _cid, _client, _admin) = setup();
+    let invoice_id = make_invoice(&env, &_client);
+    let missing_id = BytesN::from_array(&env, &[9u8; 32]);
+    let key = Indexes::invoices_by_status(InvoiceStatus::Pending);
+    let mut entries = Vec::new(&env);
+    entries.push_back(missing_id);
+    entries.push_back(invoice_id.clone());
+    entries.push_back(invoice_id.clone());
+    env.storage().persistent().set(&key, &entries);
+
+    let readable = InvoiceStorage::get_by_status(&env, InvoiceStatus::Pending);
+    assert_eq!(readable.len(), 1);
+    assert_eq!(readable.get(0).unwrap(), invoice_id);
+
+    let first = InvoiceStorage::cleanup_index_page(
+        &env,
+        &InvoiceIndex::Status(InvoiceStatus::Pending),
+        0,
+        100,
+    );
+    assert_eq!(first.removed, 2);
+    assert_eq!(first.next_offset, 0);
+    assert!(InvoiceStorage::get(&env, &invoice_id).is_some());
+
+    let second = InvoiceStorage::cleanup_index_page(
+        &env,
+        &InvoiceIndex::Status(InvoiceStatus::Pending),
+        first.next_offset,
+        100,
+    );
+    assert_eq!(second.removed, 0);
+    assert_eq!(second.next_offset, 1);
+}


### PR DESCRIPTION
Closes #2418

## Summary

Add graceful handling for stale, missing, duplicate, and expired bid/invoice index entries.

## Failure Mode

Secondary indexes can outlive or diverge from their canonical records after expiry, cancellation, partial migration, or interrupted cleanup. Queries previously trusted indexed IDs and could return missing, mismatched, expired, or ineligible records.

## Changes

- Added bounded, admin-authorized invoice index cleanup.
- Added replay-safe pagination for invoice index cleanup.
- Removed missing, mismatched, and duplicate invoice index entries.
- Preserved canonical invoice records during cleanup.
- Added read-time validation for business, status, customer, tax ID, tag, and category indexes.
- Prevented cross-invoice bid index entries from being returned.
- Excluded expired `Placed` bids from placed-bid queries.
- Excluded overdue verified invoices from available-invoice queries.
- Added regression coverage for stale, missing, duplicate, and replayed cleanup scenarios.

## Acceptance Criteria

- [x] Stale index entries are skipped during reads and removable through an authorized bounded cleanup path.
- [x] Valid records are never removed because an index is stale.
- [x] Cleanup is bounded, idempotent, and replay-safe.
- [x] Queries do not return records whose status or expiry makes them ineligible.
- [x] Tests inject missing and duplicate index entries.
- [x] Tests verify cleanup replay and valid-record preservation.
- [x] Bid and invoice query paths validate canonical records before returning results.

## Security and Correctness

Cleanup validates every indexed ID against the canonical record before removing it. Missing records, mismatched records, and duplicates are removed from the selected index only. Canonical invoice and bid records are never deleted by this cleanup path.

When cleanup removes entries, pagination resumes from the same offset because later entries shift left. This prevents interrupted or replayed cleanup from skipping entries.

## Backward Compatibility

Existing storage key formats and canonical records are unchanged. Reads may now return fewer entries when indexes contain stale, missing, duplicate, or status-inconsistent IDs. Terminal historical records remain preserved.

## Rollback and Migration

The cleanup operation is additive and can be disabled operationally without modifying canonical records. Existing deployments can invoke the admin cleanup endpoint incrementally by index and page. No destructive migration is required.

## Validation

- Editor diagnostics: passed.
- `git diff --check`: passed.
- Rust test execution: not completed because `cargo` is unavailable in the current environment.
- Full CI validation remains required before merge.

Closes #2418