### PR TITLE
fix: implement authorization boundaries in payments.rs

### DIFF
--- a/quicklendx-contracts/src/lib.rs
+++ b/quicklendx-contracts/src/lib.rs
@@ -1,4 +1,4 @@
-﻿#![no_std]
+#![no_std]
 #![allow(
     dead_code,
     unused_imports,
@@ -231,6 +231,8 @@ mod test_freshness_bounds;
 mod test_investor_kyc;
 #[cfg(test)]
 mod test_payments;
+#[cfg(test)]
+mod test_payments_auth;
 #[cfg(test)]
 mod test_queries;
 #[cfg(test)]

--- a/quicklendx-contracts/src/payments.rs
+++ b/quicklendx-contracts/src/payments.rs
@@ -491,6 +491,17 @@ fn validate_and_prepare_escrow(
         return Err(QuickLendXError::InvoiceAlreadyFunded);
     }
 
+    let invoice = InvoiceStorage::get_invoice(env, invoice_id)
+        .ok_or(QuickLendXError::StorageKeyNotFound)?;
+
+    if invoice.business != *business {
+        return Err(QuickLendXError::Unauthorized);
+    }
+
+    if invoice.currency != *currency {
+        return Err(QuickLendXError::InvalidCurrency);
+    }
+
     EscrowStorage::require_no_active_reserve_repair(env, currency)?;
     let next_held_reserve = EscrowStorage::held_reserve_after_increase(env, currency, amount)?;
 
@@ -622,7 +633,15 @@ pub fn create_escrow_record_only(
 /// * [`QuickLendXError::TokenTransferFailed`] - the token contract panicked; escrow status is
 ///   **not** updated so the release can be safely retried.
 pub fn release_escrow(env: &Env, invoice_id: &BytesN<32>) -> Result<(), QuickLendXError> {
-    let mut escrow = EscrowStorage::get_escrow_by_invoice(env, invoice_id).unwrap();
+    let mut escrow = EscrowStorage::get_escrow_by_invoice(env, invoice_id)
+        .ok_or(QuickLendXError::StorageKeyNotFound)?;
+
+    let invoice = InvoiceStorage::get_invoice(env, invoice_id)
+        .ok_or(QuickLendXError::StorageKeyNotFound)?;
+
+    if escrow.business != invoice.business {
+        return Err(QuickLendXError::Unauthorized);
+    }
 
     if escrow.status != EscrowStatus::Held {
         // Prevents repeated release (idempotency)
@@ -677,7 +696,17 @@ pub fn release_escrow(env: &Env, invoice_id: &BytesN<32>) -> Result<(), QuickLen
 /// * [`QuickLendXError::TokenTransferFailed`] - the token contract panicked; escrow status is
 ///   **not** updated so the refund can be safely retried.
 pub fn refund_escrow(env: &Env, invoice_id: &BytesN<32>) -> Result<(), QuickLendXError> {
-    let mut escrow = EscrowStorage::get_escrow_by_invoice(env, invoice_id).unwrap();
+    let mut escrow = EscrowStorage::get_escrow_by_invoice(env, invoice_id)
+        .ok_or(QuickLendXError::StorageKeyNotFound)?;
+
+    let invoice = InvoiceStorage::get_invoice(env, invoice_id)
+        .ok_or(QuickLendXError::StorageKeyNotFound)?;
+
+    if let Some(ref inv_investor) = invoice.investor {
+        if escrow.investor != *inv_investor {
+            return Err(QuickLendXError::Unauthorized);
+        }
+    }
 
     if escrow.status != EscrowStatus::Held {
         return Err(QuickLendXError::InvalidStatus);

--- a/quicklendx-contracts/src/test_due_date_guard.rs
+++ b/quicklendx-contracts/src/test_due_date_guard.rs
@@ -55,7 +55,7 @@ currency,
 String::from_str(&env, "past-due invoice"),
 InvoiceCategory::Services,
 Vec::new(&env),
-        None, /* early_payment_discount_bps */,
+        None /* early_payment_discount_bps */,
         None
 )
     });
@@ -81,7 +81,7 @@ currency,
 String::from_str(&env, "due-now invoice"),
 InvoiceCategory::Services,
 Vec::new(&env),
-        None, /* early_payment_discount_bps */,
+        None /* early_payment_discount_bps */,
         None
 )
     });
@@ -107,7 +107,7 @@ currency,
 String::from_str(&env, "future invoice"),
 InvoiceCategory::Services,
 Vec::new(&env),
-        None, /* early_payment_discount_bps */,
+        None /* early_payment_discount_bps */,
         None
 )
     });

--- a/quicklendx-contracts/src/test_payments_auth.rs
+++ b/quicklendx-contracts/src/test_payments_auth.rs
@@ -1,0 +1,152 @@
+#![cfg(test)]
+
+use crate::errors::QuickLendXError;
+use crate::payments::{create_escrow, refund_escrow, release_escrow};
+use crate::storage::InvoiceStorage;
+use crate::types::{Invoice, InvoiceStatus};
+use crate::QuickLendXContract;
+use soroban_sdk::{testutils::Address as _, Address, BytesN, Env, Vec, String};
+
+fn setup() -> (Env, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(QuickLendXContract, ());
+    (env, contract_id)
+}
+
+fn create_dummy_invoice(
+    env: &Env,
+    invoice_id: &BytesN<32>,
+    business: &Address,
+    currency: &Address,
+    investor: Option<Address>,
+) {
+    let invoice = Invoice {
+        invoice_id: invoice_id.clone(),
+        business: business.clone(),
+        amount: 1000,
+        due_date: 0,
+        status: InvoiceStatus::Verified,
+        currency: currency.clone(),
+        metadata_hash: String::from_str(env, "hash"),
+        created_at: 0,
+        funded_amount: 0,
+        funded_at: None,
+        investor: investor,
+        category: String::from_str(env, "cat"),
+        tags: Vec::new(env),
+        insurance_opt_in: false,
+        payment_history: Vec::new(env),
+        origination_fee_bps: None,
+        early_payment_discount_bps: None,
+        insurance_premium: 0,
+        escrow_id: None,
+        repayment_type: crate::types::RepaymentType::Full,
+    };
+    InvoiceStorage::store_invoice(env, &invoice);
+}
+
+#[test]
+fn test_create_escrow_cross_tenant_rejected() {
+    let (env, contract_id) = setup();
+    let invoice_id = BytesN::from_array(&env, &[1u8; 32]);
+    let actual_business = Address::generate(&env);
+    let forged_business = Address::generate(&env);
+    let currency = Address::generate(&env);
+    let investor = Address::generate(&env);
+
+    env.as_contract(&contract_id, || {
+        create_dummy_invoice(&env, &invoice_id, &actual_business, &currency, None);
+
+        // Attempt to create escrow with a business address that doesn't own the invoice
+        let result = create_escrow(&env, &invoice_id, &investor, &forged_business, 100, &currency);
+        assert_eq!(result, Err(QuickLendXError::Unauthorized));
+
+        // Attempt to create escrow with wrong currency
+        let wrong_currency = Address::generate(&env);
+        let result2 = create_escrow(&env, &invoice_id, &investor, &actual_business, 100, &wrong_currency);
+        assert_eq!(result2, Err(QuickLendXError::InvalidCurrency));
+    });
+}
+
+#[test]
+fn test_release_escrow_cross_tenant_rejected() {
+    let (env, contract_id) = setup();
+    let invoice_id = BytesN::from_array(&env, &[1u8; 32]);
+    let business = Address::generate(&env);
+    let currency = Address::generate(&env);
+    let investor = Address::generate(&env);
+
+    env.as_contract(&contract_id, || {
+        // Create an invoice with one business
+        create_dummy_invoice(&env, &invoice_id, &business, &currency, None);
+
+        // Create the escrow directly (simulating a state where escrow.business differs from invoice.business,
+        // which shouldn't happen with our new create_escrow checks, but we test the release boundary).
+        let forged_business = Address::generate(&env);
+        let escrow_id = BytesN::from_array(&env, &[2u8; 32]);
+        let escrow = crate::payments::Escrow {
+            escrow_id,
+            invoice_id: invoice_id.clone(),
+            investor: investor.clone(),
+            business: forged_business.clone(),
+            amount: 100,
+            currency: currency.clone(),
+            created_at: 0,
+            status: crate::payments::EscrowStatus::Held,
+        };
+        crate::payments::EscrowStorage::store_escrow(&env, &escrow);
+
+        // Releasing should fail because escrow.business != invoice.business
+        let result = release_escrow(&env, &invoice_id);
+        assert_eq!(result, Err(QuickLendXError::Unauthorized));
+    });
+}
+
+#[test]
+fn test_refund_escrow_cross_tenant_rejected() {
+    let (env, contract_id) = setup();
+    let invoice_id = BytesN::from_array(&env, &[1u8; 32]);
+    let business = Address::generate(&env);
+    let currency = Address::generate(&env);
+    let actual_investor = Address::generate(&env);
+    let forged_investor = Address::generate(&env);
+
+    env.as_contract(&contract_id, || {
+        // Invoice is funded by actual_investor
+        create_dummy_invoice(&env, &invoice_id, &business, &currency, Some(actual_investor.clone()));
+
+        let escrow_id = BytesN::from_array(&env, &[2u8; 32]);
+        let escrow = crate::payments::Escrow {
+            escrow_id,
+            invoice_id: invoice_id.clone(),
+            investor: forged_investor.clone(),
+            business: business.clone(),
+            amount: 100,
+            currency: currency.clone(),
+            created_at: 0,
+            status: crate::payments::EscrowStatus::Held,
+        };
+        crate::payments::EscrowStorage::store_escrow(&env, &escrow);
+
+        // Refunding should fail because escrow.investor != invoice.investor
+        let result = refund_escrow(&env, &invoice_id);
+        assert_eq!(result, Err(QuickLendXError::Unauthorized));
+    });
+}
+
+#[test]
+fn test_release_and_refund_escrow_missing_state_handled() {
+    let (env, contract_id) = setup();
+    let invoice_id = BytesN::from_array(&env, &[1u8; 32]);
+
+    env.as_contract(&contract_id, || {
+        // Missing escrow gracefully errors out rather than panic/unwrap
+        let result_release = release_escrow(&env, &invoice_id);
+        assert_eq!(result_release, Err(QuickLendXError::StorageKeyNotFound));
+
+        let result_refund = refund_escrow(&env, &invoice_id);
+        assert_eq!(result_refund, Err(QuickLendXError::StorageKeyNotFound));
+    });
+}
+

--- a/quicklendx-contracts/tests/auth_verification_test.rs
+++ b/quicklendx-contracts/tests/auth_verification_test.rs
@@ -39,7 +39,7 @@ proptest! {
 
         let due_date = env.ledger().timestamp() + 86400;
         let invoice_amount = 100_000i128;
-        
+
         // KYC-verify business before upload_invoice and investor before place_bid.
         client.submit_kyc_application(&business, &String::from_str(&env, "KYC"));
         client.verify_business(&admin, &business);
@@ -67,7 +67,7 @@ proptest! {
         client.place_bid(&investor, &invoice_id, &bid_amount, &expected_return, &salt);
 
         let auths = env.auths();
-        
+
         let (auth_address, invocation) = auths.last().unwrap();
 
         assert_eq!(auth_address, &investor, "The auth address must match the investor");

--- a/quicklendx-contracts/tests/invoice_lifecycle_e2e.rs
+++ b/quicklendx-contracts/tests/invoice_lifecycle_e2e.rs
@@ -188,9 +188,7 @@ fn test_invoice_lifecycle_happy_path() {
         &String::from_str(&env, "Consulting services"),
         &InvoiceCategory::Consulting,
         &Vec::new(&env),
-
         &None,
-
     );
 
     let invoice = fx.client.get_invoice(&invoice_id);
@@ -561,9 +559,7 @@ fn test_invoice_lifecycle_default_branch() {
         &String::from_str(&env, "Goods delivery"),
         &InvoiceCategory::Consulting,
         &Vec::new(&env),
-
         &None,
-
     );
 
     assert_eq!(
@@ -730,9 +726,7 @@ fn test_partial_then_full_settle() {
         &String::from_str(&env, "Technology services"),
         &InvoiceCategory::Consulting,
         &Vec::new(&env),
-
         &None,
-
     );
     assert_eq!(
         fx.client.get_invoice(&invoice_id).status,

--- a/quicklendx-contracts/tests/test_admin_lookalike.rs
+++ b/quicklendx-contracts/tests/test_admin_lookalike.rs
@@ -2,8 +2,8 @@
 
 extern crate std;
 
-use quicklendx_contracts::{QuickLendXContract, QuickLendXContractClient};
 use quicklendx_contracts::errors::QuickLendXError;
+use quicklendx_contracts::{QuickLendXContract, QuickLendXContractClient};
 use soroban_sdk::{testutils::Address as _, Address, Env};
 
 fn setup_with_admin() -> (Env, QuickLendXContractClient<'static>, Address) {


### PR DESCRIPTION
Closes #2450. Added strict business and currency validation to escrow creation, avoiding cross-tenant exposure. Gracefully handle missing/stale escrow states.