### PR TITLE
[#2398] guard fee-recipient rotation with delayed activation

### DIFF
--- a/docs/FEE_RECIPIENT_ROTATION.md
+++ b/docs/FEE_RECIPIENT_ROTATION.md
@@ -8,7 +8,7 @@ To prevent human error (like sending protocol fees to a typo'd or inaccessible a
 
 ### Step 1: Initiate Rotation (Admin)
 
-The current protocol admin initiates the rotation by proposing a new address. This records the intent on-chain and starts the timelock.
+The current protocol admin initiates the rotation by proposing a new address. This records the intent on-chain and starts the timelock. The initial recipient may be configured once during fee-system setup; replacing an active recipient must use this delayed flow.
 
 **Entrypoint:** `initiate_treasury_rotation(new_treasury)`
 
@@ -25,10 +25,9 @@ soroban contract invoke \
 **Timelock:**
 Once initiated, a **1-day (86,400 seconds) timelock** begins. The rotation cannot be confirmed until this delay has elapsed.
 
-### Step 2: Confirm Rotation (New Treasury)
+### Step 2: Confirm Rotation (Admin and New Treasury)
 
-After the 1-day timelock has elapsed, the rotation must be confirmed. 
-**Crucially, this entrypoint must be authorized by the `new_treasury` address, not the admin.** This proves that the operator actually holds the private key to the new destination address.
+After the 1-day timelock has elapsed, the rotation must be confirmed. The configured administrator must authorize finalization, and the proposed `new_treasury` address must also authorize the underlying confirmation. This provides both governance approval and proof that the destination key is controlled by the operator.
 
 **Entrypoint:** `confirm_treasury_rotation(new_treasury)`
 
@@ -36,11 +35,14 @@ After the 1-day timelock has elapsed, the rotation must be confirmed.
 ```bash
 soroban contract invoke \
   --id CD... \
-  --source new_treasury_key \
+  --source admin_key \
   -- \
   confirm_treasury_rotation \
   --new_treasury GBNEWTREASURYADDRESS...
 ```
+
+The new recipient must authorize the same transaction as required by the
+contract's two-party confirmation guard.
 
 **Deadline (TTL):**
 The confirmation must happen before the rotation request expires (currently 7 days after initiation). If the deadline passes, the rotation request is dropped, and you must start over from Step 1.
@@ -61,3 +63,60 @@ soroban contract invoke \
 ```
 
 If cancelled, the active treasury remains unchanged, and fees continue to route to the old address.
+
+Initiation, cancellation, and successful confirmation each emit a distinct
+control-plane event. Indexers should retain all three event types, including
+cancellations, so operators can reconstruct the complete review history.
+
+## Security and compatibility notes
+
+The active fee route is stored in the fee-system platform configuration. Its
+initial recipient can be established once; later changes through the legacy
+single-step configuration entrypoint are rejected. The rotation request is
+stored separately, so a rejected or cancelled request leaves the active
+recipient untouched.
+
+An attacker cannot finalize a request by supplying the proposed address alone:
+the configured administrator must authorize the finalization and the proposed
+recipient must authorize the confirmation. Wrong-address, early, expired, or
+replayed finalization attempts return before the active configuration changes.
+
+No migration is required. Existing platform fee configuration records keep
+their serialized shape, and existing recipients remain active until a valid
+rotation is finalized. To roll back a mistaken finalized change, the admin
+can initiate a new rotation back to the previous address and wait through the
+same review delay; there is no emergency single-step bypass.
+
+## Validation matrix
+
+The contract-level regression suite covers the following state transitions:
+
+| Scenario | Required invariant |
+| --- | --- |
+| Bootstrap configuration | The first recipient can be established once |
+| Legacy reconfiguration | Rejected; active recipient is unchanged |
+| Proposal | Pending request is queryable and routing is unchanged |
+| Duplicate proposal | Rejected; the first request remains intact |
+| Same-address proposal | Rejected without creating a request |
+| Early finalization | Rejected; request and routing remain intact |
+| Exact minimum delay | Finalization succeeds |
+| Wrong proposed address | Rejected without consuming the request |
+| Exact confirmation deadline | Finalization succeeds |
+| Expired confirmation | Request is cleared and routing is unchanged |
+| Cancellation | Request is cleared, old recipient stays active, event is emitted |
+| Replayed finalization | Rejected after the request is consumed |
+| Replacement after cancellation/expiry | A new timelock starts |
+| Sequential rotations | Every proposal and confirmation remains indexable |
+
+Settlement resolves the recipient from the active platform fee configuration
+at the time the fee is routed. Settlements before finalization use the old
+address, while settlements after finalization use the new address; a pending
+proposal does not affect either path. This keeps the review window auditable
+without changing already-routed funds.
+
+For incident response, cancel the pending request during the review window and
+verify the active address with `get_treasury_address`. If the request has
+already been finalized, record the confirmation event and initiate a compensating
+rotation to the intended address. Operators should compare the initiated,
+confirmed, and cancelled event sequence against the pending-request view before
+approving a second rotation.

--- a/quicklendx-contracts/src/events.rs
+++ b/quicklendx-contracts/src/events.rs
@@ -1648,6 +1648,8 @@ pub fn emit_treasury_rotation_confirmed(env: &Env, admin: &Address, new_address:
 }
 
 pub fn treasury_rotation_cancelled(env: &Env, admin: &Address) {
+    // Cancellation is part of the auditable control-plane history even though
+    // it does not change the active recipient.
     env.events().publish(
         (symbol_short!("tr_rot_c"), admin.clone()),
         (),

--- a/quicklendx-contracts/src/fees.rs
+++ b/quicklendx-contracts/src/fees.rs
@@ -316,10 +316,11 @@ impl FeeManager {
 
         // Fetch existing config and reject duplicate treasury address.
         let mut platform_config = Self::get_platform_fee_config(env)?;
-        if let Some(ref existing) = platform_config.treasury_address {
-            if *existing == treasury_address {
-                return Err(QuickLendXError::InvalidFeeConfiguration);
-            }
+        // The first configuration establishes the recipient.  Once a live
+        // recipient exists, all replacements must use the delayed rotation
+        // flow so no single admin mutation can redirect fees immediately.
+        if platform_config.treasury_address.is_some() {
+            return Err(QuickLendXError::OperationNotAllowed);
         }
 
         let treasury_config = TreasuryConfig {
@@ -1271,6 +1272,7 @@ impl FeeManager {
         }
 
         env.storage().instance().remove(&ROTATION_KEY);
+        crate::events::treasury_rotation_cancelled(env, admin);
         Ok(())
     }
 

--- a/quicklendx-contracts/src/lib.rs
+++ b/quicklendx-contracts/src/lib.rs
@@ -303,6 +303,8 @@ mod test_analytics_consistency;
 mod test_snapshot;
 #[cfg(test)]
 mod test_bid_capacity_stress;
+#[cfg(test)]
+mod test_fee_recipient_rotation_guard;
 // Issue #1891 â€” min-partial-fill amount boundary: at limit, one below, one above.
 #[cfg(test)]
 mod test_min_partial_fill_boundary;
@@ -801,12 +803,41 @@ impl QuickLendXContract {
         init::ProtocolInitializer::set_treasury(&env, &admin, &treasury)
     }
 
-    /// Admin-only: cancel a pending treasury address rotation before it executes.
+    /// Propose a delayed fee-recipient rotation (admin only).
+    pub fn initiate_treasury_rotation(
+        env: Env,
+        new_treasury: Address,
+    ) -> Result<fees::RecipientRotationRequest, QuickLendXError> {
+        let admin = BusinessVerificationStorage::get_admin(&env).ok_or(QuickLendXError::NotAdmin)?;
+        fees::FeeManager::initiate_treasury_rotation(&env, &admin, new_treasury)
+    }
+
+    /// Finalize a delayed fee-recipient rotation.
     ///
-    /// # Arguments
-    /// * `admin` - The address of the caller, must be the current admin.
-    pub fn cancel_treasury_rotation(env: Env, admin: Address) -> Result<(), QuickLendXError> {
-        admin::cancel_treasury_rotation(&env, &admin)
+    /// The configured admin must authorize the finalization, and the proposed
+    /// recipient must also authorize the underlying FeeManager confirmation.
+    /// Requiring both parties prevents an admin typo and prevents a proposed
+    /// recipient from changing control without administrator approval.
+    pub fn confirm_treasury_rotation(
+        env: Env,
+        new_treasury: Address,
+    ) -> Result<Address, QuickLendXError> {
+        let admin = BusinessVerificationStorage::get_admin(&env).ok_or(QuickLendXError::NotAdmin)?;
+        admin.require_auth();
+        fees::FeeManager::confirm_treasury_rotation(&env, &new_treasury)
+    }
+
+    /// Cancel a pending fee-recipient rotation (admin only).
+    pub fn cancel_treasury_rotation(env: Env) -> Result<(), QuickLendXError> {
+        let admin = BusinessVerificationStorage::get_admin(&env).ok_or(QuickLendXError::NotAdmin)?;
+        fees::FeeManager::cancel_treasury_rotation(&env, &admin)
+    }
+
+    /// Return the complete pending fee-recipient rotation request, if any.
+    pub fn get_pending_treasury_rotation(
+        env: Env,
+    ) -> Option<fees::RecipientRotationRequest> {
+        fees::FeeManager::get_pending_rotation(&env)
     }
 
     /// Get the pending treasury address and its execution timestamp, if any.
@@ -5447,4 +5478,3 @@ impl QuickLendXContract {
         diagnostics::get_protocol_diagnostics(&env)
     }
 }
-

--- a/quicklendx-contracts/src/test_fee_recipient_rotation_guard.rs
+++ b/quicklendx-contracts/src/test_fee_recipient_rotation_guard.rs
@@ -1,0 +1,383 @@
+//! Contract-surface regression tests for guarded fee-recipient rotation.
+//!
+//! The FeeManager owns the delayed rotation state machine. These tests exercise
+//! the public contract entrypoints that connect that state machine to the live
+//! fee-routing configuration. They cover every mutation boundary where an
+//! unauthorized, early, expired, cancelled, or replayed operation must leave
+//! the active recipient unchanged.
+
+#![cfg(test)]
+
+use crate::fees::MIN_ROTATION_DELAY_SECONDS;
+use crate::{QuickLendXContract, QuickLendXContractClient};
+use soroban_sdk::{
+    testutils::{Address as _, Events, Ledger},
+    xdr, Address, Env, Symbol, TryFromVal,
+};
+
+const ROTATION_TTL_SECONDS: u64 = 604_800;
+
+fn setup(env: &Env) -> (QuickLendXContractClient, Address, Address) {
+    let contract_id = env.register(QuickLendXContract, ());
+    let client = QuickLendXContractClient::new(env, &contract_id);
+    let admin = Address::generate(env);
+    let original = Address::generate(env);
+    client.initialize_admin(&admin);
+    client.initialize_fee_system(&admin);
+    client.configure_treasury(&original);
+    (client, admin, original)
+}
+
+fn new_address(env: &Env) -> Address {
+    Address::generate(env)
+}
+
+fn advance_to_min_delay(env: &Env) {
+    env.ledger()
+        .set_timestamp(env.ledger().timestamp() + MIN_ROTATION_DELAY_SECONDS);
+}
+
+fn advance_to_expiry(env: &Env, initiated_at: u64) {
+    env.ledger()
+        .set_timestamp(initiated_at + ROTATION_TTL_SECONDS + 1);
+}
+
+fn count_topic(env: &Env, topic: &str) -> u32 {
+    let topic = Symbol::new(env, topic);
+    let topic_xdr = xdr::ScVal::try_from_val(env, &topic).expect("topic to ScVal");
+    env.events()
+        .all()
+        .events()
+        .iter()
+        .filter(|event| match &event.body {
+            xdr::ContractEventBody::V0(body) => body.topics.first() == Some(&topic_xdr),
+        })
+        .count() as u32
+}
+
+#[test]
+fn public_rotation_flow_starts_with_the_active_recipient() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, original) = setup(&env);
+    assert_eq!(client.get_treasury_address(), Some(original.clone()));
+    assert!(client.get_pending_treasury_rotation().is_none());
+
+    let proposed = new_address(&env);
+    let request = client.initiate_treasury_rotation(&proposed);
+
+    assert_eq!(request.new_address, proposed);
+    assert_eq!(client.get_treasury_address(), Some(original));
+    assert_eq!(
+        request.confirmation_deadline,
+        request.initiated_at + ROTATION_TTL_SECONDS
+    );
+    assert_eq!(count_topic(&env, "tr_rot_i"), 1);
+}
+
+#[test]
+fn active_recipient_is_stable_until_exact_delay_then_changes_once() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, original) = setup(&env);
+    let proposed = new_address(&env);
+    client.initiate_treasury_rotation(&proposed);
+
+    let early = client.try_confirm_treasury_rotation(&proposed);
+    assert!(early.is_err());
+    assert_eq!(client.get_treasury_address(), Some(original.clone()));
+    assert!(client.get_pending_treasury_rotation().is_some());
+
+    advance_to_min_delay(&env);
+    assert_eq!(client.confirm_treasury_rotation(&proposed), proposed);
+    assert_eq!(client.get_treasury_address(), Some(proposed));
+    assert!(client.get_pending_treasury_rotation().is_none());
+    assert_eq!(count_topic(&env, "tr_rot_f"), 1);
+}
+
+#[test]
+fn cancellation_keeps_routing_on_the_original_recipient_and_emits_event() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, original) = setup(&env);
+    let proposed = new_address(&env);
+    client.initiate_treasury_rotation(&proposed);
+    client.cancel_treasury_rotation();
+
+    assert_eq!(client.get_treasury_address(), Some(original));
+    assert!(client.get_pending_treasury_rotation().is_none());
+    assert_eq!(count_topic(&env, "tr_rot_c"), 1);
+}
+
+#[test]
+fn duplicate_proposal_is_rejected_without_replacing_pending_request() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, original) = setup(&env);
+    let first = new_address(&env);
+    let second = new_address(&env);
+    client.initiate_treasury_rotation(&first);
+
+    let result = client.try_initiate_treasury_rotation(&second);
+    assert!(result.is_err());
+    assert_eq!(client.get_treasury_address(), Some(original));
+    assert_eq!(
+        client
+            .get_pending_treasury_rotation()
+            .expect("first request remains")
+            .new_address,
+        first
+    );
+}
+
+#[test]
+fn cancellation_allows_a_reviewed_replacement_proposal() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, original) = setup(&env);
+    let abandoned = new_address(&env);
+    let replacement = new_address(&env);
+    client.initiate_treasury_rotation(&abandoned);
+    client.cancel_treasury_rotation();
+    client.initiate_treasury_rotation(&replacement);
+
+    assert_eq!(client.get_treasury_address(), Some(original));
+    assert_eq!(
+        client.get_pending_treasury_rotation().unwrap().new_address,
+        replacement
+    );
+}
+
+#[test]
+fn wrong_recipient_cannot_finalize_or_clear_pending_state() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, original) = setup(&env);
+    let proposed = new_address(&env);
+    let wrong = new_address(&env);
+    client.initiate_treasury_rotation(&proposed);
+    advance_to_min_delay(&env);
+
+    let result = client.try_confirm_treasury_rotation(&wrong);
+    assert!(result.is_err());
+    assert_eq!(client.get_treasury_address(), Some(original));
+    assert_eq!(
+        client.get_pending_treasury_rotation().unwrap().new_address,
+        proposed
+    );
+}
+
+#[test]
+fn replayed_finalization_is_rejected_and_recipient_stays_active() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, _original) = setup(&env);
+    let proposed = new_address(&env);
+    client.initiate_treasury_rotation(&proposed);
+    advance_to_min_delay(&env);
+    client.confirm_treasury_rotation(&proposed);
+
+    let result = client.try_confirm_treasury_rotation(&proposed);
+    assert!(result.is_err());
+    assert_eq!(client.get_treasury_address(), Some(proposed));
+}
+
+#[test]
+fn expired_finalization_clears_request_without_changing_routing() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, original) = setup(&env);
+    let proposed = new_address(&env);
+    let request = client.initiate_treasury_rotation(&proposed);
+    advance_to_expiry(&env, request.initiated_at);
+
+    let result = client.try_confirm_treasury_rotation(&proposed);
+    assert!(result.is_err());
+    assert_eq!(client.get_treasury_address(), Some(original));
+    assert!(client.get_pending_treasury_rotation().is_none());
+}
+
+#[test]
+fn exact_deadline_is_valid_but_one_second_later_is_not() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, original) = setup(&env);
+    let proposed = new_address(&env);
+    let request = client.initiate_treasury_rotation(&proposed);
+    env.ledger().set_timestamp(request.confirmation_deadline);
+    assert_eq!(client.confirm_treasury_rotation(&proposed), proposed);
+
+    let second = new_address(&env);
+    let request = client.initiate_treasury_rotation(&second);
+    env.ledger()
+        .set_timestamp(request.confirmation_deadline + 1);
+    assert!(client.try_confirm_treasury_rotation(&second).is_err());
+    assert_eq!(client.get_treasury_address(), Some(proposed));
+    assert_ne!(client.get_treasury_address(), Some(original));
+}
+
+#[test]
+fn legacy_single_step_reconfiguration_is_rejected_after_bootstrap() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, original) = setup(&env);
+    let attempted = new_address(&env);
+    let result = client.try_configure_treasury(&attempted);
+
+    assert!(result.is_err());
+    assert_eq!(client.get_treasury_address(), Some(original));
+    assert!(client.get_pending_treasury_rotation().is_none());
+}
+
+#[test]
+fn finalized_recipient_is_visible_to_the_fee_router_configuration() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, original) = setup(&env);
+    assert_eq!(client.get_treasury_address(), Some(original.clone()));
+
+    let proposed = new_address(&env);
+    client.initiate_treasury_rotation(&proposed);
+    advance_to_min_delay(&env);
+    client.confirm_treasury_rotation(&proposed);
+
+    // FeeManager::route_platform_fee reads this same platform configuration;
+    // the view proves settlement observes the activated recipient without a
+    // token transfer obscuring this state-machine assertion.
+    assert_eq!(client.get_treasury_address(), Some(proposed));
+    assert_ne!(client.get_treasury_address(), Some(original));
+}
+
+#[test]
+fn every_rotation_step_has_a_distinct_audit_topic() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, _original) = setup(&env);
+    let proposed = new_address(&env);
+    client.initiate_treasury_rotation(&proposed);
+    client.cancel_treasury_rotation();
+
+    assert_eq!(count_topic(&env, "tr_rot_i"), 1);
+    assert_eq!(count_topic(&env, "tr_rot_c"), 1);
+    assert_eq!(count_topic(&env, "tr_rot_f"), 0);
+}
+
+#[test]
+fn a_second_rotation_requires_a_new_delay_window() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, _original) = setup(&env);
+    let first = new_address(&env);
+    client.initiate_treasury_rotation(&first);
+    advance_to_min_delay(&env);
+    client.confirm_treasury_rotation(&first);
+
+    let second = new_address(&env);
+    let request = client.initiate_treasury_rotation(&second);
+    assert!(client.try_confirm_treasury_rotation(&second).is_err());
+    assert_eq!(client.get_treasury_address(), Some(first));
+    assert_eq!(request.initiated_at, env.ledger().timestamp());
+}
+
+#[test]
+fn cancelling_without_a_request_does_not_mutate_active_configuration() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, original) = setup(&env);
+
+    assert!(client.try_cancel_treasury_rotation().is_err());
+    assert_eq!(client.get_treasury_address(), Some(original));
+    assert!(client.get_pending_treasury_rotation().is_none());
+    assert_eq!(count_topic(&env, "tr_rot_c"), 0);
+}
+
+#[test]
+fn proposing_the_current_recipient_is_rejected_without_pending_state() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, original) = setup(&env);
+
+    let result = client.try_initiate_treasury_rotation(&original);
+    assert!(result.is_err());
+    assert_eq!(client.get_treasury_address(), Some(original));
+    assert!(client.get_pending_treasury_rotation().is_none());
+    assert_eq!(count_topic(&env, "tr_rot_i"), 0);
+}
+
+#[test]
+fn expiry_is_recoverable_by_a_fresh_proposal() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, original) = setup(&env);
+    let expired = new_address(&env);
+    let request = client.initiate_treasury_rotation(&expired);
+    advance_to_expiry(&env, request.initiated_at);
+    assert!(client.try_confirm_treasury_rotation(&expired).is_err());
+
+    let replacement = new_address(&env);
+    let replacement_request = client.initiate_treasury_rotation(&replacement);
+    assert_eq!(replacement_request.new_address, replacement);
+    assert_eq!(client.get_treasury_address(), Some(original));
+    assert_eq!(count_topic(&env, "tr_rot_i"), 2);
+}
+
+#[test]
+fn failed_confirmation_does_not_consume_the_confirmation_window() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, original) = setup(&env);
+    let proposed = new_address(&env);
+    let wrong = new_address(&env);
+    let request = client.initiate_treasury_rotation(&proposed);
+    env.ledger()
+        .set_timestamp(request.initiated_at + MIN_ROTATION_DELAY_SECONDS - 1);
+
+    assert!(client.try_confirm_treasury_rotation(&wrong).is_err());
+    assert_eq!(client.get_treasury_address(), Some(original));
+    assert_eq!(
+        client.get_pending_treasury_rotation().unwrap().new_address,
+        proposed
+    );
+    assert_eq!(count_topic(&env, "tr_rot_f"), 0);
+}
+
+#[test]
+fn sequential_successful_rotations_preserve_the_event_trail() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, original) = setup(&env);
+    let first = new_address(&env);
+    client.initiate_treasury_rotation(&first);
+    advance_to_min_delay(&env);
+    client.confirm_treasury_rotation(&first);
+
+    let second = new_address(&env);
+    client.initiate_treasury_rotation(&second);
+    advance_to_min_delay(&env);
+    client.confirm_treasury_rotation(&second);
+
+    assert_eq!(client.get_treasury_address(), Some(second));
+    assert_ne!(client.get_treasury_address(), Some(original));
+    assert_eq!(count_topic(&env, "tr_rot_i"), 2);
+    assert_eq!(count_topic(&env, "tr_rot_f"), 2);
+}
+
+#[test]
+fn pending_request_exposes_review_window_to_operators() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, _original) = setup(&env);
+    let proposed = new_address(&env);
+    let request = client.initiate_treasury_rotation(&proposed);
+    let pending = client
+        .get_pending_treasury_rotation()
+        .expect("pending request is queryable");
+
+    assert_eq!(pending.new_address, proposed);
+    assert_eq!(pending.initiated_by, admin);
+    assert_eq!(pending.initiated_at, request.initiated_at);
+    assert_eq!(
+        pending.confirmation_deadline - pending.initiated_at,
+        ROTATION_TTL_SECONDS
+    );
+}


### PR DESCRIPTION
## Summary

- Wire the existing delayed fee-recipient rotation state machine into the live contract interface.
- Require the configured administrator to authorize proposal, cancellation, and finalization.
- Require the proposed recipient to authorize confirmation as a second control against destination typos or inaccessible keys.
- Reject legacy post-bootstrap one-step recipient replacement and emit an auditable cancellation event.
- Add end-to-end state-machine regression coverage and update the operator runbook.

## Failure mode addressed

Before this change, the FeeManager contained rotation helpers but the live contract did not expose proposal or confirmation. The public cancellation path targeted a separate legacy storage key, and `configure_treasury` could replace an active fee recipient immediately. That left the actual fee-routing surface without the review window described by the helper implementation.

## Design

- The first fee-system configuration establishes the initial recipient once.
- Subsequent replacements must be proposed through `initiate_treasury_rotation` and remain pending for at least 86,400 seconds.
- `confirm_treasury_rotation` requires both the configured admin and the proposed recipient; it validates the delay/deadline before changing the active platform fee configuration.
- `cancel_treasury_rotation` operates on the same FeeManager request key, clears it atomically, and emits `tr_rot_c`.
- Settlement routing continues to read the active platform fee configuration, so pending proposals do not affect funds and finalized rotations affect only subsequent routing.

## Acceptance coverage

- [x] A fee recipient cannot change through a single unreviewed mutation after bootstrap.
- [x] Only the configured administrator can propose, cancel, or finalize a rotation; recipient authorization is an additional confirmation guard.
- [x] Finalization before the delay, with a wrong address, after expiry, or after replay fails without changing the active recipient.
- [x] The active recipient remains stable until successful finalization.
- [x] Proposal, confirmation, and cancellation emit distinct auditable events.
- [x] Replacement proposals, exact delay/deadline boundaries, expiry recovery, cancellation, and repeated rotations are tested.
- [x] The PR documents failure mode, design, compatibility, rollback, and operator validation.

## Backward compatibility and rollback

Existing serialized platform fee configuration records are unchanged. The initial setup call remains available; only attempts to replace an already configured recipient through that legacy call are rejected. A mistaken finalized change is recoverable by initiating a new guarded rotation back to the intended address; there is no immediate bypass that would undermine the review window.

## Validation

- `cargo check -p quicklendx-contracts --lib` — passed; only existing unreachable-pattern warnings in `errors.rs` remain.
- `rustfmt --edition 2021 --check quicklendx-contracts/src/test_fee_recipient_rotation_guard.rs` — passed.
- `cargo test -p quicklendx-contracts test_fee_recipient_rotation_guard --lib` — blocked by 177 pre-existing compile errors in unrelated test modules (malformed fixtures, duplicate modules, stale signatures, and missing test-only imports). The new module contributes no reported errors before that baseline failure.
- Diff: 506 changed lines, limited to fee rotation code, event wiring, tests, and its operator documentation.

Closes #2398
