### PR TITLE
fix(invoices): bound get_invoices_by_tags query cost (#2509)

### DIFF
--- a/quicklendx-contracts/docs/error-catalog.md
+++ b/quicklendx-contracts/docs/error-catalog.md
@@ -12,7 +12,7 @@ This catalog mirrors the `QuickLendXError` variants currently defined in [`quick
 - Rating: [`src/invoice.rs`](../src/invoice.rs)
 - KYC and verification: [`src/verification.rs`](../src/verification.rs), [`src/analytics.rs`](../src/analytics.rs)
 - Audit: [`src/audit.rs`](../src/audit.rs)
-- Tags: [`src/invoice.rs`](../src/invoice.rs), [`src/verification.rs`](../src/verification.rs)
+- Tags: [`src/invoice.rs`](../src/invoice.rs), [`src/verification.rs`](../src/verification.rs), [`src/storage.rs`](../src/storage.rs)
 - Fees and treasury: [`src/fees.rs`](../src/fees.rs), [`src/profits.rs`](../src/profits.rs)
 - Disputes: [`src/dispute.rs`](../src/dispute.rs), [`src/dispute_timeline.rs`](../src/dispute_timeline.rs)
 - Notifications: [`src/notifications.rs`](../src/notifications.rs)
@@ -71,7 +71,7 @@ This catalog mirrors the `QuickLendXError` variants currently defined in [`quick
 | 1701 | `AuditIntegrityError` | Audit | Reserved ABI slot; no current production raising site found. | Operator | Audit data failed integrity expectations or reserved consistency checks. | Stop relying on the affected audit record and escalate to operators. |
 | 1702 | `AuditQueryError` | Audit | Reserved ABI slot; no current production raising site found. | Recoverable | The audit query cannot be satisfied with the provided parameters. | Narrow the query range, check indexes, and retry with valid audit filters. |
 | 1800 | `InvalidTag` | Tags | [`verification.rs`](../src/verification.rs) | Recoverable | A tag is empty, malformed, duplicated, or not allowed by validation rules. | Normalize the tag list and resubmit only accepted tag values. |
-| 1801 | `TagLimitExceeded` | Tags | [`invoice.rs`](../src/invoice.rs), [`verification.rs`](../src/verification.rs) | Recoverable | The submitted tag list exceeds the configured maximum. | Remove extra tags and keep the list within protocol limits. |
+| 1801 | `TagLimitExceeded` | Tags | [`invoice.rs`](../src/invoice.rs), [`verification.rs`](../src/verification.rs), [`storage.rs`](../src/storage.rs) (`get_invoices_by_tags` query bound, issue #2509) | Recoverable | The submitted tag list exceeds the configured maximum (write path), or a `get_invoices_by_tags` query named more tags than any invoice could ever have (read path, resource bound). | Remove extra tags and keep the list within protocol limits. |
 | 1850 | `InvalidFeeConfiguration` | Fees and treasury | [`fees.rs`](../src/fees.rs), [`profits.rs`](../src/profits.rs) | Operator | Fee settings are missing, inconsistent, or outside supported configuration. | Ask an admin/operator to correct fee configuration before retrying fee-dependent flows. |
 | 1851 | `TreasuryNotConfigured` | Fees and treasury | Reserved ABI slot; no current production raising site found. | Reserved | Treasury account configuration is missing or reserved for future validation. | If surfaced, configure the treasury account through the admin setup flow. |
 | 1852 | `InvalidFeeBasisPoints` | Fees and treasury | [`fees.rs`](../src/fees.rs), [`init.rs`](../src/init.rs), [`profits.rs`](../src/profits.rs) | Recoverable | Fee basis points are outside valid limits. | Submit fee values within configured basis-point bounds. |

--- a/quicklendx-contracts/docs/get-invoices-by-tags-resource-bound.md
+++ b/quicklendx-contracts/docs/get-invoices-by-tags-resource-bound.md
@@ -1,0 +1,141 @@
+# Resource bound on `get_invoices_by_tags` (issue #2509)
+
+## Problem
+
+`get_invoices_by_tags` is a public, unauthenticated, view-only entrypoint
+that looks up invoices matching every tag in a caller-supplied
+`tags: Vec<String>` (AND logic). Before this change it accepted a `tags`
+vector of any length. Internally
+(`InvoiceStorage::get_invoices_by_tags`), for every entry in `first_ids`
+(the match set for `tags[0]`), the function re-ran `get_invoices_by_tag`
+— a full per-tag index scan — once for each remaining tag:
+
+```
+cost ≈ |first_ids| × (tags.len() - 1) × (index scan cost per tag)
+```
+
+`tags.len()` was entirely caller-controlled with no cap. Any address
+could call this entrypoint directly with an arbitrarily long `tags`
+vector to multiply the cost of a single call, with no authorization
+required and no fee paid beyond the call's own resource consumption —
+the exact "unbounded input... exhausting service, ledger... resources"
+scenario this issue exists to close off.
+
+## Design and invariant
+
+No invoice can ever be stored with more than
+`verification::MAX_INVOICE_TAG_COUNT` (10) tags — that cap is already
+enforced at write time by `verification::validate_invoice_tags` (used by
+`Invoice::new`) and by `invoice::MAX_INVOICE_TAGS` (used by
+`Invoice::add_tag`). It follows that a query naming more than 10 tags
+can **never** match any real invoice: at most 10 of the supplied tags
+could possibly correspond to an invoice's actual tag set, so anything
+past that is provably wasted work.
+
+The fix enforces this as a hard precondition, checked before any index
+work begins:
+
+```rust
+if tags.len() > crate::verification::MAX_INVOICE_TAG_COUNT {
+    return Err(QuickLendXError::TagLimitExceeded);
+}
+```
+
+This reuses the exact error already returned when a caller tries to
+attach too many tags to an invoice (`invoice.rs`, `verification.rs`),
+so callers get one consistent, actionable error for "too many tags"
+everywhere in the contract's public API — not a second, redundant error
+variant for the same underlying condition.
+
+## Failure behavior
+
+- `tags.len() <= MAX_INVOICE_TAG_COUNT`: unchanged behavior — the query
+  runs exactly as before and returns the matching invoice IDs (or an
+  empty vector if none match).
+- `tags.len() > MAX_INVOICE_TAG_COUNT`: the call now returns
+  `Err(QuickLendXError::TagLimitExceeded)` immediately, before touching
+  storage. No index read, no partial result, no state mutation of any
+  kind (this was already a read-only path, so "no partial state" was
+  automatic; the bound now also makes the *rejection* itself immediate
+  and cheap rather than proportional to the oversized input).
+
+## Compatibility impact
+
+**This is a response-shape change**, made explicit per this issue's
+acceptance criteria: the public entrypoint
+
+```rust
+pub fn get_invoices_by_tags(env: Env, tags: Vec<String>) -> Vec<BytesN<32>>
+```
+
+becomes
+
+```rust
+pub fn get_invoices_by_tags(env: Env, tags: Vec<String>) -> Result<Vec<BytesN<32>>, QuickLendXError>
+```
+
+This mirrors an existing, established pattern in this same contract for
+other `get_*` queries that can fail validation (`get_invoice`,
+`get_platform_fee_config`, `get_revenue_split_config`,
+`get_fee_analytics`), so it is not a novel calling convention.
+
+For the Soroban-generated client, this change is backward compatible
+for every well-behaved existing caller: the auto-generated `Client`
+method (used as `client.get_invoices_by_tags(&tags)`) already unwraps a
+`Result<T, E>`-returning contract function on the caller's behalf,
+panicking only if the contract actually returns `Err`. Any caller
+passing 10 or fewer tags — which is every caller today, since no
+invoice can have more — sees no behavioral difference at all. A caller
+that inspects the result explicitly (`try_get_invoices_by_tags`) gains
+the ability to detect and handle the new rejection instead of it
+surfacing as a panic.
+
+No storage layout changed. No migration is required — this is a
+stateless validation added to a read-only query.
+
+## Rollback
+
+Reverting this change is a pure code revert (drop the length check,
+restore the old `Vec<BytesN<32>>` return type and its two call sites in
+`storage.rs` / `lib.rs`). There is no persisted state to roll back or
+reconcile, since the change touches neither storage layout nor any
+write path.
+
+## Operational limitations
+
+- The cap (`MAX_INVOICE_TAG_COUNT` = 10) is fixed at compile time via
+  the shared constant; it is not independently configurable for this
+  query without also changing what the write-side cap allows (which is
+  intentional — the two must stay in lock-step for the "can never
+  match" argument above to hold).
+- This bound addresses the caller-controlled `tags.len()` amplification
+  vector specifically. It does not change the per-tag index scan's own
+  cost, which is proportional to how many invoices legitimately share a
+  tag — that growth is organic (tied to real protocol usage over time,
+  not a single call's input), the same category of bound every other
+  `get_invoices_by_tag`-style query in this contract already accepts.
+
+## Security assumptions
+
+- `get_invoices_by_tags` remains intentionally unauthenticated (it is a
+  read-only query over already-public invoice metadata); the fix adds a
+  resource bound, not an access-control change.
+- The bound is enforced identically regardless of caller identity —
+  there is no allowlist or elevated-caller exemption, since the
+  underlying invariant (no invoice can have more than 10 tags) holds
+  for every invoice regardless of who is querying.
+
+## Tests
+
+`quicklendx-contracts/src/test_max_invoice_tags_boundary.rs`, section 4
+(`get_invoices_by_tags query boundary`), exercises the bound through the
+actual contract client (`QuickLendXContractClient`) — the real
+integration boundary — mirroring the existing below/at/over/far-over
+pattern already used for the write-side cap in the same file:
+
+- accepts `MAX_INVOICE_TAG_COUNT - 1` tags (empty match set, no error)
+- accepts exactly `MAX_INVOICE_TAG_COUNT` tags (inclusive boundary)
+- rejects `MAX_INVOICE_TAG_COUNT + 1` tags with `TagLimitExceeded`
+- rejects `MAX_INVOICE_TAG_COUNT * 10` tags with `TagLimitExceeded`
+  (proves the check is a real bound, not an off-by-one that only
+  catches the first overflow)

--- a/quicklendx-contracts/src/lib.rs
+++ b/quicklendx-contracts/src/lib.rs
@@ -3594,8 +3594,17 @@ impl QuickLendXContract {
         InvoiceStorage::get_invoices_by_tag(&env, &tag)
     }
 
-    /// Get invoices by multiple tags (AND logic)
-    pub fn get_invoices_by_tags(env: Env, tags: Vec<String>) -> Vec<BytesN<32>> {
+    /// Get invoices by multiple tags (AND logic).
+    ///
+    /// Returns `QuickLendXError::TagLimitExceeded` if `tags.len()` exceeds
+    /// `verification::MAX_INVOICE_TAG_COUNT` (10) — the same cap already
+    /// enforced when tags are attached to an invoice, so no query can ever
+    /// need more than that many to match anything. See
+    /// `InvoiceStorage::get_invoices_by_tags` for the resource-bound rationale.
+    pub fn get_invoices_by_tags(
+        env: Env,
+        tags: Vec<String>,
+    ) -> Result<Vec<BytesN<32>>, QuickLendXError> {
         InvoiceStorage::get_invoices_by_tags(&env, &tags)
     }
 

--- a/quicklendx-contracts/src/storage.rs
+++ b/quicklendx-contracts/src/storage.rs
@@ -948,9 +948,26 @@ impl InvoiceStorage {
         Self::index_entries(env, &InvoiceIndex::Tag(tag.clone()))
     }
 
-    pub fn get_invoices_by_tags(env: &Env, tags: &Vec<String>) -> Vec<BytesN<32>> {
+    /// Look up invoices matching every tag in `tags` (AND logic).
+    ///
+    /// # Resource bound
+    /// `tags.len()` is rejected above [`crate::verification::MAX_INVOICE_TAG_COUNT`]
+    /// *before* any index work begins. No invoice can ever be stored with more
+    /// tags than that cap (enforced at creation by
+    /// [`crate::verification::validate_invoice_tags`]), so a query requesting
+    /// more tags than the cap can never match anything — it can only force the
+    /// contract to redo the tag-index scan below once per extra tag. Without
+    /// this check, an unauthenticated caller could pass an arbitrarily long
+    /// `tags` vector and multiply the cost of this call by its length.
+    pub fn get_invoices_by_tags(
+        env: &Env,
+        tags: &Vec<String>,
+    ) -> Result<Vec<BytesN<32>>, QuickLendXError> {
+        if tags.len() > crate::verification::MAX_INVOICE_TAG_COUNT {
+            return Err(QuickLendXError::TagLimitExceeded);
+        }
         if tags.is_empty() {
-            return Vec::new(env);
+            return Ok(Vec::new(env));
         }
         let mut result = Vec::new(env);
         let first_tag = tags.get(0).unwrap();
@@ -970,7 +987,7 @@ impl InvoiceStorage {
                 result.push_back(id);
             }
         }
-        result
+        Ok(result)
     }
 
     pub fn get_invoice_count_by_tag(env: &Env, tag: &String) -> u32 {

--- a/quicklendx-contracts/src/test_max_invoice_tags_boundary.rs
+++ b/quicklendx-contracts/src/test_max_invoice_tags_boundary.rs
@@ -34,10 +34,10 @@ extern crate alloc;
 use crate::errors::QuickLendXError;
 use crate::invoice::{Invoice, InvoiceCategory, MAX_INVOICE_TAGS};
 use crate::verification::{validate_invoice_tags, MAX_INVOICE_TAG_COUNT};
-use crate::QuickLendXContract;
+use crate::{QuickLendXContract, QuickLendXContractClient};
 
 use alloc::format;
-use soroban_sdk::{testutils::Address as _, Address, Env, String, Vec};
+use soroban_sdk::{testutils::Address as _, Address, BytesN, Env, String, Vec};
 
 // ---------------------------------------------------------------------------
 // Shared helpers
@@ -380,4 +380,100 @@ fn validate_invoice_tags_accepts_empty_vector_below_max_invoice_tag_count() {
         let tags: Vec<String> = Vec::new(&env);
         assert!(validate_invoice_tags(&env, &tags).is_ok());
     });
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 4. get_invoices_by_tags query boundary — resource/rate-limit regression
+//    (issue #2509)
+// ═══════════════════════════════════════════════════════════════════════════
+//
+// `InvoiceStorage::get_invoices_by_tags` (behind the public,
+// unauthenticated `QuickLendXContract::get_invoices_by_tags` entrypoint)
+// previously accepted an unbounded `tags: Vec<String>` and, for every tag
+// past the first, re-ran a full tag-index scan. Since no invoice can ever be
+// stored with more than `MAX_INVOICE_TAG_COUNT` tags (locked in above), a
+// query naming more tags than that can never match anything — it can only
+// force wasted, caller-controlled work. Any caller could pass an
+// arbitrarily long `tags` vector to multiply the cost of a single call with
+// no authorization required.
+//
+// These tests exercise the bound through the actual contract client (the
+// integration boundary real callers use), not the internal storage helper
+// directly, mirroring the below/at/over/far-over boundary pattern used for
+// `validate_invoice_tags` above.
+
+/// Unwraps a `try_get_invoices_by_tags` call down to the contract's own
+/// `Result`, panicking on any unexpected host/conversion-level error so
+/// test failures point at the real assertion instead of a decoding issue.
+fn get_invoices_by_tags_result(
+    client: &QuickLendXContractClient,
+    tags: &Vec<String>,
+) -> Result<Vec<BytesN<32>>, QuickLendXError> {
+    match client.try_get_invoices_by_tags(tags) {
+        Ok(Ok(ids)) => Ok(ids),
+        Err(Ok(err)) => Err(err),
+        other => panic!("unexpected host/conversion error: {:?}", other),
+    }
+}
+
+/// The query accepts a tag count strictly below the cap and returns an
+/// empty match set (no invoices exist yet) rather than erroring — proves
+/// the bound check does not reject legitimate, well-formed input.
+#[test]
+fn get_invoices_by_tags_query_accepts_tag_count_below_max_invoice_tag_count() {
+    let (env, contract_id) = fresh_env_with_contract();
+    let client = QuickLendXContractClient::new(&env, &contract_id);
+    let tags = distinct_tags_vec(&env, MAX_INVOICE_TAG_COUNT.saturating_sub(1));
+
+    let result = get_invoices_by_tags_result(&client, &tags);
+    assert!(
+        result.is_ok(),
+        "expected Ok below cap, got {:?}",
+        result.unwrap_err()
+    );
+    assert!(result.unwrap().is_empty());
+}
+
+/// The query accepts exactly `MAX_INVOICE_TAG_COUNT` tags — the inclusive
+/// upper bound of legitimate input, since a real invoice may carry exactly
+/// that many tags.
+#[test]
+fn get_invoices_by_tags_query_accepts_tag_count_exactly_at_max_invoice_tag_count() {
+    let (env, contract_id) = fresh_env_with_contract();
+    let client = QuickLendXContractClient::new(&env, &contract_id);
+    let tags = distinct_tags_vec(&env, MAX_INVOICE_TAG_COUNT);
+
+    let result = get_invoices_by_tags_result(&client, &tags);
+    assert!(
+        result.is_ok(),
+        "expected Ok at exact cap, got {:?}",
+        result.unwrap_err()
+    );
+}
+
+/// The query rejects `MAX_INVOICE_TAG_COUNT + 1` tags with the same stable
+/// `TagLimitExceeded` error already used for the write-side cap, giving
+/// callers one consistent, actionable error for "too many tags" everywhere
+/// in the contract's public API.
+#[test]
+fn get_invoices_by_tags_query_rejects_tag_count_one_over_max_invoice_tag_count() {
+    let (env, contract_id) = fresh_env_with_contract();
+    let client = QuickLendXContractClient::new(&env, &contract_id);
+    let tags = distinct_tags_vec(&env, MAX_INVOICE_TAG_COUNT + 1);
+
+    let err = get_invoices_by_tags_result(&client, &tags).unwrap_err();
+    assert_eq!(err, QuickLendXError::TagLimitExceeded);
+}
+
+/// The query keeps rejecting far past the cap — an order of magnitude over
+/// — proving the check is a real bound and not a fragile off-by-one
+/// comparison that only happens to catch the first overflow.
+#[test]
+fn get_invoices_by_tags_query_rejects_tag_count_far_over_max_invoice_tag_count() {
+    let (env, contract_id) = fresh_env_with_contract();
+    let client = QuickLendXContractClient::new(&env, &contract_id);
+    let tags = distinct_tags_vec(&env, MAX_INVOICE_TAG_COUNT * 10);
+
+    let err = get_invoices_by_tags_result(&client, &tags).unwrap_err();
+    assert_eq!(err, QuickLendXError::TagLimitExceeded);
 }


### PR DESCRIPTION
Closes #2509.

## Summary

`get_invoices_by_tags` (`quicklendx-contracts/src/lib.rs` → `InvoiceStorage::get_invoices_by_tags` in `storage.rs`) is a **public, unauthenticated, view-only** entrypoint that matches invoices against every tag in a caller-supplied `tags: Vec<String>` (AND logic). It previously accepted a `tags` vector of **any length**, and for every tag past the first, re-ran a full per-tag index scan (`get_invoices_by_tag` → `index_entries` → a storage read plus a per-entry match check). `tags.len()` was entirely caller-controlled with no cap — any address could call this directly with an arbitrarily long `tags` vector to multiply the cost of a single call, with no authorization required. This is exactly the "unbounded input... exhausting service, ledger... resources" scenario issue #2509 describes.

## Design and invariant

No invoice can ever be stored with more than `verification::MAX_INVOICE_TAG_COUNT` (10) tags — already enforced at write time by `verification::validate_invoice_tags` (used by `Invoice::new`) and `invoice::MAX_INVOICE_TAGS` (used by `Invoice::add_tag`). It follows that a query naming more than 10 tags can **never match anything real** — anything past 10 is provably wasted, caller-controlled work.

The fix enforces this as a hard precondition, checked *before* any index work begins:

```rust
if tags.len() > crate::verification::MAX_INVOICE_TAG_COUNT {
    return Err(QuickLendXError::TagLimitExceeded);
}
```

This reuses the exact error already returned when a caller tries to attach too many tags to an invoice — one consistent, actionable error for "too many tags" everywhere in the contract's public API, per the "return actionable limit errors" acceptance criterion, rather than a second redundant error variant.

Full design/invariant/failure-behavior/compatibility/rollback/security writeup: [`quicklendx-contracts/docs/get-invoices-by-tags-resource-bound.md`](quicklendx-contracts/docs/get-invoices-by-tags-resource-bound.md).

## Acceptance criteria

- [x] **Enforce bounded input and work before expensive operations, return actionable limit errors, and preserve fair use.** The length check runs first, before any storage read; it returns the existing, specific `TagLimitExceeded` error.
- [x] **Preserve compatible public behavior and make any required migration, error, or response-shape change explicit.** This *is* an explicit response-shape change (documented below and in the linked doc): `get_invoices_by_tags` now returns `Result<Vec<BytesN<32>>, QuickLendXError>` instead of `Vec<BytesN<32>>`, mirroring an existing pattern already used by `get_invoice`, `get_platform_fee_config`, `get_revenue_split_config`, and `get_fee_analytics` in this same contract. No storage layout changed; no migration needed (stateless validation on a read-only query). Every well-behaved caller (≤10 tags — i.e. every caller today) sees **zero** behavioral difference, since the Soroban-generated client already unwraps a `Result`-returning contract call transparently.
- [x] **Ensure rejected, stale, repeated, and failed operations leave no unauthorized or partial state.** This was already a read-only path (no state mutation on any code path); the bound now also makes the *rejection itself* immediate rather than proportional to the oversized input.
- [x] **Add focused regression coverage that proves the invariant at the actual integration boundary.** See Tests below — exercised through `QuickLendXContractClient`, not the internal storage helper directly.

## Files changed

- [`quicklendx-contracts/src/storage.rs`](quicklendx-contracts/src/storage.rs) — `InvoiceStorage::get_invoices_by_tags`: added the bound check, changed return type to `Result<Vec<BytesN<32>>, QuickLendXError>`.
- [`quicklendx-contracts/src/lib.rs`](quicklendx-contracts/src/lib.rs) — `QuickLendXContract::get_invoices_by_tags` entrypoint: propagates the new `Result` return type.
- [`quicklendx-contracts/src/test_max_invoice_tags_boundary.rs`](quicklendx-contracts/src/test_max_invoice_tags_boundary.rs) — new "§4" section: 4 focused regression tests (see below), added to the file that's already the canonical home for this exact cap's boundary tests.
- [`quicklendx-contracts/docs/get-invoices-by-tags-resource-bound.md`](quicklendx-contracts/docs/get-invoices-by-tags-resource-bound.md) — new doc covering design, invariant, failure behavior, compatibility impact, rollback, operational limitations, and security assumptions.
- [`quicklendx-contracts/docs/error-catalog.md`](quicklendx-contracts/docs/error-catalog.md) — updated the `TagLimitExceeded` (1801) row and the "Tags" domain-module map to reflect the new emission site.

## Tests

`test_max_invoice_tags_boundary.rs`, new section 4, called through the actual contract client (`QuickLendXContractClient` → `try_get_invoices_by_tags`), mirroring the file's existing below/at/over/far-over pattern:

- `get_invoices_by_tags_query_accepts_tag_count_below_max_invoice_tag_count` — `MAX_INVOICE_TAG_COUNT - 1` tags succeeds (empty result set, no invoices indexed).
- `get_invoices_by_tags_query_accepts_tag_count_exactly_at_max_invoice_tag_count` — exactly `MAX_INVOICE_TAG_COUNT` tags succeeds (inclusive boundary).
- `get_invoices_by_tags_query_rejects_tag_count_one_over_max_invoice_tag_count` — `MAX_INVOICE_TAG_COUNT + 1` tags returns `TagLimitExceeded`.
- `get_invoices_by_tags_query_rejects_tag_count_far_over_max_invoice_tag_count` — `MAX_INVOICE_TAG_COUNT * 10` tags returns `TagLimitExceeded` (proves the check is a real bound, not an off-by-one that only catches the first overflow).

## Verification — commands and results

This repository's own CI is currently **stubbed** (see `.github/workflows/ci.yml`: `"build (paused — CI stabilization in progress)"`), and `cargo check --tests` on `upstream/main` as-is currently fails with **~182 pre-existing, unrelated errors** — a widespread `Invoice::new` / `upload_invoice` signature drift (two `Option<u32>` parameters added, dozens of call sites across test files never updated to match) plus a couple of unrelated `Hash<32>`/`BytesN<32>` type mismatches (`dispute.rs`) and one broken `match` (`storage.rs::cleanup_index_page`, untouched by this PR). None of it is caused by, or related to, this change.

Given that, verification was done in two layers:

**1. This change in isolation, against the real (broken) base:**
```
cargo check -p quicklendx-contracts --lib
```
Result: exactly the same 4 pre-existing errors that exist on `upstream/main` before this change (2 in `dispute.rs`, 2 in `storage.rs::cleanup_index_page`) — confirming this change introduces **zero new errors**. `get_invoices_by_tags` itself does not appear anywhere in the error output.

**2. Full correctness of the new code, with the pre-existing unrelated bugs neutralized locally (never committed — verified via `git diff`/`git status` after each check):**
```
cargo check -p quicklendx-contracts --lib --tests
```
Result: **0 errors** — the full library test target (including the new test module) compiles 100% cleanly; only 3 pre-existing, unrelated `unreachable_pattern` warnings remain in `errors.rs`.

```
cargo fmt --check
```
(scoped per-file, since the crate-wide invocation hits the same pre-existing parse-breaking files elsewhere): zero formatting deltas anywhere in or after the new code in `storage.rs` and `test_max_invoice_tags_boundary.rs`. `lib.rs`'s own diff visually matches the established multi-line signature style already used by `get_invoice`.

**3. Actually running the tests:** blocked on this machine by a local mingw/gcc linker failure (`ld returned 1 exit status`) at the final link step — reproduced identically against an unrelated, unmodified crate in this same environment, confirming it's a local toolchain limitation, not a code issue. I was unable to execute `cargo test` locally as a result. I'd appreciate CI (once un-stubbed) or a reviewer with a working toolchain confirming the 4 new tests pass — happy to address anything that surfaces.

## Security / correctness note

- No access-control change: `get_invoices_by_tags` remains intentionally unauthenticated (read-only query over already-public invoice metadata). The fix is a resource bound, not an authorization change, and applies identically to every caller.
- The bound is provably safe, not just heuristically tight: since no invoice can ever have more than `MAX_INVOICE_TAG_COUNT` tags (enforced independently at write time), rejecting queries above that count cannot reject any query that could have legitimately matched something.
- No new state, no storage-layout change, no migration required.

## Out of scope

Per the issue's own scope note, this PR does not touch the pre-existing, unrelated `Invoice::new`/`upload_invoice` signature drift affecting ~182 other call sites, nor the `dispute.rs` / `storage.rs::cleanup_index_page` type errors, nor the currently-stubbed CI pipeline — all confirmed pre-existing and independent of this change, and each large enough to warrant its own dedicated fix.
