### PR TITLE
[Quality][#2391] Make bid acceptance invoice-scoped and atomic

### DIFF
--- a/quicklendx-contracts/src/escrow.rs
+++ b/quicklendx-contracts/src/escrow.rs
@@ -18,11 +18,18 @@
 
 use crate::admin::AdminStorage;
 use crate::errors::QuickLendXError;
-use crate::events::{emit_escrow_refunded, emit_investment_withdrawn, emit_invoice_funded};
-use crate::payments::{create_escrow, create_escrow_record_only, refund_escrow, EscrowStatus, EscrowStorage};
+use crate::events::{
+    emit_bid_accepted, emit_escrow_refunded, emit_investment_withdrawn, emit_invoice_funded,
+};
+use crate::payments::{
+    create_escrow, create_escrow_record_only, refund_escrow, EscrowStatus, EscrowStorage,
+};
 use crate::storage::{BidStorage, InvestmentStorage, InvoiceStorage};
 use crate::types::{BidStatus, Investment, InvestmentStatus, InvoiceStatus};
-use crate::verification::{require_business_active, require_business_not_pending};
+use crate::verification::{
+    require_business_active, require_business_not_pending, require_investor_not_frozen,
+    require_investor_not_pending,
+};
 use soroban_sdk::{Address, BytesN, Env, Vec};
 
 /// Loaded and validated state required to accept a bid.
@@ -90,7 +97,7 @@ pub(crate) fn load_accept_bid_context(
         return Err(QuickLendXError::InvalidStatus);
     }
 
-    let bid = BidStorage::get_bid(env, bid_id).unwrap();
+    let bid = BidStorage::get_bid(env, bid_id).ok_or(QuickLendXError::StorageKeyNotFound)?;
 
     if bid.invoice_id != *invoice_id {
         return Err(QuickLendXError::Unauthorized);
@@ -99,6 +106,12 @@ pub(crate) fn load_accept_bid_context(
     if bid.status != BidStatus::Placed {
         return Err(QuickLendXError::InvalidStatus);
     }
+
+    // KYC and freeze status are checked again at acceptance time. A bid can
+    // remain open after its investor's verification changes, so placement-time
+    // validation alone is not sufficient authorization for moving funds.
+    require_investor_not_frozen(env, &bid.investor)?;
+    require_investor_not_pending(env, &bid.investor)?;
 
     if bid.is_expired(env.ledger().timestamp()) {
         return Err(QuickLendXError::InvalidStatus);
@@ -139,21 +152,34 @@ pub fn accept_bid_and_fund(
 
     let mut escrow_amount = bid.bid_amount;
     if let Some(fee_bps) = invoice.origination_fee_bps {
-        let total_fee = (bid.bid_amount.checked_mul(fee_bps as i128).ok_or(QuickLendXError::ArithmeticOverflow)?)
-            .checked_div(10000).ok_or(QuickLendXError::ArithmeticOverflow)?;
-            
-        escrow_amount = bid.bid_amount.checked_sub(total_fee).ok_or(QuickLendXError::ArithmeticOverflow)?;
-        
+        let total_fee = (bid
+            .bid_amount
+            .checked_mul(fee_bps as i128)
+            .ok_or(QuickLendXError::ArithmeticOverflow)?)
+        .checked_div(10000)
+        .ok_or(QuickLendXError::ArithmeticOverflow)?;
+
+        escrow_amount = bid
+            .bid_amount
+            .checked_sub(total_fee)
+            .ok_or(QuickLendXError::ArithmeticOverflow)?;
+
         if total_fee > 0 {
             // Single transfer for the full bid amount avoids a stale balance read
             // that could occur when two sequential transfer_funds calls are made
             // from the same source address within one transaction.
-            crate::payments::transfer_funds(env, &invoice.currency, &bid.investor, &env.current_contract_address(), bid.bid_amount)?;
-            
+            crate::payments::transfer_funds(
+                env,
+                &invoice.currency,
+                &bid.investor,
+                &env.current_contract_address(),
+                bid.bid_amount,
+            )?;
+
             let mut fees_collected = soroban_sdk::Map::new(env);
             fees_collected.set(crate::fees::FeeType::Origination, total_fee);
             crate::fees::FeeManager::collect_fees(env, &bid.investor, fees_collected, total_fee)?;
-            
+
             // Funds are already in the contract from the single transfer above.
             // Create the escrow record without a second transfer.
             let escrow_id = create_escrow_record_only(
@@ -172,9 +198,11 @@ pub fn accept_bid_and_fund(
 
             // 7. Events
             emit_invoice_funded(env, invoice_id, &bid.investor, bid.bid_amount);
+            emit_bid_accepted(env, &bid, invoice_id, &invoice.business);
 
             // Lifecycle trigger: emits `NotificationType::BidAccepted` to the investor
-            let _ = crate::notifications::NotificationSystem::notify_bid_accepted(env, &invoice, &bid);
+            let _ =
+                crate::notifications::NotificationSystem::notify_bid_accepted(env, &invoice, &bid);
 
             return Ok(escrow_id);
         }
@@ -197,6 +225,7 @@ pub fn accept_bid_and_fund(
 
     // 7. Events
     emit_invoice_funded(env, invoice_id, &bid.investor, bid.bid_amount);
+    emit_bid_accepted(env, &bid, invoice_id, &invoice.business);
 
     // Lifecycle trigger: emits `NotificationType::BidAccepted` to the investor
     // after escrow funding and state transitions complete successfully.

--- a/quicklendx-contracts/src/lib.rs
+++ b/quicklendx-contracts/src/lib.rs
@@ -2473,71 +2473,13 @@ impl QuickLendXContract {
         invoice_id: BytesN<32>,
         bid_id: BytesN<32>,
     ) -> Result<(), QuickLendXError> {
-        BidStorage::cleanup_expired_bids(&env, &invoice_id);
-        let mut invoice = InvoiceStorage::get_invoice(&env, &invoice_id)
-            .ok_or(QuickLendXError::InvoiceNotFound)?;
-        if InvoiceStorage::is_frozen(&env, &invoice_id) {
-            InvoiceStorage::require_lock_within_time_limit(&env, &invoice_id)?;
-            return Err(QuickLendXError::InvoiceFrozen);
-        }
-        require_no_active_freeze(&env, &invoice_id)?;
-        let bid = BidStorage::get_bid(&env, &bid_id).unwrap();
-        let invoice_id = bid.invoice_id.clone();
-        BidStorage::cleanup_expired_bids(&env, &invoice_id);
-        let mut bid = BidStorage::get_bid(&env, &bid_id).unwrap();
-        require_investor_not_frozen(&env, &bid.investor)?;
-        invoice.business.require_auth();
-
-        // Enforce business is active (not deleted/frozen).
-        require_business_active(&env, &invoice.business)?;
-
-        // Enforce KYC: a pending business must not accept bids.
-        require_business_not_pending(&env, &invoice.business)?;
-
-        if invoice.status != InvoiceStatus::Verified || bid.status != BidStatus::Placed {
-            return Err(QuickLendXError::InvalidStatus);
-        }
-
-        let escrow_id = create_escrow(
-            &env,
-            &invoice_id,
-            &bid.investor,
-            &invoice.business,
-            bid.bid_amount,
-            &invoice.currency,
-        )?;
-        bid.status = BidStatus::Accepted;
-        BidStorage::update_bid(&env, &bid);
-        // Remove from old status list before changing status
-        InvoiceStorage::remove_from_status_invoices(&env, InvoiceStatus::Verified, &invoice_id);
-
-        invoice.mark_as_funded(
-            &env,
-            bid.investor.clone(),
-            bid.bid_amount,
-            env.ledger().timestamp(),
-        );
-        InvoiceStorage::update_invoice(&env, &invoice);
-
-        // Add to new status list after status change
-        InvoiceStorage::add_to_status_invoices(&env, InvoiceStatus::Funded, &invoice_id);
-        let investment_id = InvestmentStorage::generate_unique_investment_id(&env);
-        let investment = Investment {
-            investment_id: investment_id.clone(),
-            invoice_id: invoice_id.clone(),
-            investor: bid.investor.clone(),
-            amount: bid.bid_amount,
-            funded_at: env.ledger().timestamp(),
-            status: InvestmentStatus::Active,
-            insurance: Vec::new(&env),
-        };
-        InvestmentStorage::store_investment(&env, &investment);
-
-        let escrow = EscrowStorage::get_escrow(&env, &escrow_id).unwrap();
-        emit_escrow_created(&env, &escrow);
-        emit_bid_accepted(&env, &bid, &invoice_id, &invoice.business);
-
-        Ok(())
+        // Keep the legacy entrypoint on the same atomic implementation as the
+        // explicit funding API.  The previous duplicate implementation
+        // replaced the caller-supplied invoice ID with `bid.invoice_id`
+        // before checking that the two IDs matched.  A bid from another
+        // invoice could consequently fund one invoice while indexing escrow
+        // and investment state under another.
+        do_accept_bid_and_fund(&env, &invoice_id, &bid_id).map(|_| ())
     }
 
     /// Add insurance coverage to an active investment (investor only).
@@ -5447,4 +5389,3 @@ impl QuickLendXContract {
         diagnostics::get_protocol_diagnostics(&env)
     }
 }
-

--- a/quicklendx-contracts/src/test_bid_cancel_accept_race.rs
+++ b/quicklendx-contracts/src/test_bid_cancel_accept_race.rs
@@ -21,6 +21,8 @@ struct CancelAcceptFixture {
     env: Env,
     client: QuickLendXContractClient<'static>,
     contract_id: Address,
+    business: Address,
+    currency: Address,
     invoice_id: BytesN<32>,
     bid_id: BytesN<32>,
     investor: Address,
@@ -101,7 +103,10 @@ fn build_cancel_accept_fixture() -> CancelAcceptFixture {
         &String::from_str(&env, "Cancel accept race invoice"),
         &InvoiceCategory::Services,
         &Vec::new(&env),
-        &None);
+        &None,
+        &None,
+        &None,
+    );
     client.verify_invoice(&invoice_id);
 
     let bid_id = client.place_bid(
@@ -116,10 +121,61 @@ fn build_cancel_accept_fixture() -> CancelAcceptFixture {
         env,
         client,
         contract_id,
+        business,
+        currency,
         invoice_id,
         bid_id,
         investor,
     }
+}
+
+/// The legacy `accept_bid` API must reject a bid whose invoice does not match
+/// the invoice argument.  This is a particularly important atomicity check:
+/// accepting the mismatched bid used to create escrow under the bid's invoice
+/// while marking the requested invoice as funded.
+#[test]
+fn test_accept_bid_rejects_mismatched_invoice_without_cross_invoice_state() {
+    let fixture = build_cancel_accept_fixture();
+    let second_invoice = fixture.client.upload_invoice(
+        &fixture.business,
+        &10_000i128,
+        &fixture.currency,
+        &(fixture.env.ledger().timestamp() + 86_400),
+        &String::from_str(&fixture.env, "Mismatched bid invoice"),
+        &InvoiceCategory::Services,
+        &Vec::new(&fixture.env),
+        &None,
+        &None,
+        &None,
+    );
+    fixture.client.verify_invoice(&second_invoice);
+    let second_bid = fixture.client.place_bid(
+        &fixture.investor,
+        &second_invoice,
+        &9_000i128,
+        &10_000i128,
+        &BytesN::from_array(&fixture.env, &[1u8; 32]),
+    );
+
+    let result = fixture
+        .client
+        .try_accept_bid(&fixture.invoice_id, &second_bid);
+    let error = result
+        .expect_err("a bid for another invoice must be rejected")
+        .expect("contract error must decode");
+    assert_eq!(error, QuickLendXError::Unauthorized);
+
+    assert_no_funding_state(&fixture.client, &fixture.invoice_id);
+    assert_no_funding_state(&fixture.client, &second_invoice);
+    assert_eq!(
+        fixture
+            .client
+            .get_bid(&second_bid)
+            .expect("bid exists")
+            .status,
+        BidStatus::Placed,
+        "losing bid must remain untouched for a later valid acceptance"
+    );
 }
 
 fn assert_no_funding_state(client: &QuickLendXContractClient, invoice_id: &BytesN<32>) {


### PR DESCRIPTION
## Summary

Fix bid acceptance so competing investors and malformed cross-invoice requests cannot create inconsistent funding state.

## What changed

- Route the legacy `accept_bid` entrypoint through the canonical guarded `accept_bid_and_fund` implementation.
- Validate the requested invoice ID against the bid’s stored invoice ID before any escrow, bid, invoice, or investment mutation.
- Replace missing-bid panics with the deterministic `StorageKeyNotFound` contract error.
- Re-check investor KYC and freeze status at acceptance time, since a bid may remain open after its placement-time verification.
- Preserve the accepted-bid event while keeping escrow, invoice, bid, and investment writes in one atomic flow.
- Add a regression test proving a bid from another invoice leaves both invoices and the bid untouched.

## Acceptance criteria

- [x] A second acceptance after the invoice is funded is rejected by the existing invoice/escrow guards.
- [x] A bid from another invoice is rejected before state changes.
- [x] Only the invoice business, with active/KYC-valid status, can authorize acceptance.
- [x] Investor freeze and KYC status are revalidated immediately before funding.
- [x] Escrow transfer and state transitions use the canonical atomic funding flow.
- [x] Deterministic error and accepted-bid event behavior is retained.
- [x] Regression coverage verifies no cross-invoice partial state.

## Validation

- `cargo check --manifest-path quicklendx-contracts/Cargo.toml --lib` passes.
- `git diff --check` passes.
- The full Rust test target is currently blocked by pre-existing upstream test drift (stale generated-client signatures, duplicate test modules, and missing test-only imports; 178 errors before the focused test can run).

Closes #2391
