### PR TITLE
[Quality][#2393] Reject overflowed default-finality deadlines

### DIFF
--- a/docs/default-finality-matrix.md
+++ b/docs/default-finality-matrix.md
@@ -70,6 +70,10 @@ guard, which must reject a second default attempt with
 Implementation notes:
 
 - `defaults::mark_invoice_defaulted` remains the canonical default path.
+- Default eligibility is strict: timestamps at `due_date + grace_period` are
+  still ineligible; only a timestamp after that checked deadline may trigger
+  the transition. Deadline overflow and stored grace values above the protocol
+  maximum fail with `InvalidTimestamp` rather than extending the window.
 - `defaults::handle_default` must refuse defaulting once settlement has finalized
   or the escrow status is no longer `Held`.
 - Any admin/testing shortcut that wants to produce `Defaulted` must route through

--- a/quicklendx-contracts/src/defaults.rs
+++ b/quicklendx-contracts/src/defaults.rs
@@ -109,9 +109,15 @@ pub fn resolve_grace_period(env: &Env, grace_period: Option<u64>) -> Result<u64,
             }
             Ok(value)
         }
-        None => Ok(ProtocolInitializer::get_protocol_config(env)
-            .map(|config| config.grace_period_seconds)
-            .unwrap_or(DEFAULT_GRACE_PERIOD)),
+        None => {
+            let value = ProtocolInitializer::get_protocol_config(env)
+                .map(|config| config.grace_period_seconds)
+                .unwrap_or(DEFAULT_GRACE_PERIOD);
+            if value > MAX_GRACE_PERIOD {
+                return Err(QuickLendXError::InvalidTimestamp);
+            }
+            Ok(value)
+        }
     }
 }
 
@@ -158,7 +164,7 @@ pub fn mark_invoice_defaulted(
 
     let current_timestamp = env.ledger().timestamp();
     let grace = resolve_grace_period(env, grace_period)?;
-    let grace_deadline = invoice.grace_deadline(grace);
+    let grace_deadline = invoice.checked_grace_deadline(grace)?;
 
     if current_timestamp <= grace_deadline {
         return Err(QuickLendXError::OperationNotAllowed);
@@ -256,6 +262,7 @@ pub fn scan_funded_invoice_expirations(
     grace_period: u64,
     limit: Option<u32>,
 ) -> Result<OverdueScanResult, QuickLendXError> {
+    let grace_period = resolve_grace_period(env, Some(grace_period))?;
     let funded_invoices = InvoiceStorage::get_invoices_by_status(env, InvoiceStatus::Funded);
     let total_funded = funded_invoices.len();
 
@@ -286,7 +293,7 @@ pub fn scan_funded_invoice_expirations(
                     );
                 }
 
-                if current_timestamp > invoice.grace_deadline(grace_period) {
+                if current_timestamp > invoice.checked_grace_deadline(grace_period)? {
                     let _ = invoice.check_and_handle_expiration(env, grace_period)?;
                 }
             }
@@ -362,9 +369,10 @@ pub fn handle_default(env: &Env, invoice_id: &BytesN<32>) -> Result<(), QuickLen
             .persistent()
             .get(&investor_history_key)
             .unwrap_or(0);
-        env.storage()
-            .persistent()
-            .set(&investor_history_key, &investor_history_count.saturating_add(1));
+        env.storage().persistent().set(
+            &investor_history_key,
+            &investor_history_count.saturating_add(1),
+        );
         crate::storage::bump_persistent(env, &investor_history_key);
     }
 

--- a/quicklendx-contracts/src/invoice.rs
+++ b/quicklendx-contracts/src/invoice.rs
@@ -16,7 +16,6 @@ pub use crate::types::{
 /// tag-based query/index operations predictable.
 pub const MAX_INVOICE_TAGS: u32 = 10;
 
-
 /// Require that the number of tags does not exceed the given cap.
 ///
 /// Defence-in-depth: even though tag vectors are individually bounded by
@@ -218,7 +217,7 @@ impl Invoice {
         env: &Env,
         grace_period: u64,
     ) -> Result<bool, QuickLendXError> {
-        if env.ledger().timestamp() <= self.grace_deadline(grace_period) {
+        if env.ledger().timestamp() <= self.checked_grace_deadline(grace_period)? {
             return Ok(false);
         }
         if self.status == InvoiceStatus::Funded {
@@ -405,6 +404,18 @@ impl Invoice {
         self.due_date.saturating_add(grace_period)
     }
 
+    /// Derive the deadline used by default/finality decisions.
+    ///
+    /// Saturating arithmetic is useful for legacy read-only callers, but it
+    /// would turn an invalid timestamp configuration into a silently extended
+    /// default window. Runtime transitions must use this checked variant so
+    /// malformed or overflowed deadlines fail closed.
+    pub fn checked_grace_deadline(&self, grace_period: u64) -> Result<u64, QuickLendXError> {
+        self.due_date
+            .checked_add(grace_period)
+            .ok_or(QuickLendXError::InvalidTimestamp)
+    }
+
     fn compute_average_rating(&self) -> u32 {
         if self.ratings.is_empty() {
             return 0;
@@ -469,4 +480,3 @@ fn zero_address(env: &Env) -> Address {
         "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
     )
 }
-

--- a/quicklendx-contracts/src/test_due_date_boundaries.rs
+++ b/quicklendx-contracts/src/test_due_date_boundaries.rs
@@ -11,10 +11,10 @@
 #![cfg(test)]
 
 use super::*;
-use crate::invoice::InvoiceCategory;
+use crate::invoice::{Invoice, InvoiceCategory};
 use soroban_sdk::{
     testutils::{Address as _, Ledger},
-    Address, BytesN, Env, String, Vec, token,
+    token, Address, BytesN, Env, String, Vec,
 };
 
 fn setup() -> (Env, QuickLendXContractClient<'static>, Address) {
@@ -54,7 +54,8 @@ fn due_date_equal_to_current_timestamp_is_rejected() {
         &String::from_str(&env, "Test"),
         &InvoiceCategory::Services,
         &Vec::new(&env),
-        &None);
+        &None,
+    );
     assert!(result.is_err());
 }
 
@@ -75,7 +76,8 @@ fn due_date_one_second_after_now_is_accepted() {
         &String::from_str(&env, "Test"),
         &InvoiceCategory::Services,
         &Vec::new(&env),
-        &None);
+        &None,
+    );
     assert!(result.is_ok());
 }
 
@@ -140,7 +142,8 @@ fn allows_payment_at_due() {
         &String::from_str(&env, "Past due"),
         &InvoiceCategory::Services,
         &Vec::new(&env),
-        &None);
+        &None,
+    );
     assert!(result.is_err());
 }
 
@@ -156,9 +159,11 @@ fn allows_payment_at_last_grace_period_ledger() {
     let due = now + 86_400;
     let grace_period = 7 * 86_400u64;
 
-    let invoice_id = create_and_fund_invoice(&env, &client, &admin, &business, &investor, 1000, due);
+    let invoice_id =
+        create_and_fund_invoice(&env, &client, &admin, &business, &investor, 1000, due);
 
-    env.ledger().with_mut(|l| l.timestamp = due + grace_period - 1);
+    env.ledger()
+        .with_mut(|l| l.timestamp = due + grace_period - 1);
     let expired = client.check_invoice_expiration(&invoice_id, &Some(grace_period));
     assert!(!expired);
     assert_eq!(
@@ -167,11 +172,7 @@ fn allows_payment_at_last_grace_period_ledger() {
     );
 
     client
-        .make_payment(
-            &invoice_id,
-            &100,
-            &String::from_str(&env, "tx-grace-last"),
-        )
+        .make_payment(&invoice_id, &100, &String::from_str(&env, "tx-grace-last"))
         .expect("payment at last grace-period ledger must succeed");
 
     assert_eq!(
@@ -192,7 +193,8 @@ fn handles_payment_at_grace_boundary() {
     let due = now + 86_400;
     let grace_period = 7 * 86_400u64;
 
-    let invoice_id = create_and_fund_invoice(&env, &client, &admin, &business, &investor, 1000, due);
+    let invoice_id =
+        create_and_fund_invoice(&env, &client, &admin, &business, &investor, 1000, due);
 
     let deadline = due + grace_period;
     env.ledger().with_mut(|l| l.timestamp = deadline);
@@ -204,11 +206,7 @@ fn handles_payment_at_grace_boundary() {
     );
 
     client
-        .make_payment(
-            &invoice_id,
-            &100,
-            &String::from_str(&env, "tx-boundary"),
-        )
+        .make_payment(&invoice_id, &100, &String::from_str(&env, "tx-boundary"))
         .expect("payment at exact grace boundary must succeed");
 
     assert_eq!(
@@ -229,9 +227,11 @@ fn rejects_payment_after_grace_period() {
     let due = now + 86_400;
     let grace_period = 7 * 86_400u64;
 
-    let invoice_id = create_and_fund_invoice(&env, &client, &admin, &business, &investor, 1000, due);
+    let invoice_id =
+        create_and_fund_invoice(&env, &client, &admin, &business, &investor, 1000, due);
 
-    env.ledger().with_mut(|l| l.timestamp = due + grace_period + 1);
+    env.ledger()
+        .with_mut(|l| l.timestamp = due + grace_period + 1);
     let expired = client.check_invoice_expiration(&invoice_id, &Some(grace_period));
     assert!(expired, "past grace period must expire invoice");
     assert_eq!(
@@ -239,14 +239,10 @@ fn rejects_payment_after_grace_period() {
         InvoiceStatus::Defaulted
     );
 
-    let result = client.try_make_payment(
-        &invoice_id,
-        &100,
-        &String::from_str(&env, "tx-after-grace"),
-    );
+    let result =
+        client.try_make_payment(&invoice_id, &100, &String::from_str(&env, "tx-after-grace"));
     assert!(result.is_err(), "payment after grace must be rejected");
 }
-
 
 #[test]
 fn due_date_zero_is_rejected() {
@@ -263,7 +259,8 @@ fn due_date_zero_is_rejected() {
         &String::from_str(&env, "Zero due date"),
         &InvoiceCategory::Services,
         &Vec::new(&env),
-        &None);
+        &None,
+    );
     assert!(result.is_err());
 }
 
@@ -286,7 +283,8 @@ fn invoice_not_overdue_at_exact_due_date() {
         &String::from_str(&env, "Boundary test"),
         &InvoiceCategory::Services,
         &Vec::new(&env),
-        &None);
+        &None,
+    );
 
     // Advance to exactly the due date
     env.ledger().with_mut(|l| l.timestamp = due);
@@ -313,7 +311,8 @@ fn invoice_overdue_one_second_after_due_date() {
         &String::from_str(&env, "Boundary test"),
         &InvoiceCategory::Services,
         &Vec::new(&env),
-        &None);
+        &None,
+    );
 
     let invoice = client.get_invoice(&invoice_id);
     // One second past due: should be overdue
@@ -339,7 +338,8 @@ fn grace_deadline_uses_saturating_add() {
         &String::from_str(&env, "Grace test"),
         &InvoiceCategory::Services,
         &Vec::new(&env),
-        &None);
+        &None,
+    );
 
     let invoice = client.get_invoice(&invoice_id);
 
@@ -366,11 +366,37 @@ fn grace_deadline_calculation_is_correct() {
         &String::from_str(&env, "Grace calc test"),
         &InvoiceCategory::Services,
         &Vec::new(&env),
-        &None);
+        &None,
+    );
 
     let invoice = client.get_invoice(&invoice_id);
     let deadline = invoice.grace_deadline(grace_period);
     assert_eq!(deadline, due + grace_period);
+}
+
+#[test]
+fn checked_grace_deadline_rejects_overflow() {
+    let env = Env::default();
+    env.ledger().with_mut(|ledger| ledger.timestamp = 1);
+    let invoice = Invoice::new(
+        &env,
+        Address::generate(&env),
+        1_000,
+        Address::generate(&env),
+        u64::MAX,
+        String::from_str(&env, "overflow boundary"),
+        InvoiceCategory::Services,
+        Vec::new(&env),
+        None,
+        None,
+        None,
+    )
+    .expect("maximum future due date is valid");
+
+    assert_eq!(
+        invoice.checked_grace_deadline(1),
+        Err(QuickLendXError::InvalidTimestamp)
+    );
 }
 
 #[test]
@@ -391,6 +417,7 @@ fn due_date_far_future_accepted() {
         &String::from_str(&env, "Far future"),
         &InvoiceCategory::Services,
         &Vec::new(&env),
-        &None);
+        &None,
+    );
     assert!(result.is_ok());
 }


### PR DESCRIPTION
## Summary

Harden default eligibility around due-date and grace-period boundaries so malformed timing configuration fails closed instead of silently extending the default window.

## What changed

- Add a checked deadline derivation for all runtime default/finality decisions.
- Preserve the existing saturating `grace_deadline` read helper for compatibility, while keeping it out of state-changing eligibility paths.
- Reject overflowed `due_date + grace_period` arithmetic with `InvalidTimestamp`.
- Revalidate configured grace periods, including values loaded from existing storage, against the protocol maximum.
- Apply the same checked policy to permissionless funded-invoice scans.
- Add maximum-timestamp overflow coverage and document the strict boundary rule.

## Acceptance criteria

- [x] Exact-boundary behavior remains strict: equality with the grace deadline is ineligible; one second after is eligible.
- [x] Ineligible calls return before default state/finality side effects.
- [x] The existing duplicate transition guard keeps repeated eligible triggers idempotently rejected.
- [x] Deadline derivation uses checked arithmetic in runtime paths.
- [x] Invalid configured grace periods and arithmetic overflow return `InvalidTimestamp`.
- [x] Existing boundary and large-time coverage is retained, with an explicit overflow regression test.

## Security and compatibility

This is fail-closed for malformed or legacy configuration. Valid configured values and all ordinary timestamps retain the existing behavior and ABI. The saturating helper remains available to read-only compatibility callers; only default/finality decisions use the checked method.

## Validation

- `cargo check --manifest-path quicklendx-contracts/Cargo.toml --lib` passes.
- `git diff --check` passes.
- The repository’s complete Rust test target is currently blocked by pre-existing upstream test drift (stale generated-client signatures, duplicate test modules, and missing test-only imports; 178 errors before focused tests can run).

Closes #2393
