### PR TITLE
fix: enforce invoice lifecycle state-transition matrix (QE-2026-08)

### DIFF
--- a/quicklendx-contracts/src/lib.rs
+++ b/quicklendx-contracts/src/lib.rs
@@ -159,6 +159,8 @@ mod test_cancel_invoice_matrix;
 mod test_cleanup_pagination;
 #[cfg(test)]
 mod test_config_bounds_matrix;
+#[cfg(test)]
+mod test_invoice_lifecycle_invariants;
 #[cfg(all(test, feature = "legacy-tests"))]
 mod test_currency;
 #[cfg(all(test, feature = "legacy-tests"))]
@@ -2149,6 +2151,37 @@ impl QuickLendXContract {
 
         let mut invoice = InvoiceStorage::get_invoice(&env, &invoice_id)
             .ok_or(QuickLendXError::InvoiceNotFound)?;
+
+        // Enforce the documented lifecycle at the public admin entry point.
+        //
+        // Legal transition matrix (QE-2026-08 / issue #2433):
+        //   Pending -> Verified  (verification)
+        //   Verified -> Funded   (funding; normally reached via accept_bid)
+        //   Funded  -> Paid      (settlement; normally reached via payment flows)
+        //
+        // All other requests are rejected with `InvalidStatus` BEFORE any state or
+        // status index is touched, so rejected, stale, repeated, and out-of-order
+        // operations leave no partial/unauthorized state:
+        //   * Backward transitions (e.g. Funded -> Verified) are illegal.
+        //   * Skipped transitions (e.g. Pending -> Paid, `settlement before funding`)
+        //     are illegal — they would otherwise misprice exposure.
+        //   * Repeated transitions (e.g. Verified -> Verified) are illegal.
+        //   * Terminal states (`InvoiceStatus::is_terminal`), including `Paid`, can
+        //     never be left — an invoice that has settled may not be re-opened.
+        //
+        // `Defaulted` is intentionally NOT part of this local matrix: every request
+        // for a default is routed through `do_mark_invoice_defaulted` above, which
+        // centrally enforces the richer default-finality checks (grace window,
+        // escrow state, duplicate-default guard) before mutating anything.
+        let allowed = matches!(
+            (invoice.status, new_status),
+            (InvoiceStatus::Pending, InvoiceStatus::Verified)
+                | (InvoiceStatus::Verified, InvoiceStatus::Funded)
+                | (InvoiceStatus::Funded, InvoiceStatus::Paid)
+        );
+        if !allowed {
+            return Err(QuickLendXError::InvalidStatus);
+        }
 
         // Remove from old status list
         InvoiceStorage::remove_from_status_invoices(&env, invoice.status, &invoice_id);

--- a/quicklendx-contracts/src/test_invoice_lifecycle_invariants.rs
+++ b/quicklendx-contracts/src/test_invoice_lifecycle_invariants.rs
@@ -1,0 +1,242 @@
+//! State-transition invariants for the invoice lifecycle admin entry point.
+//!
+//! QE-2026-08 / issue #2433. `update_invoice_status` is the last weakly-guarded
+//! place an invoice status can be changed without going through the domain
+//! flows (`accept_bid`, payment settlement, `do_mark_invoice_defaulted`). These
+//! tests pin the legal transition matrix and prove that rejected, stale,
+//! repeated, skipped, and out-of-order transitions leave no partial or
+//! unauthorized state (invoice fields and the per-status index stay intact).
+//!
+//! Legal matrix enforced:
+//!   Pending -> Verified -> Funded -> Paid
+//! Everything else (backwards, skipped, repeated, terminal) must return
+//! `InvalidStatus` with zero side effects. `Defaulted` may only be entered via
+//! the centralized `do_mark_invoice_defaulted` path, not through the raw matrix.
+
+use super::*;
+use crate::errors::QuickLendXError;
+use crate::invoice::{InvoiceCategory, InvoiceStatus};
+use soroban_sdk::{testutils::Address as _, token, Address, BytesN, Env, String, Vec};
+
+const INV_AMOUNT: i128 = 1_000;
+
+fn setup(env: &Env) -> (QuickLendXContractClient<'_>, Address, Address) {
+    let contract_id = env.register(QuickLendXContract, ());
+    env.ledger().set_timestamp(1);
+    let client = QuickLendXContractClient::new(env, &contract_id);
+    let admin = Address::generate(env);
+    client.set_admin(&admin);
+    (client, admin, contract_id)
+}
+
+fn kyc_business(env: &Env, client: &QuickLendXContractClient, admin: &Address, biz: &Address) {
+    client.submit_kyc_application(biz, &String::from_str(env, "lifecycle KYC"));
+    client.verify_business(admin, biz);
+}
+
+/// Register a real Stellar Asset Contract and seed the contract account so
+/// token-instance / decimal lookups used by the currency precision guard work.
+fn mint_currency(env: &Env, contract_id: &Address, business: &Address) -> Address {
+    let token_admin = Address::generate(env);
+    let currency = env
+        .register_stellar_asset_contract_v2(token_admin)
+        .address();
+    let sac = token::StellarAssetClient::new(env, &currency);
+    let bal = 10_000_000i128;
+    sac.mint(business, &bal);
+    // Ensure the contract has a token instance entry so balance/decimals
+    // lookups don't fail with "missing value".
+    sac.mint(contract_id, &1i128);
+    currency
+}
+
+fn upload_invoice(
+    env: &Env,
+    client: &QuickLendXContractClient,
+    biz: &Address,
+    currency: &Address,
+) -> BytesN<32> {
+    let due = env.ledger().timestamp() + 86_400;
+    client.upload_invoice(
+        biz,
+        &INV_AMOUNT,
+        currency,
+        &due,
+        &String::from_str(env, "lifecycle invariant"),
+        &InvoiceCategory::Services,
+        &Vec::new(env),
+        &None,
+        &None,
+        &None,
+    )
+}
+
+/// The full legal matrix plus every illegal class the issue calls out (stale,
+/// repeated, skipped, backward, and terminal-immutable transitions), with the
+/// per-status index checked after every step so no partial state slips through.
+#[test]
+fn update_invoice_status_enforces_full_lifecycle_matrix() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, cid) = setup(&env);
+    let biz = Address::generate(&env);
+    let currency = mint_currency(&env, &cid, &biz);
+    kyc_business(&env, &client, &admin, &biz);
+    let id = upload_invoice(&env, &client, &biz, &currency);
+
+    assert_eq!(client.get_invoice(&id).status, InvoiceStatus::Pending);
+
+    // Skipped: Pending -> Funded (no verification).
+    assert!(matches!(
+        client.try_update_invoice_status(&id, &InvoiceStatus::Funded),
+        Err(Ok(QuickLendXError::InvalidStatus))
+    ));
+
+    // Skipped: Pending -> Paid (settlement before funding).
+    assert!(matches!(
+        client.try_update_invoice_status(&id, &InvoiceStatus::Paid),
+        Err(Ok(QuickLendXError::InvalidStatus))
+    ));
+
+    // Nothing moved: still Pending, indexed under Pending only.
+    assert_eq!(client.get_invoice(&id).status, InvoiceStatus::Pending);
+    assert_eq!(
+        client.get_invoice_count_by_status(&InvoiceStatus::Pending),
+        1
+    );
+    assert_eq!(
+        client.get_invoice_count_by_status(&InvoiceStatus::Verified),
+        0
+    );
+    assert_eq!(
+        client.get_invoice_count_by_status(&InvoiceStatus::Funded),
+        0
+    );
+    assert_eq!(client.get_invoice_count_by_status(&InvoiceStatus::Paid), 0);
+
+    // Legal: Pending -> Verified.
+    client.update_invoice_status(&id, &InvoiceStatus::Verified);
+    assert_eq!(client.get_invoice(&id).status, InvoiceStatus::Verified);
+    assert_eq!(
+        client.get_invoice_count_by_status(&InvoiceStatus::Pending),
+        0
+    );
+    assert_eq!(
+        client.get_invoice_count_by_status(&InvoiceStatus::Verified),
+        1
+    );
+
+    // Repeated: Verified -> Verified must be rejected without index drift.
+    assert!(matches!(
+        client.try_update_invoice_status(&id, &InvoiceStatus::Verified),
+        Err(Ok(QuickLendXError::InvalidStatus))
+    ));
+    assert_eq!(
+        client.get_invoice_count_by_status(&InvoiceStatus::Verified),
+        1
+    );
+    assert_eq!(
+        client.get_invoice_count_by_status(&InvoiceStatus::Pending),
+        0
+    );
+
+    // Backward: Verified -> Pending must be rejected.
+    assert!(matches!(
+        client.try_update_invoice_status(&id, &InvoiceStatus::Pending),
+        Err(Ok(QuickLendXError::InvalidStatus))
+    ));
+    assert_eq!(client.get_invoice(&id).status, InvoiceStatus::Verified);
+
+    // Legal: Verified -> Funded.
+    client.update_invoice_status(&id, &InvoiceStatus::Funded);
+    assert_eq!(client.get_invoice(&id).status, InvoiceStatus::Funded);
+    assert_eq!(
+        client.get_invoice_count_by_status(&InvoiceStatus::Verified),
+        0
+    );
+    assert_eq!(
+        client.get_invoice_count_by_status(&InvoiceStatus::Funded),
+        1
+    );
+
+    // Backward: Funded -> Verified rejected.
+    assert!(matches!(
+        client.try_update_invoice_status(&id, &InvoiceStatus::Verified),
+        Err(Ok(QuickLendXError::InvalidStatus))
+    ));
+    assert_eq!(client.get_invoice(&id).status, InvoiceStatus::Funded);
+
+    // Legal: Funded -> Paid (terminal).
+    client.update_invoice_status(&id, &InvoiceStatus::Paid);
+    assert_eq!(client.get_invoice(&id).status, InvoiceStatus::Paid);
+    assert_eq!(client.get_invoice_count_by_status(&InvoiceStatus::Paid), 1);
+    assert_eq!(
+        client.get_invoice_count_by_status(&InvoiceStatus::Funded),
+        0
+    );
+
+    // Terminal immutability: Paid may not be re-opened in any direction.
+    assert!(matches!(
+        client.try_update_invoice_status(&id, &InvoiceStatus::Funded),
+        Err(Ok(QuickLendXError::InvalidStatus))
+    ));
+    assert!(matches!(
+        client.try_update_invoice_status(&id, &InvoiceStatus::Verified),
+        Err(Ok(QuickLendXError::InvalidStatus))
+    ));
+    assert_eq!(client.get_invoice(&id).status, InvoiceStatus::Paid);
+    assert_eq!(client.get_invoice_count_by_status(&InvoiceStatus::Paid), 1);
+    assert_eq!(
+        client.get_invoice_count_by_status(&InvoiceStatus::Funded),
+        0
+    );
+}
+
+/// The financial-safety core: a rejected transition must not mutate asset-level
+/// fields. On the old behaviour, `Pending -> Paid` would have run
+/// `mark_as_paid` (setting `total_paid`/`settled_at`) and `Paid -> Funded`
+/// would have re-opened funding (setting `funded_amount`/`investor`) on a
+/// settled invoice, mispricing exposure. Both must now be atomic no-ops.
+#[test]
+fn rejected_transition_leaves_no_partial_state() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, cid) = setup(&env);
+    let biz = Address::generate(&env);
+    let currency = mint_currency(&env, &cid, &biz);
+    kyc_business(&env, &client, &admin, &biz);
+    let id = upload_invoice(&env, &client, &biz, &currency);
+
+    // Settlement-before-funding must not set any payment fields.
+    assert!(matches!(
+        client.try_update_invoice_status(&id, &InvoiceStatus::Paid),
+        Err(Ok(QuickLendXError::InvalidStatus))
+    ));
+    let invoice = client.get_invoice(&id);
+    assert_eq!(invoice.status, InvoiceStatus::Pending);
+    assert_eq!(invoice.total_paid, 0);
+    assert!(invoice.settled_at.is_none());
+    assert_eq!(invoice.funded_amount, 0);
+    assert!(invoice.investor.is_none());
+
+    // A settled invoice cannot be re-opened to Funded (would reactivate
+    // exposure after settlement and could misprice the obligation).
+    client.update_invoice_status(&id, &InvoiceStatus::Verified);
+    client.update_invoice_status(&id, &InvoiceStatus::Funded);
+    client.update_invoice_status(&id, &InvoiceStatus::Paid);
+    let paid_invoice = client.get_invoice(&id);
+    assert_eq!(paid_invoice.status, InvoiceStatus::Paid);
+    assert_eq!(paid_invoice.total_paid, INV_AMOUNT);
+    assert!(paid_invoice.settled_at.is_some());
+
+    assert!(matches!(
+        client.try_update_invoice_status(&id, &InvoiceStatus::Funded),
+        Err(Ok(QuickLendXError::InvalidStatus))
+    ));
+    let after = client.get_invoice(&id);
+    assert_eq!(after.status, InvoiceStatus::Paid);
+    assert_eq!(after.total_paid, INV_AMOUNT);
+    assert_eq!(after.funded_amount, INV_AMOUNT);
+    assert!(after.settled_at.is_some());
+    assert_eq!(client.get_invoice_count_by_status(&InvoiceStatus::Paid), 1);
+}


### PR DESCRIPTION
## What this fixes

Closes #2433 (QE-2026-08)

`update_invoice_status` is the **last admin entry point that can move an invoice between lifecycle statuses without going through a domain flow** (`accept_bid` for funding, payment settlement for paid, `do_mark_invoice_defaulted` for default). Before this change it could transition an invoice **unconditionally**:

```rust
match new_status {
    Verified => …,   // from *any* state, even after settlement
    Funded   => …,   // re-opens funding on an already-funded or settled invoice
    Paid     => …,   // "settles" a Pending invoice before it was ever funded
    _        => return Err(InvalidStatus),  // …but only *after* removing it from its status index
}
```

That violates the invariant the issue calls out: **an invalid state can misprice exposure or permit settlement after the underlying obligation changed** (e.g. `Pending -> Paid` calls `mark_as_paid` and sets `total_paid`/`settled_at`, and `Paid -> Funded` re-activates `funded_amount`/`investor` on a settled invoice). It also left partial state: a request for `Cancelled`/`Refunded` was rejected only *after* the invoice had been pulled out of its old status index, silently de-indexing it.

## Root cause

The lifecycle was only documented implicitly (callers were expected to go through the domain flows) and was **not enforced at the weakest entry point**. `update_invoice_status` treated `Verified`/`Funded`/`Paid` as independent "set to" commands rather than as **transitions** on a state machine, so there was no a-priori guard against backward, skipped, repeated, re-opened, or terminal-immutable transitions — and no guarantee that a rejected request was a no-op.

## The fix and why this approach

Introduce an explicit, reviewable transition matrix **at the public entry point, before any state or status index is touched**:

```
Pending -> Verified -> Funded -> Paid
```

```rust
let allowed = matches!(
    (invoice.status, new_status),
    (InvoiceStatus::Pending, InvoiceStatus::Verified)
        | (InvoiceStatus::Verified, InvoiceStatus::Funded)
        | (InvoiceStatus::Funded, InvoiceStatus::Paid)
);
if !allowed {
    return Err(QuickLendXError::InvalidStatus);
}
```

Why this is the right shape:

- **Enforced at the integration boundary**, so the guarantee holds for every external caller (including current and future test setups), not just at individual `invoice.verify()`/`mark_as_*` mutators.
- **Rejected requests are atomic no-ops.** The guard runs before `remove_from_status_invoices`, so backward/skipped/repeated/terminal-immutable requests (and the previously buggy `Cancelled`/`Refunded` destinations) no longer de-index the invoice or mutate asset fields (`total_paid`, `settled_at`, `funded_amount`, `investor`).
- **`Defaulted` intentionally stays outside the matrix.** Every default request is still routed through `do_mark_invoice_defaulted`, which already centralizes the richer finality checks (grace window, escrow state, duplicate-default guard). Keeping that routing untouched avoids duplicating or weakening those guards.
- **Minimal and local.** No changes to storage, events, `defaults.rs` finality, `escrow`/`settlement`, or any domain flow.

Alternatives considered and rejected:

- *Enforce inside `Invoice::verify`/`mark_as_*` mutators* — spread across several structs, easily bypassed by any future caller that forgets, and doesn't fix the index-removal-before-reject bug.
- *Reject only `Pending -> Paid`/terminal re-open heuristics* — ad hoc, wouldn't cover repeated/backward/stale edges, and wouldn't be reviewable as a single matrix.
- *Keep the loose behavior and only add tests* — the issue explicitly requires the invariant to be **enforced**, not just observed.

### Compatibility note (intentional behavior change)

This is a deliberate, documented compatibility change per the issue's acceptance criteria. `update_invoice_status` no longer permits out-of-sequence transitions that were previously silently accepted (e.g. jumping `Pending -> Paid`, or re-opening a settled/in-terminal invoice). Authorized users and integrators must drive the lifecycle in order — the same order the domain flows already require. The error/response shape is unchanged (`InvalidStatus`), so `try_update_invoice_status` callers are unaffected; only *which* requests return that error has been tightened. Following this change, any legacy test or tooling that used `update_invoice_status` as an unrestricted state-plotter must move state sequentially (or use the domain entry points).

## What could break / risk review

- This touches a **contract-call safety path** (admin financial-state mutation). The matrix is deliberately conservative: it only *removes* previously-invalid transitions and never widens *any* legal one, so no currently-correct flow regresses.
- The previously-possible (but unsafe) `Paid -> Funded` / `Paid -> Verified` re-open is now rejected — anyone who relied on that to "correct" a settled invoice via the raw entry point will get `InvalidStatus`. That is the intended safety improvement (a settled invoice is terminal).
- `Cancelled`/`Refunded` were already rejected as targets; the fix additionally ensures the invoice stays correctly indexed (no partial de-index) on those rejections.

## How it was tested

> ⚠️ **Important environment note.** This repository's `main` does **not** currently compile independently of this change: a plain `cargo build` fails with ~69 pre-existing, unrelated errors (duplicate `RatingsSnapshot` definitions in `types.rs`, missing `AuditOperation` variants in `audit.rs`, unresolved `create_escrow_record_only`, missing `observability` module, etc.). Additionally, the contracts CI job (`ci.yml`) is stubbed out ("build check intentionally stubbed while main-branch CI is being stabilized"). Because I kept this PR strictly scoped to #2433 and did not bundle a full build-repair, **the full contract test suite cannot be executed in this environment.**

So the change was validated by rigorous manual review instead:

- Traced the full `update_invoice_status` control flow to confirm the guard runs before `remove_from_status_invoices` and before any `invoice.verify()/mark_as_*` mutation, so every rejected path is an atomic no-op.
- Cross-checked every client/type symbol used by the new tests (`store`→`upload_invoice`, `submit_kyc_application`, `verify_business`, `get_invoice`, `get_invoice_count_by_status`, `try_update_invoice_status`) against the actual contract signatures and against the repo's established test patterns (`test_events.rs`, `test_lifecycle.rs`, `test_cancel_invoice_matrix.rs`), including the `matches!(r, Err(Ok(QuickLendXError::InvalidStatus)))` assertion convention.
- Verified `mark_as_funded` sets `funded_amount`/`funded_at`/`investor` and `mark_as_paid` sets `total_paid`/`settled_at` so the "no partial state" assertions match real mutator behavior.
- `rustfmt --edition 2021` passes on the new test file (it parses cleanly). `cargo fmt`/`cargo test` on the crate cannot run until `main`'s pre-existing breakage is repaired.
- The new tests **would fail before the fix**: `update_invoice_status` previously accepted `Pending -> Paid` (running `mark_as_paid`) and `Paid -> Funded` (re-opening funding on a settled invoice) — exactly the assertions `rejected_transition_leaves_no_partial_state` and `update_invoice_status_enforces_full_lifecycle_matrix` now pin.

**To actually execute the suite**, the pre-existing `main` breakage must first be repaired (see follow-up below); after that, run:

```bash
cd quicklendx-contracts
cargo fmt --all -- --check
cargo build --tests
cargo test update_invoice_status_enforces_full_lifecycle_matrix \
         rejected_transition_leaves_no_partial_state
# full suite:
cargo test
./scripts/check-wasm-size.sh
```

## Follow-up worth filing separately

- **Build-repair of `main`**: deduplicate the duplicated `RatingsSnapshot`/`RATINGS_SNAPSHOT_SCHEMA_VERSION` in `types.rs`, reconcile `AuditOperation` variants with their call sites, resolve `create_escrow_record_only`, restore the `observability` module declaration, and re-enable the stubbed contracts CI. This is a prerequisite for running the contract test suite at all, and is intentionally **not** bundled here.
- After the build-repair lands, augment this test with the fuzz/artifact classifications the issue lists (concurrent + failure-path invocation) to extend the invariant proof into property tests.